### PR TITLE
fix buffer size bug

### DIFF
--- a/firmware/application/usb_serial_io.c
+++ b/firmware/application/usb_serial_io.c
@@ -40,13 +40,15 @@
 
 SerialUSBDriver SUSBD1;
 
+uint8_t usbBulkBuffer[64];
+
 void bulk_out_receive(void) {
     int ret;
     do {
         ret = usb_transfer_schedule(
             &usb_endpoint_bulk_out,
-            &usb_endpoint_bulk_out.buffer[0],
-            32,
+            &usbBulkBuffer[0],
+            64,
             serial_bulk_transfer_complete,
             NULL);
 
@@ -61,7 +63,7 @@ void serial_bulk_transfer_complete(void* user_data, unsigned int bytes_transferr
     for (unsigned int i = 0; i < bytes_transferred; i++) {
         msg_t ret;
         do {
-            ret = chIQPutI(&SUSBD1.iqueue, usb_endpoint_bulk_out.buffer[i]);
+            ret = chIQPutI(&SUSBD1.iqueue, usbBulkBuffer[i]);
             if (ret == Q_FULL)
                 chThdSleepMilliseconds(1);
 

--- a/firmware/application/usb_serial_io.c
+++ b/firmware/application/usb_serial_io.c
@@ -40,7 +40,7 @@
 
 SerialUSBDriver SUSBD1;
 
-uint8_t usbBulkBuffer[64];
+uint8_t usbBulkBuffer[USBSERIAL_BUFFERS_SIZE];
 
 void bulk_out_receive(void) {
     int ret;
@@ -48,7 +48,7 @@ void bulk_out_receive(void) {
         ret = usb_transfer_schedule(
             &usb_endpoint_bulk_out,
             &usbBulkBuffer[0],
-            64,
+            USBSERIAL_BUFFERS_SIZE,
             serial_bulk_transfer_complete,
             NULL);
 
@@ -75,9 +75,9 @@ void serial_bulk_transfer_complete(void* user_data, unsigned int bytes_transferr
 
 static void onotify(GenericQueue* qp) {
     SerialUSBDriver* sdp = chQGetLink(qp);
-    uint8_t buff[64];
+    uint8_t buff[USBSERIAL_BUFFERS_SIZE];
     int n = chOQGetFullI(&sdp->oqueue);
-    if (n > 64) n = 64;  // don't overflow
+    if (n > USBSERIAL_BUFFERS_SIZE) n = USBSERIAL_BUFFERS_SIZE;  // don't overflow
     if (n > 0) {
         for (int i = 0; i < n; i++) {
             buff[i] = chOQGetI(&sdp->oqueue);
@@ -141,8 +141,8 @@ static const struct SerialUSBDriverVMT vmt = {
 
 void init_serial_usb_driver(SerialUSBDriver* sdp) {
     sdp->vmt = &vmt;
-    chIQInit(&sdp->iqueue, sdp->ib, SERIAL_BUFFERS_SIZE, NULL, sdp);
-    chOQInit(&sdp->oqueue, sdp->ob, SERIAL_BUFFERS_SIZE, onotify, sdp);
+    chIQInit(&sdp->iqueue, sdp->ib, USBSERIAL_BUFFERS_SIZE, NULL, sdp);
+    chOQInit(&sdp->oqueue, sdp->ob, USBSERIAL_BUFFERS_SIZE, onotify, sdp);
 }
 
 // queue handler from ch

--- a/firmware/application/usb_serial_io.h
+++ b/firmware/application/usb_serial_io.h
@@ -24,6 +24,10 @@
 #include "ch.h"
 #include "hal.h"
 
+#ifndef USBSERIAL_BUFFERS_SIZE
+#define USBSERIAL_BUFFERS_SIZE 300
+#endif
+
 struct SerialUSBDriverVMT {
     _base_asynchronous_channel_methods
 };
@@ -31,10 +35,10 @@ struct SerialUSBDriverVMT {
 struct SerialUSBDriver {
     /** @brief Virtual Methods Table.*/
     const struct SerialUSBDriverVMT* vmt;
-    InputQueue iqueue;               /* Output queue.*/
-    OutputQueue oqueue;              /* Input circular buffer.*/
-    uint8_t ib[SERIAL_BUFFERS_SIZE]; /* Output circular buffer.*/
-    uint8_t ob[SERIAL_BUFFERS_SIZE];
+    InputQueue iqueue;                  /* Output queue.*/
+    OutputQueue oqueue;                 /* Input circular buffer.*/
+    uint8_t ib[USBSERIAL_BUFFERS_SIZE]; /* Output circular buffer.*/
+    uint8_t ob[USBSERIAL_BUFFERS_SIZE];
 };
 
 typedef struct SerialUSBDriver SerialUSBDriver;

--- a/firmware/application/usb_serial_io.h
+++ b/firmware/application/usb_serial_io.h
@@ -25,7 +25,7 @@
 #include "hal.h"
 
 #ifndef USBSERIAL_BUFFERS_SIZE
-#define USBSERIAL_BUFFERS_SIZE 300
+#define USBSERIAL_BUFFERS_SIZE 400
 #endif
 
 struct SerialUSBDriverVMT {

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -241,12 +241,12 @@ static void cmd_screenframeshort(BaseSequentialStream* chp, int argc, char* argv
     for (int y = 0; y < ui::screen_height; y++) {
         std::array<ui::ColorRGB888, ui::screen_width> row;
         portapack::display.read_pixels({0, y, ui::screen_width, 1}, row);
-        for (int px = 0; px < ui::screen_width; px += 60) {
-            char buffer[60];
-            for (int i = 0; i < 60; ++i) {
+        for (int px = 0; px < ui::screen_width; px += 240) {
+            char buffer[240];
+            for (int i = 0; i < 240; ++i) {
                 buffer[i] = getChrFromRgb(row[px + i].r, row[px + i].g, row[px + i].b);
             }
-            fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)buffer, 60);
+            fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)buffer, 240);
         }
         chprintf(chp, "\r\n");
     }

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -241,18 +241,17 @@ static void cmd_screenframeshort(BaseSequentialStream* chp, int argc, char* argv
     for (int y = 0; y < ui::screen_height; y++) {
         std::array<ui::ColorRGB888, ui::screen_width> row;
         portapack::display.read_pixels({0, y, ui::screen_width, 1}, row);
-        for (int px = 0; px < ui::screen_width; px += 240) {
-            char buffer[240];
-            for (int i = 0; i < 240; ++i) {
-                buffer[i] = getChrFromRgb(row[px + i].r, row[px + i].g, row[px + i].b);
-            }
-            fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)buffer, 240);
+        char buffer[242];
+        for (int i = 0; i < 240; ++i) {
+            buffer[i] = getChrFromRgb(row[i].r, row[i].g, row[i].b);
         }
-        chprintf(chp, "\r\n");
+        buffer[240] = '\r';
+        buffer[241] = '\n';
+        fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)buffer, 242);
     }
 
     evtd->exit_shell_working_mode();
-    chprintf(chp, "ok\r\n");
+    chprintf(chp, "\r\nok\r\n");
 }
 
 static void cmd_write_memory(BaseSequentialStream* chp, int argc, char* argv[]) {


### PR DESCRIPTION
The usb_endpoint_bulk_out.buffer is [32], but the usb descriptor sends 64 byte buffer, and also the &SUSBD1.iqueue is 64 bytes.
I don't want to modify files in hackfr, so introduced a new buffer, and using that.
With this the sending data from host to pp can speed up a lot (double data per usb packet).