### PR TITLE
GPS + orientation for Sonde

### DIFF
--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -135,7 +135,7 @@ void SondeView::on_gps(const GPSPosDataMessage* msg) {
 void SondeView::on_orientation(const OrientationDataMessage* msg) {
     if (!geomap_view_)
         return;
-    geomap_view_->update_my_orientation(msg->angle);
+    geomap_view_->update_my_orientation(msg->angle, true);
 }
 
 void SondeView::focus() {

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -90,7 +90,7 @@ SondeView::SondeView(NavigationView& nav)
     };
 
     button_see_map.on_select = [this, &nav](Button&) {
-        nav.push<GeoMapView>(
+        geomap_view_ = nav.push<GeoMapView>(
             sonde_id,
             gps_info.alt,
             GeoPos::alt_unit::METERS,
@@ -98,6 +98,9 @@ SondeView::SondeView(NavigationView& nav)
             gps_info.lat,
             gps_info.lon,
             999);  // set a dummy heading out of range to draw a cross...probably not ideal?
+        nav.set_on_pop([this]() {
+            geomap_view_ = nullptr;
+        });
     };
 
     logger = std::make_unique<SondeLogger>();
@@ -122,6 +125,17 @@ SondeView::~SondeView() {
     receiver_model.disable();
     baseband::shutdown();
     audio::output::stop();
+}
+
+void SondeView::on_gps(const GPSPosDataMessage* msg) {
+    if (!geomap_view_)
+        return;
+    geomap_view_->update_my_position(msg->lat, msg->lon, msg->altitude);
+}
+void SondeView::on_orientation(const OrientationDataMessage* msg) {
+    if (!geomap_view_)
+        return;
+    geomap_view_->update_my_orientation(msg->angle);
 }
 
 void SondeView::focus() {

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -60,6 +60,8 @@ class SondeView : public View {
 
     SondeView(NavigationView& nav);
     ~SondeView();
+    SondeView(const SondeView& other) = delete;
+    SondeView& operator=(const SondeView& other) = delete;
 
     void focus() override;
 
@@ -173,6 +175,8 @@ class SondeView : public View {
         {16 * 8, 15 * 16, 12 * 8, 3 * 16},
         "See on map"};
 
+    GeoMapView* geomap_view_{nullptr};
+
     MessageHandlerRegistration message_handler_packet{
         Message::ID::SondePacket,
         [this](Message* const p) {
@@ -181,6 +185,21 @@ class SondeView : public View {
             this->on_packet(packet);
         }};
 
+    MessageHandlerRegistration message_handler_gps{
+        Message::ID::GPSPosData,
+        [this](Message* const p) {
+            const auto message = static_cast<const GPSPosDataMessage*>(p);
+            this->on_gps(message);
+        }};
+    MessageHandlerRegistration message_handler_orientation{
+        Message::ID::OrientationData,
+        [this](Message* const p) {
+            const auto message = static_cast<const OrientationDataMessage*>(p);
+            this->on_orientation(message);
+        }};
+
+    void on_gps(const GPSPosDataMessage* msg);
+    void on_orientation(const OrientationDataMessage* msg);
     void on_packet(const sonde::Packet& packet);
     char* float_to_char(float x, char* p);
 };

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -516,8 +516,11 @@ void GeoMap::update_my_position(float lat, float lon, int32_t altitude) {
     markerListUpdated = true;
     set_dirty();
 }
-void GeoMap::update_my_orientation(uint16_t angle) {
+void GeoMap::update_my_orientation(uint16_t angle, bool refresh) {
     my_angle = angle;
+    if (refresh) {
+        set_dirty();
+    }
 }
 
 void GeoMapView::focus() {
@@ -530,8 +533,8 @@ void GeoMapView::focus() {
 void GeoMapView::update_my_position(float lat, float lon, int32_t altitude) {
     geomap.update_my_position(lat, lon, altitude);
 }
-void GeoMapView::update_my_orientation(uint16_t angle) {
-    geomap.update_my_orientation(angle);
+void GeoMapView::update_my_orientation(uint16_t angle, bool refresh) {
+    geomap.update_my_orientation(angle, refresh);
 }
 
 void GeoMapView::update_position(float lat, float lon, uint16_t angle, int32_t altitude, int32_t speed) {

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -519,6 +519,7 @@ void GeoMap::update_my_position(float lat, float lon, int32_t altitude) {
 void GeoMap::update_my_orientation(uint16_t angle, bool refresh) {
     my_angle = angle;
     if (refresh) {
+        markerListUpdated = true;
         set_dirty();
     }
 }

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -186,7 +186,7 @@ class GeoMap : public Widget {
     bool on_keyboard(const KeyboardEvent event) override;
 
     void update_my_position(float lat, float lon, int32_t altitude);
-    void update_my_orientation(uint16_t angle);
+    void update_my_orientation(uint16_t angle, bool refresh = false);
 
     bool init();
     void set_mode(GeoMapMode mode);
@@ -278,7 +278,7 @@ class GeoMapView : public View {
 
     void update_position(float lat, float lon, uint16_t angle, int32_t altitude, int32_t speed = 0);
     void update_my_position(float lat, float lon, int32_t altitude);
-    void update_my_orientation(uint16_t angle);
+    void update_my_orientation(uint16_t angle, bool refresh = false);
 
     std::string title() const override { return "Map view"; };
 


### PR DESCRIPTION
For balloon hunt the map can show own gps + orientation. (from serial port via gotgps, gotorientation commands)