### PR TITLE
Geomap enhancements

### DIFF
--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -86,19 +86,19 @@ GeoPos::GeoPos(
     field_lon_seconds.on_change = changed_fn;
 
     const auto wrapped_lat_seconds = [this](int32_t v) {
-        field_lat_minutes.on_encoder(v);
+        field_lat_minutes.on_encoder((field_lat_degrees.value() >= 0) ? v : -v);
     };
 
     const auto wrapped_lat_minutes = [this](int32_t v) {
-        field_lat_degrees.on_encoder(v);
+        field_lat_degrees.on_encoder((field_lat_degrees.value() >= 0) ? v : -v);
     };
 
     const auto wrapped_lon_seconds = [this](int32_t v) {
-        field_lon_minutes.on_encoder(v);
+        field_lon_minutes.on_encoder((field_lon_degrees.value() >= 0) ? v : -v);
     };
 
     const auto wrapped_lon_minutes = [this](int32_t v) {
-        field_lon_degrees.on_encoder(v);
+        field_lon_degrees.on_encoder((field_lon_degrees.value() >= 0) ? v : -v);
     };
 
     field_lat_seconds.on_wrap = wrapped_lat_seconds;

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -260,20 +260,15 @@ ui::Point GeoMap::item_rect_pixel(GeoMarker& item) {
     float y = mapPoint.y - y_pos;
 
     if (map_zoom > 1) {
-        x = x * map_zoom + geomap_rect_half_width;
-        y = y * map_zoom + geomap_rect_half_height;
+        x = x * map_zoom + zoom_pixel_offset;
+        y = y * map_zoom + zoom_pixel_offset;
     } else if (map_zoom < 0) {
-        x = x / (-map_zoom) + geomap_rect_half_width;
-        y = y / (-map_zoom) + geomap_rect_half_height;
-    } else {
-        x -= geomap_rect_half_width;
-        y -= geomap_rect_half_height;
+        x = x / (-map_zoom);
+        y = y / (-map_zoom);
     }
 
-    if (map_zoom > 1) {
-        x += zoom_pixel_offset;
-        y += zoom_pixel_offset;
-    }
+    x += geomap_rect_half_width;
+    y += geomap_rect_half_height;
 
     return {(int16_t)x, (int16_t)y};
 }

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -85,6 +85,27 @@ GeoPos::GeoPos(
     field_lon_minutes.on_change = changed_fn;
     field_lon_seconds.on_change = changed_fn;
 
+    const auto wrapped_lat_seconds = [this](int32_t v) {
+        field_lat_minutes.on_encoder(v);
+    };
+
+    const auto wrapped_lat_minutes = [this](int32_t v) {
+        field_lat_degrees.on_encoder(v);
+    };
+
+    const auto wrapped_lon_seconds = [this](int32_t v) {
+        field_lon_minutes.on_encoder(v);
+    };
+
+    const auto wrapped_lon_minutes = [this](int32_t v) {
+        field_lon_degrees.on_encoder(v);
+    };
+
+    field_lat_seconds.on_wrap = wrapped_lat_seconds;
+    field_lat_minutes.on_wrap = wrapped_lat_minutes;
+    field_lon_seconds.on_wrap = wrapped_lon_seconds;
+    field_lon_minutes.on_wrap = wrapped_lon_minutes;
+
     text_alt_unit.set(altitude_unit_ ? "m" : "ft");
     if (speed_unit_ == KMPH) text_speed_unit.set("kmph");
     if (speed_unit_ == MPH) text_speed_unit.set("mph");

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -192,8 +192,8 @@ bool GeoMap::on_encoder(const EncoderEvent delta) {
         return false;
     }
 
-    zoom_pixel_offset = (map_visible && (map_zoom > 1)) ? (float)map_zoom / 2 : 0.0f;
     map_visible = map_opened && (map_zoom <= MAP_ZOOM_RESOLUTION_LIMIT);
+    zoom_pixel_offset = (map_visible && (map_zoom > 1)) ? (float)map_zoom / 2 : 0.0f;
 
     // Trigger map redraw
     markerListUpdated = true;
@@ -542,16 +542,13 @@ MapMarkerStored GeoMap::store_marker(GeoMarker& marker) {
     MapMarkerStored ret;
 
     // Check if it could be on screen
-    // Only checking one direction to reduce CPU
+    // (Shows more distant planes when zoomed out)
     GeoPoint mapPoint = lat_lon_to_map_pixel(marker.lat, marker.lon);
-    float x = mapPoint.x + zoom_pixel_offset - (x_pos - (r.width() / 2));
-    float y = mapPoint.y + zoom_pixel_offset - (y_pos - (r.height() / 2));
+    int x_dist = abs((int)mapPoint.x - (int)x_pos);
+    int y_dist = abs((int)mapPoint.y - (int)y_pos);
+    int zoom_out = (map_zoom < 0) ? -map_zoom : 1;
 
-    // TODO: adjust when zoomed out to show more planes
-    if (map_zoom < 0) {
-    }
-
-    if (false == ((x >= 0) && (x < r.width()) && (y > 10) && (y < r.height()))) {
+    if ((x_dist >= (zoom_out * r.width() / 2)) || (y_dist >= (zoom_out * r.height() / 2))) {
         ret = MARKER_NOT_STORED;
     } else if (markerListLen < NumMarkerListElements) {
         markerList[markerListLen] = marker;

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -275,10 +275,10 @@ void GeoMap::draw_map_grid() {
     display.fill_rectangle({{0, r.top()}, {r.width(), r.height()}}, Color::black());
 
     for (uint16_t line = y; line < r.height(); line += grid_spacing) {
-        display.fill_rectangle({{0, r.top() + line}, {r.width(), 1}}, Color::dark_blue());
+        display.fill_rectangle({{0, r.top() + line}, {r.width(), 1}}, Color::darker_grey());
     }
     for (uint16_t column = x; column < r.width(); column += grid_spacing) {
-        display.fill_rectangle({{column, r.top()}, {1, r.height()}}, Color::dark_blue());
+        display.fill_rectangle({{column, r.top()}, {1, r.height()}}, Color::darker_grey());
     }
 }
 

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -86,7 +86,7 @@ GeoPos::GeoPos(
     field_lon_seconds.on_change = changed_fn;
 
     const auto wrapped_lat_seconds = [this](int32_t v) {
-        field_lat_minutes.on_encoder((field_lat_degrees.value() >= 0) ? v : -v);
+        field_lat_minutes.on_encoder(v);
     };
 
     const auto wrapped_lat_minutes = [this](int32_t v) {
@@ -94,7 +94,7 @@ GeoPos::GeoPos(
     };
 
     const auto wrapped_lon_seconds = [this](int32_t v) {
-        field_lon_minutes.on_encoder((field_lon_degrees.value() >= 0) ? v : -v);
+        field_lon_minutes.on_encoder(v);
     };
 
     const auto wrapped_lon_minutes = [this](int32_t v) {

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -520,8 +520,8 @@ MapMarkerStored GeoMap::store_marker(GeoMarker& marker) {
     double lat_rad = sin(marker.lat * pi / 180);
     int x = (map_width * (marker.lon + 180) / 360) - x_pos + zoom_pixel_offset;
     int y = (map_height - ((map_world_lon / 2 * log((1 + lat_rad) / (1 - lat_rad))) - map_offset)) - y_pos + zoom_pixel_offset;  // Offset added for the GUI
-    if (false == ((x >= 0) && (x < geomap_rect_width) && (y > 10) && (y < geomap_rect_height)))
-    {
+
+    if (false == ((x >= 0) && (x < geomap_rect_width) && (y > 10) && (y < geomap_rect_height))) {
         ret = MARKER_NOT_STORED;
     } else if (markerListLen < NumMarkerListElements) {
         markerList[markerListLen] = marker;

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -189,7 +189,7 @@ bool GeoMap::on_encoder(const EncoderEvent delta) {
     }
 
     map_visible = map_opened && (map_zoom <= MAP_ZOOM_RESOLUTION_LIMIT);
-    zoom_pixel_offset = (map_visible && (map_zoom > 0)) ? (float)map_zoom / 2 : 0;
+    zoom_pixel_offset = (map_visible && (map_zoom > 1)) ? (float)map_zoom / 2 : 0.0f;
 
     // Trigger map redraw
     markerListUpdated = true;
@@ -520,7 +520,7 @@ MapMarkerStored GeoMap::store_marker(GeoMarker& marker) {
     double lat_rad = sin(marker.lat * pi / 180);
     int x = (map_width * (marker.lon + 180) / 360) - x_pos + zoom_pixel_offset;
     int y = (map_height - ((map_world_lon / 2 * log((1 + lat_rad) / (1 - lat_rad))) - map_offset)) - y_pos + zoom_pixel_offset;  // Offset added for the GUI
-    if (false == ((x >= 0) && (x < geomap_rect_width) && (y > 10) && (y < geomap_rect_height)))  // Dont draw within symbol size of top
+    if (false == ((x >= 0) && (x < geomap_rect_width) && (y > 10) && (y < geomap_rect_height)))
     {
         ret = MARKER_NOT_STORED;
     } else if (markerListLen < NumMarkerListElements) {

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -65,6 +65,7 @@ GeoPos::GeoPos(
     set_lon(0);
 
     const auto changed_fn = [this](int32_t) {
+        // Convert degrees/minutes/seconds fields to decimal (floating point) lat/lon degree
         float lat_value = lat();
         float lon_value = lon();
 
@@ -255,8 +256,8 @@ ui::Point GeoMap::item_rect_pixel(GeoMarker& item) {
     const auto geomap_rect_half_height = r.height() / 2;
 
     GeoPoint mapPoint = lat_lon_to_map_pixel(item.lat, item.lon);
-    float x = mapPoint.x + zoom_pixel_offset - x_pos;
-    float y = mapPoint.y + zoom_pixel_offset - y_pos;
+    float x = mapPoint.x - x_pos;
+    float y = mapPoint.y - y_pos;
 
     if (map_zoom > 1) {
         x = x * map_zoom + geomap_rect_half_width;
@@ -267,6 +268,11 @@ ui::Point GeoMap::item_rect_pixel(GeoMarker& item) {
     } else {
         x -= geomap_rect_half_width;
         y -= geomap_rect_half_height;
+    }
+
+    if (map_zoom > 1) {
+        x += zoom_pixel_offset;
+        y += zoom_pixel_offset;
     }
 
     return {(int16_t)x, (int16_t)y};

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -366,7 +366,7 @@ void GeoMap::move(const float lon, const float lat) {
 
 bool GeoMap::init() {
     auto result = map_file.open("ADSB/world_map.bin");
-    map_opened = !result.is_valid();  
+    map_opened = !result.is_valid();
 
     if (map_opened) {
         map_file.read(&map_width, 2);
@@ -520,7 +520,7 @@ MapMarkerStored GeoMap::store_marker(GeoMarker& marker) {
     double lat_rad = sin(marker.lat * pi / 180);
     int x = (map_width * (marker.lon + 180) / 360) - x_pos + zoom_pixel_offset;
     int y = (map_height - ((map_world_lon / 2 * log((1 + lat_rad) / (1 - lat_rad))) - map_offset)) - y_pos + zoom_pixel_offset;  // Offset added for the GUI
-    if (false == ((x >= 0) && (x < geomap_rect_width) && (y > 10) && (y < geomap_rect_height)))              // Dont draw within symbol size of top
+    if (false == ((x >= 0) && (x < geomap_rect_width) && (y > 10) && (y < geomap_rect_height)))  // Dont draw within symbol size of top
     {
         ret = MARKER_NOT_STORED;
     } else if (markerListLen < NumMarkerListElements) {

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -31,7 +31,7 @@
 
 #define MAX_MAP_ZOOM_IN 1000
 #define MAX_MAP_ZOOM_OUT 10
-#define MAP_ZOOM_RESOLUTION_LIMIT 6  // Max zoom-in to show map; screen width (240) must divide into this evenly
+#define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
 namespace ui {
 
@@ -240,10 +240,11 @@ class GeoMap : public Widget {
     double map_world_lon{};
     double map_offset{};
 
-    int32_t x_pos{}, y_pos{};
-    int32_t prev_x_pos{0xFFFF}, prev_y_pos{0xFFFF};
+    float x_pos{}, y_pos{};
+    float prev_x_pos{32767.0f}, prev_y_pos{32767.0f};
     float lat_{};
     float lon_{};
+    float zoom_pixel_offset{0};
     float pixels_per_km{};
     uint16_t angle_{};
     std::string tag_{};

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -147,13 +147,15 @@ class GeoPos : public View {
         2,
         {0, 59},
         1,
-        ' '};
+        ' ',
+        true};
     NumberField field_lat_seconds{
         {13 * 8, 1 * 16},
         2,
         {0, 59},
         1,
-        ' '};
+        ' ',
+        true};
     Text text_lat_decimal{
         {17 * 8, 1 * 16, 13 * 8, 1 * 16},
         ""};
@@ -169,13 +171,15 @@ class GeoPos : public View {
         2,
         {0, 59},
         1,
-        ' '};
+        ' ',
+        true};
     NumberField field_lon_seconds{
         {13 * 8, 2 * 16},
         2,
         {0, 59},
         1,
-        ' '};
+        ' ',
+        true};
     Text text_lon_decimal{
         {17 * 8, 2 * 16, 13 * 8, 1 * 16},
         ""};

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -33,6 +33,9 @@
 #define MAX_MAP_ZOOM_OUT 10
 #define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
+#define INVALID_LAT_LON 200
+#define INVALID_ANGLE 400
+
 namespace ui {
 
 enum GeoMapMode {
@@ -220,10 +223,12 @@ class GeoMap : public Widget {
 
    private:
     void draw_scale(Painter& painter);
-    void draw_bearing(const Point origin, const uint16_t angle, uint32_t size, const Color color);
+    void draw_marker_item(Painter& painter, GeoMarker& item, const Color color, const Color fontColor = Color::white(), const Color backColor = Color::black());
     void draw_marker(Painter& painter, const ui::Point itemPoint, const uint16_t itemAngle, const std::string itemTag, const Color color = Color::red(), const Color fontColor = Color::white(), const Color backColor = Color::black());
     void draw_markers(Painter& painter);
-    void draw_mypos();
+    void draw_mypos(Painter& painter);
+    void draw_bearing(const Point origin, const uint16_t angle, uint32_t size, const Color color);
+    void draw_map_grid();
     void map_read_line(ui::Color* buffer, uint16_t pixels);
 
     bool manual_panning_{false};
@@ -250,10 +255,8 @@ class GeoMap : public Widget {
     std::string tag_{};
 
     // the portapack's position data ( for example injected from serial )
-    float my_lat{200};
-    float my_lon{200};
+    GeoMarker my_pos{INVALID_LAT_LON, INVALID_LAT_LON, INVALID_ANGLE, ""};  // lat, lon, angle, tag
     int32_t my_altitude{0};
-    uint16_t my_angle{400};
 
     int markerListLen{0};
     GeoMarker markerList[NumMarkerListElements];

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -31,7 +31,7 @@
 
 namespace ui {
 
-#define MAX_MAP_ZOOM_IN 2000
+#define MAX_MAP_ZOOM_IN 4000
 #define MAX_MAP_ZOOM_OUT 10
 #define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
@@ -40,12 +40,7 @@ namespace ui {
 
 #define GEOMAP_BANNER_HEIGHT (3 * 16)
 #define GEOMAP_RECT_WIDTH 240
-#define GEOMAP_RECT_HALF_WIDTH (GEOMAP_RECT_WIDTH / 2)
-#define GEOMAP_RECT_TOP (GEOMAP_BANNER_HEIGHT + 16)
-#define GEOMAP_RECT_HEIGHT (320 - GEOMAP_RECT_TOP)
-#define GEOMAP_RECT_HALF_HEIGHT (GEOMAP_RECT_HEIGHT / 2)
-#define GEOMAP_RECT_CENTER_X (GEOMAP_RECT_HALF_WIDTH)
-#define GEOMAP_RECT_CENTER_Y (GEOMAP_RECT_TOP + GEOMAP_RECT_HALF_HEIGHT)
+#define GEOMAP_RECT_HEIGHT (320 - 16 - GEOMAP_BANNER_HEIGHT)
 
 enum GeoMapMode {
     DISPLAY,
@@ -232,6 +227,10 @@ class GeoMap : public Widget {
     void clear_markers();
     MapMarkerStored store_marker(GeoMarker& marker);
 
+    static const Dim banner_height = GEOMAP_BANNER_HEIGHT;
+    static const Dim geomap_rect_width = GEOMAP_RECT_WIDTH;
+    static const Dim geomap_rect_height = GEOMAP_RECT_HEIGHT;
+
    private:
     void draw_scale(Painter& painter);
     ui::Point item_rect_pixel(GeoMarker& item);
@@ -337,7 +336,7 @@ class GeoMapView : public View {
         speed_unit_};
 
     GeoMap geomap{
-        {0, GEOMAP_BANNER_HEIGHT, GEOMAP_RECT_WIDTH, GEOMAP_RECT_HEIGHT}};
+        {0, GeoMap::banner_height, GeoMap::geomap_rect_width, GeoMap::geomap_rect_height}};
 
     Button button_ok{
         {20 * 8, 8, 8 * 8, 2 * 16},

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -29,18 +29,33 @@
 
 #include "portapack.hpp"
 
-#define MAX_MAP_ZOOM_IN 1000
+namespace ui {
+
+#define MAX_MAP_ZOOM_IN 2000
 #define MAX_MAP_ZOOM_OUT 10
 #define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
 #define INVALID_LAT_LON 200
 #define INVALID_ANGLE 400
 
-namespace ui {
+#define GEOMAP_BANNER_HEIGHT (3 * 16)
+#define GEOMAP_RECT_WIDTH 240
+#define GEOMAP_RECT_HALF_WIDTH (GEOMAP_RECT_WIDTH / 2)
+#define GEOMAP_RECT_TOP (GEOMAP_BANNER_HEIGHT + 16)
+#define GEOMAP_RECT_HEIGHT (320 - GEOMAP_RECT_TOP)
+#define GEOMAP_RECT_HALF_HEIGHT (GEOMAP_RECT_HEIGHT / 2)
+#define GEOMAP_RECT_CENTER_X (GEOMAP_RECT_HALF_WIDTH)
+#define GEOMAP_RECT_CENTER_Y (GEOMAP_RECT_TOP + GEOMAP_RECT_HALF_HEIGHT)
 
 enum GeoMapMode {
     DISPLAY,
     PROMPT
+};
+
+struct GeoPoint {
+   public:
+    float x{0};
+    float y{0};
 };
 
 struct GeoMarker {
@@ -217,12 +232,10 @@ class GeoMap : public Widget {
     void clear_markers();
     MapMarkerStored store_marker(GeoMarker& marker);
 
-    static const Dim banner_height = 3 * 16;
-    static const Dim geomap_rect_width = 240;
-    static const Dim geomap_rect_height = 320 - 16 - banner_height;
-
    private:
     void draw_scale(Painter& painter);
+    ui::Point item_rect_pixel(GeoMarker& item);
+    GeoPoint lat_lon_to_map_pixel(float lat, float lon);
     void draw_marker_item(Painter& painter, GeoMarker& item, const Color color, const Color fontColor = Color::white(), const Color backColor = Color::black());
     void draw_marker(Painter& painter, const ui::Point itemPoint, const uint16_t itemAngle, const std::string itemTag, const Color color = Color::red(), const Color fontColor = Color::white(), const Color backColor = Color::black());
     void draw_markers(Painter& painter);
@@ -249,7 +262,7 @@ class GeoMap : public Widget {
     float prev_x_pos{32767.0f}, prev_y_pos{32767.0f};
     float lat_{};
     float lon_{};
-    float zoom_pixel_offset{0};
+    float zoom_pixel_offset{0.0f};
     float pixels_per_km{};
     uint16_t angle_{};
     std::string tag_{};
@@ -324,7 +337,7 @@ class GeoMapView : public View {
         speed_unit_};
 
     GeoMap geomap{
-        {0, GeoMap::banner_height, GeoMap::geomap_rect_width, GeoMap::geomap_rect_height}};
+        {0, GEOMAP_BANNER_HEIGHT, GEOMAP_RECT_WIDTH, GEOMAP_RECT_HEIGHT}};
 
     Button button_ok{
         {20 * 8, 8, 8 * 8, 2 * 16},

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -32,7 +32,7 @@
 namespace ui {
 
 #define MAX_MAP_ZOOM_IN 4000
-#define MAX_MAP_ZOOM_OUT 10
+#define MAX_MAP_ZOOM_OUT 12
 #define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
 #define INVALID_LAT_LON 200

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -29,8 +29,9 @@
 
 #include "portapack.hpp"
 
-#define MAX_MAP_ZOOM_IN 5
+#define MAX_MAP_ZOOM_IN 1000
 #define MAX_MAP_ZOOM_OUT 10
+#define MAP_ZOOM_RESOLUTION_LIMIT 6  // Max zoom-in to show map; screen width (240) must divide into this evenly
 
 namespace ui {
 
@@ -201,6 +202,13 @@ class GeoMap : public Widget {
         angle_ = new_angle;
     }
 
+    bool map_file_opened() { return map_opened; }
+
+    void set_hide_center_marker(bool hide) {
+        hide_center_marker_ = hide;
+    }
+    bool hide_center_marker() { return hide_center_marker_; }
+
     static const int NumMarkerListElements = 30;
 
     void clear_markers();
@@ -219,8 +227,11 @@ class GeoMap : public Widget {
     void map_read_line(ui::Color* buffer, uint16_t pixels);
 
     bool manual_panning_{false};
+    bool hide_center_marker_{false};
     GeoMapMode mode_{};
     File map_file{};
+    bool map_opened{};
+    bool map_visible{};
     uint16_t map_width{}, map_height{};
     int32_t map_center_x{}, map_center_y{};
     int16_t map_zoom{1};
@@ -302,8 +313,6 @@ class GeoMapView : public View {
     float lon_{};
     uint16_t angle_{};
     std::function<void(void)> on_close_{nullptr};
-
-    bool map_opened{};
 
     GeoPos geopos{
         {0, 0},

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -31,7 +31,7 @@
 #include "chprintf.h"
 #include "irq_controls.hpp"
 #include "string_format.hpp"
-#include "usb_serial_device_to_host.h"
+#include "usb_serial_io.h"
 
 using namespace portapack;
 
@@ -2118,7 +2118,15 @@ bool NumberField::on_key(const KeyEvent key) {
 }
 
 bool NumberField::on_encoder(const EncoderEvent delta) {
+    int32_t old_value = value();
     set_value(value() + (delta * step));
+
+    if (on_wrap) {
+        if ((delta > 0) && (value() < old_value))
+            on_wrap(1);
+        else if ((delta < 0) && (value() > old_value))
+            on_wrap(-1);
+    }
     return true;
 }
 

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -783,6 +783,7 @@ class NumberField : public Widget {
    public:
     std::function<void(NumberField&)> on_select{};
     std::function<void(int32_t)> on_change{};
+    std::function<void(int32_t)> on_wrap{};
 
     using range_t = std::pair<int32_t, int32_t>;
 


### PR DESCRIPTION
Increased zoom-in support:
*  Allow zoom-in to very high levels for Foxhunt.
*  Show grid squares (versus map) when zoomed in more than 5X.
*  Modified scale display to handle increased zoom-in.
*  Use floating point for current x_pos/y_pos for sub-pixel accuracy when zooming in (original accuracy was only to 1 pixel of the UN-Zoomed map).
* Changed meaning of x_pos/y_pos to point to center of map region versus to upper left corner (reduces math when zooming).
*  Tweak marker positions to compensate for map being shifted by map_zoom/2 pixels when zooming in.
* Added a 1-pixel dot in the middle of the bearing marker to show where the center of this marker is located.
* Zoom in power-of-two steps once the map resolution is exceeded.
* Eliminated some of the redundant code to reduce code size.
* Show more distant planes when zoomed out.
* NEW:  Added wrapping support to Lat/Lon fields (when seconds passes 60 the minutes are incremented, when minutes pass 60 the degrees are incremented, etc)

Also redrawing map automatically after smaller x/y position changes.

I had considered allowing the map view to show up when there is no world_map.bin file and it worked OK, but ultimately left that disabled so it's obvious to the user why their map is black.  To enable geomap without the world_map file, just comment out the display_model in GeoMapView::focus() and it will work now and show the correct scale (but map will just show the grid squares).

PR also includes "hide_center_marker" function from HTotoo's branch