### PR TITLE
Build packages via cmake

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -51,22 +51,7 @@ jobs:
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev
-      - name: Create Small SD Card ZIP - No World Map
-        run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
-      - name: Download world map
-        run: |
-          wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
-      - name: Unzip world map
-        run: |
-          unzip world_map.zip -d sdcard/ADSB
-      - name: Create Firmware ZIP
-        run: |
-          zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
-      - name: Create SD Card ZIP
-        run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev make release
       - name: Create changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +95,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./firmware.zip
+          asset_path: build/firmware/firmware.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_FIRMWARE.zip
           asset_content_type: application/zip
       - name: Upload SD Card Assets
@@ -120,7 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard.zip
+          asset_path: build/firmware/sdcard.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD.zip
           asset_content_type: application/zip
       - name: Upload SD Card Assets - No Map
@@ -130,6 +115,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard-no-map.zip
+          asset_path: build/firmware/sdcard-no-map.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD-no-world-map.zip
           asset_content_type: application/zip

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -48,8 +48,6 @@ jobs:
           git submodule update --init --recursive
       - name: Build the Docker image
         run: docker build -t portapack-dev -f dockerfile-nogit . --tag my-image-name:$(date +%s)
-      - name: Make build folder
-        run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
         run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev make release
       - name: Create changelog

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -35,22 +35,7 @@ jobs:
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev
-      - name: Create Small SD Card ZIP - No World Map
-        run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
-      - name: Download world map
-        run: |
-          wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
-      - name: Unzip world map
-        run: |
-          unzip world_map.zip -d sdcard/ADSB
-      - name: Create Firmware ZIP
-        run: |
-          zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
-      - name: Create SD Card ZIP
-        run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+        run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev make release
       - name: Create changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +89,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./firmware.zip
+          asset_path: build/firmware/firmware.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_FIRMWARE.zip
           asset_content_type: application/zip
       - name: Upload SD Card Assets
@@ -114,7 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard.zip
+          asset_path: build/firmware/sdcard.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD.zip
           asset_content_type: application/zip
       - name: Upload SD Card Assets - No Map
@@ -124,7 +109,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard-no-map.zip
+          asset_path: build/firmware/sdcard-no-map.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD-no-world-map.zip
           asset_content_type: application/zip
      

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -32,8 +32,6 @@ jobs:
         run: echo "::set-output name=past_version::$(cat .github/workflows/past_version.txt)"
       - name: Build the Docker image
         run: docker build -t portapack-dev -f dockerfile-nogit . --tag my-image-name:$(date +%s)
-      - name: Make build folder
-        run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
         run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev make release
       - name: Create changelog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ message("Building version: ${VERSION} MD5: ${VERSION_MD5}")
 
 set(LICENSE_PATH ${CMAKE_CURRENT_LIST_DIR}/LICENSE)
 set(HARDWARE_PATH ${CMAKE_CURRENT_LIST_DIR}/hardware)
+set(SD_TEMPLATE_PATH ${CMAKE_CURRENT_LIST_DIR}/sdcard)
+set(FLASHING_PATH ${CMAKE_CURRENT_LIST_DIR}/flashing)
 
 add_subdirectory(hackrf-portapack)
 

--- a/dockerfile-nogit
+++ b/dockerfile-nogit
@@ -11,7 +11,7 @@ WORKDIR /havoc/firmware
 
 # Fetch dependencies from APT
 RUN apt-get update \
- && apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl ninja-build \
+ && apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl ninja-build zip \
  && apt-get -qy autoremove \
  && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfile-nogit-arm
+++ b/dockerfile-nogit-arm
@@ -11,7 +11,7 @@ WORKDIR /havoc/firmware
 
 # Fetch dependencies from APT
 RUN apt-get update \
- && apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl ninja-build \
+ && apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl ninja-build zip \
  && apt-get -qy autoremove \
  && rm -rf /var/lib/apt/lists/*
 

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -122,27 +122,28 @@ add_custom_target(
 )
 
 add_custom_command(
-	OUTPUT world_map.zip
-	COMMAND wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
-	VERBATIM
-)
-
-add_custom_target(
-	world_map
-	COMMAND unzip world_map.zip -d sdcard/ADSB
-	DEPENDS sd_template world_map.zip
-	VERBATIM
-)
-
-add_custom_command(
-	OUTPUT sdcard.zip
+	OUTPUT sdcard-no-map.zip
 	COMMAND mkdir -p sdcard/FIRMWARE
 	COMMAND cp ${FIRMWARE_FILENAME} sdcard/FIRMWARE/portapack-mayhem_${VERSION_NOHASH}.bin
 	COMMAND mkdir -p sdcard/APPS
 	COMMAND cp application/*.ppma sdcard/APPS
+	COMMAND rm -f sdcard-no-map.zip
+	COMMAND cd sdcard && zip -r ../sdcard-no-map.zip *
+	DEPENDS firmware sd_template
+)
+
+add_custom_target(
+	sdcard-no-map
+	DEPENDS sdcard-no-map.zip
+)
+
+add_custom_command(
+	OUTPUT sdcard.zip
+	COMMAND wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
+	COMMAND unzip world_map.zip -d sdcard/ADSB
 	COMMAND rm -f sdcard.zip
 	COMMAND cd sdcard && zip -r ../sdcard.zip *
-	DEPENDS firmware sd_template world_map
+	DEPENDS sdcard-no-map
 )
 
 add_custom_target(

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -105,6 +105,51 @@ add_custom_command(
 	# There shouldnt be any funny business in the filenames above :)
 )
 
+add_custom_target(
+	ppfw ALL
+	DEPENDS ${PPFW_FILENAME}
+)
+
+add_custom_target(
+	oci
+	DEPENDS ${PPFW_FILENAME}
+)
+
+add_custom_target(
+	sd_template
+	COMMAND rm -rf sdcard
+	COMMAND cp -av ${SD_TEMPLATE_PATH} ./
+)
+
+add_custom_command(
+	OUTPUT world_map.zip
+	COMMAND wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
+	VERBATIM
+)
+
+add_custom_target(
+	world_map
+	COMMAND unzip world_map.zip -d sdcard/ADSB
+	DEPENDS sd_template world_map.zip
+	VERBATIM
+)
+
+add_custom_command(
+	OUTPUT sdcard.zip
+	COMMAND mkdir -p sdcard/FIRMWARE
+	COMMAND cp ${FIRMWARE_FILENAME} sdcard/FIRMWARE/portapack-mayhem_${VERSION_NOHASH}.bin
+	COMMAND mkdir -p sdcard/APPS
+	COMMAND cp application/*.ppma sdcard/APPS
+	COMMAND rm -f sdcard.zip
+	COMMAND cd sdcard && zip -r ../sdcard.zip *
+	DEPENDS firmware sd_template world_map
+)
+
+add_custom_target(
+	sdcard
+	DEPENDS sdcard.zip
+)
+
 # TODO: Bad hack to fix location of LICENSE file for tar.
 add_custom_command(
 	OUTPUT ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip
@@ -122,16 +167,6 @@ add_custom_command(
 	COMMAND md5sum --binary ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip >MD5SUMS
 	COMMAND sha256sum --binary ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip >SHA256SUMS
 	DEPENDS ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip
-)
-
-add_custom_target(
-	ppfw ALL
-	DEPENDS ${PPFW_FILENAME}
-)
-
-add_custom_target(
-	oci
-	DEPENDS ${PPFW_FILENAME}
 )
 
 add_custom_target(

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -91,6 +91,18 @@ add_custom_target(
 )
 
 add_custom_command(
+	OUTPUT firmware.zip
+	COMMAND zip -j firmware.zip ${FIRMWARE_FILENAME}
+	COMMAND cd ${FLASHING_PATH} && zip -r ${CMAKE_CURRENT_BINARY_DIR}/firmware.zip *
+	DEPENDS firmware
+)
+
+add_custom_target(
+	firmware_zip
+	DEPENDS firmware.zip
+)
+
+add_custom_command(
 	OUTPUT ${PPFW_FILENAME}
 	
 	COMMAND rm -rf firmware_tar
@@ -151,27 +163,8 @@ add_custom_target(
 	DEPENDS sdcard.zip
 )
 
-# TODO: Bad hack to fix location of LICENSE file for tar.
-add_custom_command(
-	OUTPUT ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip
-	COMMAND cp ${LICENSE_PATH} LICENSE
-	COMMAND cp ${HACKRF_FIRMWARE_DFU_IMAGE} ${HACKRF_FIRMWARE_DFU_FILENAME}
-	COMMAND tar -c -j -f ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_FILENAME} ${HACKRF_FIRMWARE_DFU_FILENAME} LICENSE
-	COMMAND zip -9 -q ${FIRMWARE_NAME}-${VERSION}.zip ${FIRMWARE_FILENAME} ${HACKRF_FIRMWARE_DFU_FILENAME} LICENSE
-	COMMAND rm -f LICENSE ${HACKRF_FIRMWARE_DFU_FILENAME}
-	DEPENDS ${FIRMWARE_FILENAME} ${LICENSE_PATH} ${HACKRF_FIRMWARE_DFU_FILENAME}
-	VERBATIM
-)
-
-add_custom_command(
-	OUTPUT MD5SUMS SHA256SUMS
-	COMMAND md5sum --binary ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip >MD5SUMS
-	COMMAND sha256sum --binary ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip >SHA256SUMS
-	DEPENDS ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip
-)
-
 add_custom_target(
 	release
-	DEPENDS MD5SUMS SHA256SUMS
+	DEPENDS firmware_zip ppfw sdcard
 )
 


### PR DESCRIPTION
Moved the creation of packages from gitlab workflows to cmake
Benefits:
- The logic of creating those packages is no longer duplicated in the nightly and stable workflows
- Packages can be generated locally, so package generation is easier to test
- Makes the packaging logic more readable