### PR TITLE
reworked usb serial communication

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -116,7 +116,7 @@ set(CSRC
 	usb_serial_cdc.c
 	usb_serial_descriptor.c
 	usb_serial_endpoints.c
-	usb_serial_io.c
+	usb_serial_device_to_host.c
 	${HACKRF_PATH}/firmware/common/usb.c
 	${HACKRF_PATH}/firmware/common/usb_queue.c
 	${HACKRF_PATH}/firmware/hackrf_usb/usb_device.c
@@ -207,6 +207,7 @@ set(CPPSRC
 	usb_serial_event.cpp
 	usb_serial_thread.cpp
 	usb_serial.cpp
+	usb_serial_host_to_device.cpp
 	qrcodegen.cpp
 	radio.cpp
 	receiver_model.cpp

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -164,9 +164,8 @@ void EventDispatcher::dispatch(const eventmask_t events) {
         handle_rtc_tick();
     }
 
-    if (events & EVT_MASK_USB) {
-        handle_usb();
-    }
+    handle_usb_transfer();
+    handle_usb();
 
     if (events & EVT_MASK_SWITCHES) {
         handle_switches();
@@ -223,6 +222,10 @@ void EventDispatcher::handle_rtc_tick() {
 
 void EventDispatcher::handle_usb() {
     portapack::usb_serial.dispatch();
+}
+
+void EventDispatcher::handle_usb_transfer() {
+    portapack::usb_serial.dispatch_transfer();
 }
 
 void EventDispatcher::handle_shell() {

--- a/firmware/application/event_m0.hpp
+++ b/firmware/application/event_m0.hpp
@@ -122,6 +122,7 @@ class EventDispatcher {
     void handle_local_queue();
     void handle_rtc_tick();
     void handle_usb();
+    void handle_usb_transfer();
     void handle_shell();
 
     static ui::Widget* touch_widget(ui::Widget* const w, ui::TouchEvent event);

--- a/firmware/application/usb_serial.cpp
+++ b/firmware/application/usb_serial.cpp
@@ -1,11 +1,12 @@
 extern "C" {
-#include "usb_serial_io.h"
+#include "usb_serial_device_to_host.h"
 #include "usb_serial_cdc.h"
 }
 
 #include "usb_serial_shell.hpp"
 #include "usb_serial.hpp"
 #include "portapack.hpp"
+#include "usb_serial_host_to_device.hpp"
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/lpc43xx/usb.h>
@@ -24,6 +25,7 @@ void USBSerial::initialize() {
 
     init_serial_usb_driver(&SUSBD1);
     shellInit();
+    init_host_to_device();
 }
 
 void USBSerial::dispatch() {
@@ -35,7 +37,11 @@ void USBSerial::dispatch() {
         create_shell(_eventDispatcher);
     }
 
-    bulk_out_receive();
+    schedule_host_to_device_transfer();
+}
+
+void USBSerial::dispatch_transfer() {
+    complete_host_to_device_transfer();
 }
 
 void USBSerial::on_channel_opened() {

--- a/firmware/application/usb_serial_cdc.c
+++ b/firmware/application/usb_serial_cdc.c
@@ -31,11 +31,16 @@ static Thread* thread_usb_event = NULL;
 
 CH_IRQ_HANDLER(USB0_IRQHandler) {
     CH_IRQ_PROLOGUE();
+
+    const uint32_t status = USB0_USBSTS_D & USB0_USBINTR_D;
+
     usb0_isr();
 
-    chSysLockFromIsr();
-    chEvtSignalI(thread_usb_event, EVT_MASK_USB);
-    chSysUnlockFromIsr();
+    if (status & USB0_USBSTS_D_UI) {
+        chSysLockFromIsr();
+        chEvtSignalI(thread_usb_event, EVT_MASK_USB);
+        chSysUnlockFromIsr();
+    }
 
     CH_IRQ_EPILOGUE();
 }

--- a/firmware/application/usb_serial_host_to_device.cpp
+++ b/firmware/application/usb_serial_host_to_device.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "usb_serial_host_to_device.hpp"
+#include "event_m0.hpp"
+#include "usb_serial_device_to_host.h"
+
+extern "C" {
+#include <common/usb.h>
+#include <hackrf_usb/usb_device.h>
+#include <hackrf_usb/usb_endpoint.h>
+}
+
+#include <queue>
+#include <vector>
+
+static Thread* thread_usb_event = NULL;
+
+struct usb_bulk_buffer_t {
+    uint8_t* data;
+    size_t length;
+    bool completed;
+};
+
+std::queue<usb_bulk_buffer_t*> usb_bulk_buffer_queue;
+std::queue<usb_bulk_buffer_t*> usb_bulk_buffer_spare;
+
+void serial_bulk_transfer_complete(void* user_data, unsigned int bytes_transferred) {
+    usb_bulk_buffer_t* transfer_data = (usb_bulk_buffer_t*)user_data;
+
+    transfer_data->length = bytes_transferred;
+    transfer_data->completed = true;
+}
+
+void init_host_to_device() {
+    thread_usb_event = chThdSelf();
+}
+
+void schedule_host_to_device_transfer() {
+    if (usb_bulk_buffer_queue.size() >= 8)
+        return;
+
+    static usb_bulk_buffer_t* transfer_data = nullptr;
+
+    int ret;
+
+    do {
+        if (transfer_data == nullptr) {
+            if (usb_bulk_buffer_spare.empty() == false) {
+                transfer_data = usb_bulk_buffer_spare.front();
+                transfer_data->length = 0;
+                transfer_data->completed = false;
+                usb_bulk_buffer_spare.pop();
+            } else {
+                transfer_data = new usb_bulk_buffer_t{
+                    .data = new uint8_t[USB_BULK_BUFFER_SIZE],
+                    .length = 0,
+                    .completed = false};
+            }
+        }
+
+        ret = usb_transfer_schedule(
+            &usb_endpoint_bulk_out,
+            transfer_data->data,
+            USB_BULK_BUFFER_SIZE,
+            serial_bulk_transfer_complete,
+            transfer_data);
+
+        if (ret != -1) {
+            usb_bulk_buffer_queue.push(transfer_data);
+            transfer_data = nullptr;
+
+            if (usb_bulk_buffer_queue.size() >= 8)
+                return;
+        }
+    } while (ret != -1);
+}
+
+void complete_host_to_device_transfer() {
+    for (; !usb_bulk_buffer_queue.empty(); usb_bulk_buffer_queue.pop()) {
+        usb_bulk_buffer_t* transfer_data = usb_bulk_buffer_queue.front();
+
+        while (transfer_data->completed == false)
+            return;
+
+        chSysLock();
+        for (unsigned int i = 0; i < transfer_data->length; i++) {
+            msg_t ret;
+            do {
+                ret = chIQPutI(&SUSBD1.iqueue, transfer_data->data[i]);
+
+                if (ret == Q_FULL) {
+                    chSysUnlock();
+                    chThdSleepMilliseconds(1);  // wait for shell thread when buffer is full
+                    chSysLock();
+                }
+
+            } while (ret == Q_FULL);
+        }
+        chSysUnlock();
+
+        usb_bulk_buffer_spare.push(transfer_data);
+    }
+}

--- a/firmware/application/usb_serial_host_to_device.hpp
+++ b/firmware/application/usb_serial_host_to_device.hpp
@@ -26,35 +26,7 @@
 
 #define USB_BULK_BUFFER_SIZE 64
 
-#ifndef USBSERIAL_BUFFERS_SIZE
-#define USBSERIAL_BUFFERS_SIZE 128
-#endif
-
-struct SerialUSBDriverVMT {
-    _base_asynchronous_channel_methods
-};
-
-struct SerialUSBDriver {
-    /** @brief Virtual Methods Table.*/
-    const struct SerialUSBDriverVMT* vmt;
-    InputQueue iqueue;                  /* Output queue.*/
-    OutputQueue oqueue;                 /* Input circular buffer.*/
-    uint8_t ib[USBSERIAL_BUFFERS_SIZE]; /* Output circular buffer.*/
-    uint8_t ob[USBSERIAL_BUFFERS_SIZE];
-};
-
-typedef struct SerialUSBDriver SerialUSBDriver;
-
-extern SerialUSBDriver SUSBD1;
-
-void init_serial_usb_driver(SerialUSBDriver* sdp);
-void bulk_out_receive(void);
+void init_host_to_device();
 void serial_bulk_transfer_complete(void* user_data, unsigned int bytes_transferred);
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-size_t fillOBuffer(OutputQueue* oqp, const uint8_t* bp, size_t n);
-#ifdef __cplusplus
-}
-#endif
+void schedule_host_to_device_transfer();
+void complete_host_to_device_transfer();

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -36,7 +36,7 @@
 #include "crc.hpp"
 #include "hackrf_cpld_data.hpp"
 
-#include "usb_serial_io.h"
+#include "usb_serial_device_to_host.h"
 #include "chprintf.h"
 #include "chqueues.h"
 #include "ui_external_items_menu_loader.hpp"

--- a/firmware/application/usb_serial_shell_filesystem.cpp
+++ b/firmware/application/usb_serial_shell_filesystem.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "usb_serial_shell_filesystem.hpp"
-#include "usb_serial_io.h"
+#include "usb_serial_device_to_host.h"
 
 #include "chprintf.h"
 #include "string_format.hpp"
@@ -171,6 +171,9 @@ void cmd_sd_close(BaseSequentialStream* chp, int argc, char* argv[]) {
         chprintf(chp, "no open file\r\n");
         return;
     }
+
+    auto error = shell_file->sync();
+    if (report_on_error(chp, error)) return;
 
     delete shell_file;
     shell_file = nullptr;

--- a/firmware/application/usb_serial_thread.hpp
+++ b/firmware/application/usb_serial_thread.hpp
@@ -30,7 +30,7 @@
 #include "optional.hpp"
 
 #include "chprintf.h"
-#include "usb_serial_io.h"
+#include "usb_serial_device_to_host.h"
 
 #include <cstdint>
 #include <cstddef>

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -31,7 +31,7 @@
 #include "chprintf.h"
 #include "irq_controls.hpp"
 #include "string_format.hpp"
-#include "usb_serial_io.h"
+#include "usb_serial_device_to_host.h"
 
 using namespace portapack;
 


### PR DESCRIPTION
follow up on https://github.com/portapack-mayhem/mayhem-firmware/pull/1763

usb serial communication is now not longer handled inside an interrupt handler and no longer throws any errors