### PR TITLE
Modify encoder handler to not call "on_encoder" functions if no change

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -242,7 +242,7 @@ void ScannerView::handle_retune(int64_t freq, uint32_t freq_idx) {
 }
 
 void ScannerView::handle_encoder(EncoderEvent delta) {
-    if (delta==0)
+    if (delta == 0)
         return;
 
     auto index_step = delta > 0 ? 1 : -1;

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -242,9 +242,6 @@ void ScannerView::handle_retune(int64_t freq, uint32_t freq_idx) {
 }
 
 void ScannerView::handle_encoder(EncoderEvent delta) {
-    if (delta == 0)
-        return;
-
     auto index_step = delta > 0 ? 1 : -1;
 
     if (scan_thread)

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -397,10 +397,8 @@ ScannerView::ScannerView(
         handle_encoder(button_pause.get_encoder_delta());
         button_pause.set_encoder_delta(0);
     };
-
-    field_current_index.on_change = [this]() {
-        handle_encoder(field_current_index.get_encoder_delta());
-        field_current_index.set_encoder_delta(0);
+    field_current_index.on_encoder_change = [this](TextField&, EncoderEvent delta) {
+        handle_encoder(delta);
     };
 
     // Button to switch to Audio app

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -242,6 +242,9 @@ void ScannerView::handle_retune(int64_t freq, uint32_t freq_idx) {
 }
 
 void ScannerView::handle_encoder(EncoderEvent delta) {
+    if (delta==0)
+        return;
+
     auto index_step = delta > 0 ? 1 : -1;
 
     if (scan_thread)
@@ -275,7 +278,7 @@ ScannerView::~ScannerView() {
 }
 
 void ScannerView::show_max_index() {  // show total number of freqs to scan
-    field_current_index.set_text("---");
+    field_current_index.set_text("<->");
 
     if (entries.size() == FREQMAN_MAX_PER_FILE) {
         text_max_index.set_style(&Styles::red);
@@ -394,8 +397,10 @@ ScannerView::ScannerView(
         handle_encoder(button_pause.get_encoder_delta());
         button_pause.set_encoder_delta(0);
     };
-    field_current_index.on_encoder_change = [this](TextField&, EncoderEvent delta) {
-        handle_encoder(delta);
+
+    field_current_index.on_change = [this]() {
+        handle_encoder(field_current_index.get_encoder_delta());
+        field_current_index.set_encoder_delta(0);
     };
 
     // Button to switch to Audio app

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -226,7 +226,7 @@ class ScannerView : public View {
         {0 * 16, 2 * 16, 15 * 16, 8},
     };
 
-    TextField field_current_index{
+    ButtonWithEncoder field_current_index{
         {0, 3 * 16, 3 * 8, 16},
         {},
     };

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -226,7 +226,7 @@ class ScannerView : public View {
         {0 * 16, 2 * 16, 15 * 16, 8},
     };
 
-    ButtonWithEncoder field_current_index{
+    TextField field_current_index{
         {0, 3 * 16, 3 * 8, 16},
         {},
     };

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -432,6 +432,9 @@ bool EventDispatcher::event_bubble_key(const ui::KeyEvent event) {
 }
 
 void EventDispatcher::event_bubble_encoder(const ui::EncoderEvent event) {
+    if (event == 0)
+        return;
+
     auto target = context.focus_manager().focus_widget();
     while ((target != nullptr) && !target->on_encoder(event)) {
         target = target->parent();

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -410,6 +410,9 @@ void EventDispatcher::handle_encoder() {
 
     const uint32_t encoder_now = get_encoder_position();
     const int32_t delta = static_cast<int32_t>(encoder_now - encoder_last);
+    if (delta == 0)
+        return;
+
     encoder_last = encoder_now;
     const auto event = static_cast<ui::EncoderEvent>(delta);
     event_bubble_encoder(event);
@@ -432,9 +435,6 @@ bool EventDispatcher::event_bubble_key(const ui::KeyEvent event) {
 }
 
 void EventDispatcher::event_bubble_encoder(const ui::EncoderEvent event) {
-    if (event == 0)
-        return;
-
     auto target = context.focus_manager().focus_widget();
     while ((target != nullptr) && !target->on_encoder(event)) {
         target = target->parent();


### PR DESCRIPTION
Fixes encoder dial issue in "current index" field in Scanner #1729, and possibly some other encoder anomalies in any "on_encoder" functions that might assume that the callback won't occur unless the delta is nonzero.

FYI the text change from "---" to "<->" in Scanner in Search mode is simply meant to represent that turning the encoder when this field is highlighted will change the frequency.
