### PR TITLE
added sysinfo and radioinfo

### DIFF
--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -935,7 +935,7 @@ static void cmd_sysinfo(BaseSequentialStream* chp, int argc, char* argv[]) {
         "M4 miss: " + to_string_dec_uint(shared_memory.m4_buffer_missed) + "\r\n" +
         "uptime: " + to_string_dec_uint(chTimeNow() / 1000) + "\r\n";
 
-    chprintf(chp, info.c_str());
+    fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)info.c_str(), info.length());
     return;
 }
 
@@ -958,7 +958,7 @@ static void cmd_radioinfo(BaseSequentialStream* chp, int argc, char* argv[]) {
         "transmitter_model.baseband_bandwidth: " + to_string_dec_uint(portapack::transmitter_model.baseband_bandwidth()) + "\r\n" +
         "transmitter_model.sampling_rate: " + to_string_dec_uint(portapack::transmitter_model.sampling_rate()) + "\r\n";
 
-    chprintf(chp, info.c_str());
+    fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)info.c_str(), info.length());
     return;
 }
 


### PR DESCRIPTION
That PR is adding sysinfo and radioinfo to usb serial commands.

They are reporting the same informations as 'Performance' and 'Radio Settings' when using the DFU button.

Example output:

sysinfo:
```
ch> sysinfo
M0 heap: 32400
M0 stack: 395
M0 cpu: 22
M4 heap: 0
M4 stack: 0
M0 cpu: 0
M4 miss: 0
uptime: 12
ch>
```
radioinfo:
```
ch> radioinfo
receiver_model.target_frequency: 25435000
receiver_model.baseband_bandwidth: 1750000
receiver_model.sampling_rate: 3072000
receiver_model.modulation: 1
receiver_model.am_configuration: 0
receiver_model.nbfm_configuration: 0
receiver_model.wfm_configuration: 0
transmitter_model.target_frequency: 25435000
transmitter_model.baseband_bandwidth: 1750000
transmitter_model.sampling_rate: 3072000
ch> 
```

Solve enhancement issue https://github.com/portapack-mayhem/mayhem-firmware/issues/1768