### PR TITLE
Geomap zoom-out tweaks

### DIFF
--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -32,7 +32,7 @@
 namespace ui {
 
 #define MAX_MAP_ZOOM_IN 4000
-#define MAX_MAP_ZOOM_OUT 12
+#define MAX_MAP_ZOOM_OUT 10
 #define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
 #define INVALID_LAT_LON 200
@@ -276,7 +276,7 @@ class GeoMap : public Widget {
 
     int markerListLen{0};
     GeoMarker markerList[NumMarkerListElements];
-    bool markerListUpdated{false};
+    bool redraw_map{false};
 };
 
 class GeoMapView : public View {


### PR DESCRIPTION
* Revert max zoom out factor back to 10 (max was 12 in PR 1767), due to memory limitations.
* When zooming out, only redraw the map when position changes by abs(map_zoom) pixels.  (Was redrawing map unnecessarily for a small position change that didn't result in any visible change on the screen.)
* In the "draw_scale" function, use screen_rect versus global screen_width/height values.