### PR TITLE
Make use of "ensure_directory" function

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -40,7 +40,7 @@ using namespace portapack;
 
 namespace {
 fs::path get_settings_path(const std::string& app_name) {
-    return fs::path{u"/SETTINGS"} / app_name + u".ini";
+    return fs::path{SETTINGS_DIR} / app_name + u".ini";
 }
 }  // namespace
 
@@ -156,7 +156,7 @@ bool save_settings(std::string_view store_name, const SettingBindings& bindings)
     File f;
     auto path = get_settings_path(std::string{store_name});
 
-    make_new_directory(SETTINGS_DIR);
+    ensure_directory(SETTINGS_DIR);
     auto error = f.create(path);
     if (error)
         return false;

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -54,8 +54,6 @@
 
 namespace ui {
 
-#define RECON_CFG_FILE u"SETTINGS/recon.cfg"
-
 enum class recon_mode : uint8_t {
     Recon,
     Scanner,

--- a/firmware/application/debug.cpp
+++ b/firmware/application/debug.cpp
@@ -275,7 +275,7 @@ bool memory_dump(uint32_t* addr_start, uint32_t num_words, bool stack_flag) {
     int n{0};
     bool data_found{false};
 
-    make_new_directory(debug_dir);
+    ensure_directory(debug_dir);
     filename = next_filename_matching_pattern(debug_dir + "/" + (stack_flag ? "STACK" : "MEMORY") + "_DUMP_????.TXT");
     error = filename.empty();
     if (!error)

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -177,7 +177,7 @@ enum class PortaPackModel {
 static bool save_config(int8_t value) {
     persistent_memory::set_config_cpld(value);
     if (sd_card::status() == sd_card::Status::Mounted) {
-        make_new_directory("/hardware");
+        ensure_directory("/hardware");
         File file;
         auto sucess = file.create("/hardware/settings.txt");
         if (!sucess.is_valid()) {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -570,7 +570,7 @@ void SystemStatusView::rtc_battery_workaround() {
                 }
             }
         } else {
-            make_new_directory(SETTINGS_DIR);
+            ensure_directory(SETTINGS_DIR);
             make_new_file(DATE_FILEFLAG);
 
             year = 1980;

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -963,7 +963,7 @@ bool should_use_sdcard_for_pmem() {
 int save_persistent_settings_to_file() {
     File outfile;
 
-    make_new_directory(SETTINGS_DIR);
+    ensure_directory(SETTINGS_DIR);
     auto error = outfile.create(PMEM_SETTING_FILE);
     if (error)
         return false;
@@ -996,7 +996,7 @@ bool debug_dump() {
     std::filesystem::path filename{};
     File pmem_dump_file{};
     // create new dump file name and DEBUG directory
-    make_new_directory(debug_dir);
+    ensure_directory(debug_dir);
     filename = next_filename_matching_pattern(debug_dir + "/DEBUG_DUMP_????.TXT");
     if (filename.empty()) {
         painter.draw_string({0, 320 - 16}, ui::Styles::red, "COULD NOT GET DUMP NAME !");

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -33,10 +33,10 @@
 #include "serializer.hpp"
 #include "volume.hpp"
 
-// persistant memory from/to sdcard flag file
+// persistent memory from/to sdcard flag file
 #define PMEM_FILEFLAG u"/SETTINGS/PMEM_FILEFLAG"
 
-// persistant memory from/to sdcard flag file
+// persistent memory from/to sdcard flag file
 #define PMEM_SETTING_FILE u"/SETTINGS/pmem_settings"
 
 #define PMEM_SIZE_BYTES 256  // total amount of pmem space in bytes, including checksum

--- a/firmware/common/untar.hpp
+++ b/firmware/common/untar.hpp
@@ -53,7 +53,6 @@ class UnTar {
     }
 
     static bool create_dir(char* pathname) {
-        char* p;
         std::filesystem::filesystem_error r;
 
         if (!isValidName(pathname)) return false;
@@ -65,18 +64,7 @@ class UnTar {
         std::string dirnameStr = u'/' + pathname;
         std::filesystem::path dirname = dirnameStr;
 
-        r = make_new_directory(dirname);
-
-        if (!r.ok()) {
-            /* On failure, try creating parent directory. */
-            p = strrchr(pathname, '/');
-            if (p != NULL) {
-                *p = '\0';
-                create_dir(pathname);
-                *p = '/';
-                r = make_new_directory(dirname);
-            }
-        }
+        r = ensure_directory(dirname);
         return (r.ok());
     }
 


### PR DESCRIPTION
Make use of the "ensure_directory()" function which checks to see if the directory already exists before attempting to create one, and also recursively creates the parent directory when needed.

The "ensure_directory" function is already used extensively in the firmware, but half of the time the "make_new_directory" was being used and returned an (ignored) error (when the directory already exists).

Sorry no exciting new features in this little PR.
