### PR TITLE
Added Settings app to disable Config Mode

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -43,6 +43,7 @@ namespace fs = std::filesystem;
 #include "string_format.hpp"
 #include "ui_styles.hpp"
 #include "cpld_update.hpp"
+#include "config_mode.hpp"
 
 namespace pmem = portapack::persistent_memory;
 
@@ -657,6 +658,30 @@ void AppSettingsView::focus() {
     menu_view.focus();
 }
 
+/* SetConfigModeView ************************************/
+
+SetConfigModeView::SetConfigModeView(NavigationView& nav) {
+    add_children({&labels,
+                  &checkbox_config_mode_enabled,
+                  &button_save,
+                  &button_cancel});
+
+    checkbox_config_mode_enabled.set_value(!config_mode_disabled());
+
+    button_save.on_select = [&nav, this](Button&) {
+        config_mode_enable(checkbox_config_mode_enabled.value());
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetConfigModeView::focus() {
+    button_save.focus();
+}
+
 /* SettingsMenuView **************************************/
 
 SettingsMenuView::SettingsMenuView(NavigationView& nav) {
@@ -667,15 +692,16 @@ SettingsMenuView::SettingsMenuView(NavigationView& nav) {
         {"App Settings", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<AppSettingsView>(); }},
         {"Audio", ui::Color::dark_cyan(), &bitmap_icon_speaker, [&nav]() { nav.push<SetAudioView>(); }},
         {"Calibration", ui::Color::dark_cyan(), &bitmap_icon_options_touch, [&nav]() { nav.push<TouchCalibrationView>(); }},
+        {"Config Mode", ui::Color::dark_cyan(), &bitmap_icon_clk_ext, [&nav]() { nav.push<SetConfigModeView>(); }},
         {"Converter", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetConverterSettingsView>(); }},
         {"Date/Time", ui::Color::dark_cyan(), &bitmap_icon_options_datetime, [&nav]() { nav.push<SetDateTimeView>(); }},
         {"Encoder Dial", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetEncoderDialView>(); }},
         {"Freq. Correct", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetFrequencyCorrectionView>(); }},
         {"P.Memory Mgmt", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<SetPersistentMemoryView>(); }},
-        {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [&nav]() { nav.push<SetQRCodeView>(); }},
         {"Radio", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetRadioView>(); }},
-        {"User Interface", ui::Color::dark_cyan(), &bitmap_icon_options_ui, [&nav]() { nav.push<SetUIView>(); }},
         {"SD Card", ui::Color::dark_cyan(), &bitmap_icon_sdcard, [&nav]() { nav.push<SetSDCardView>(); }},
+        {"User Interface", ui::Color::dark_cyan(), &bitmap_icon_options_ui, [&nav]() { nav.push<SetUIView>(); }},
+        {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [&nav]() { nav.push<SetQRCodeView>(); }},
     });
     set_max_rows(2);  // allow wider buttons
 }

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -666,10 +666,10 @@ SetConfigModeView::SetConfigModeView(NavigationView& nav) {
                   &button_save,
                   &button_cancel});
 
-    checkbox_config_mode_enabled.set_value(!config_mode_disabled());
+    checkbox_config_mode_enabled.set_value(!pmem::config_disable_config_mode());
 
     button_save.on_select = [&nav, this](Button&) {
-        config_mode_enable(checkbox_config_mode_enabled.value());
+        pmem::set_config_disable_config_mode(!checkbox_config_mode_enabled.value());
         nav.pop();
     };
 

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -581,6 +581,36 @@ class AppSettingsView : public View {
         true};
 };
 
+class SetConfigModeView : public View {
+   public:
+    SetConfigModeView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Config Mode"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Controls whether firmware", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "will enter Config Mode", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "after a boot failure.", Color::light_grey()},
+    };
+
+    Checkbox checkbox_config_mode_enabled{
+        {2 * 8, 6 * 16},
+        16,
+        "Config Mode enabled"};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+};
+
 class SettingsMenuView : public BtnGridView {
    public:
     SettingsMenuView(NavigationView& nav);

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -599,7 +599,7 @@ class SetConfigModeView : public View {
     Checkbox checkbox_config_mode_enabled{
         {2 * 8, 6 * 16},
         16,
-        "Config Mode enabled"};
+        "Config Mode enable"};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},

--- a/firmware/application/config_mode.cpp
+++ b/firmware/application/config_mode.cpp
@@ -27,8 +27,7 @@
 void config_mode_blink_until_dfu();
 
 void config_mode_set() {
-    if (!portapack::persistent_memory::config_disable_config_mode_direct())
-        portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_GUARD_VALUE);
+    portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_GUARD_VALUE);
 }
 
 bool config_mode_should_enter() {
@@ -39,8 +38,7 @@ bool config_mode_should_enter() {
 }
 
 void config_mode_clear() {
-    if (!portapack::persistent_memory::config_disable_config_mode_direct())
-        portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_NORMAL_VALUE);
+    portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_NORMAL_VALUE);
 }
 
 uint32_t blink_patterns[] = {

--- a/firmware/application/config_mode.cpp
+++ b/firmware/application/config_mode.cpp
@@ -27,25 +27,20 @@
 void config_mode_blink_until_dfu();
 
 void config_mode_set() {
-    if (!config_mode_disabled())
+    if (!portapack::persistent_memory::config_disable_config_mode_direct())
         portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_GUARD_VALUE);
 }
 
 bool config_mode_should_enter() {
-    return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_GUARD_VALUE;
+    if (portapack::persistent_memory::config_disable_config_mode_direct())
+        return false;
+    else
+        return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_GUARD_VALUE;
 }
 
 void config_mode_clear() {
-    if (!config_mode_disabled())
+    if (!portapack::persistent_memory::config_disable_config_mode_direct())
         portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_NORMAL_VALUE);
-}
-
-void config_mode_enable(bool v) {
-    portapack::persistent_memory::set_config_mode_storage(v ? CONFIG_MODE_NORMAL_VALUE : CONFIG_MODE_DISABLE_VALUE);
-}
-
-bool config_mode_disabled() {
-    return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_DISABLE_VALUE;
 }
 
 uint32_t blink_patterns[] = {

--- a/firmware/application/config_mode.cpp
+++ b/firmware/application/config_mode.cpp
@@ -27,15 +27,25 @@
 void config_mode_blink_until_dfu();
 
 void config_mode_set() {
-    portapack::persistent_memory::set_config_mode_storage(CONFIG_MODE_GUARD_VALUE);
+    if (!config_mode_disabled())
+        portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_GUARD_VALUE);
 }
 
 bool config_mode_should_enter() {
-    return portapack::persistent_memory::config_mode_storage() == CONFIG_MODE_GUARD_VALUE;
+    return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_GUARD_VALUE;
 }
 
 void config_mode_clear() {
-    portapack::persistent_memory::set_config_mode_storage(CONFIG_MODE_NORMAL_VALUE);
+    if (!config_mode_disabled())
+        portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_NORMAL_VALUE);
+}
+
+void config_mode_enable(bool v) {
+    portapack::persistent_memory::set_config_mode_storage(v ? CONFIG_MODE_NORMAL_VALUE : CONFIG_MODE_DISABLE_VALUE);
+}
+
+bool config_mode_disabled() {
+    return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_DISABLE_VALUE;
 }
 
 uint32_t blink_patterns[] = {

--- a/firmware/application/config_mode.hpp
+++ b/firmware/application/config_mode.hpp
@@ -31,6 +31,8 @@
 void config_mode_set();
 bool config_mode_should_enter();
 void config_mode_clear();
+void config_mode_enable(bool v);
+bool config_mode_disabled();
 
 void config_mode_run();
 

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -416,8 +416,8 @@ void init() {
     const auto switches_state = get_switches_state();
 
     // ignore for valid check
-    auto config_mode_backup = config_mode_storage();
-    set_config_mode_storage(CONFIG_MODE_NORMAL_VALUE);
+    auto config_mode_backup = config_mode_storage_direct();
+    set_config_mode_storage_direct(CONFIG_MODE_NORMAL_VALUE);
 
     if (!(switches_state[(size_t)ui::KeyEvent::Left] && switches_state[(size_t)ui::KeyEvent::Right]) && backup_ram->is_valid()) {
         // Copy valid persistent data into cache.
@@ -434,7 +434,7 @@ void init() {
         // Copy defaults into cache.
         defaults();
     }
-    set_config_mode_storage(config_mode_backup);
+    set_config_mode_storage_direct(config_mode_backup);
 }
 
 void persist() {
@@ -948,11 +948,17 @@ void set_encoder_dial_sensitivity(uint8_t v) {
 // Recovery mode magic value storage
 static data_t* data_direct_access = reinterpret_cast<data_t*>(memory::map::backup_ram.base());
 
-uint32_t config_mode_storage() {
+uint32_t config_mode_storage_direct() {
     return data_direct_access->config_mode_storage;
 }
-void set_config_mode_storage(uint32_t v) {
+void set_config_mode_storage_direct(uint32_t v) {
     data_direct_access->config_mode_storage = v;
+}
+uint32_t config_mode_storage() {
+    return data->config_mode_storage;
+}
+void set_config_mode_storage(uint32_t v) {
+    data->config_mode_storage = v;
 }
 
 // PMem to sdcard settings

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -145,7 +145,7 @@ struct misc_config_t {
     bool disable_speaker : 1;
     bool config_disable_external_tcxo : 1;
     bool config_sdcard_high_speed_io : 1;
-    bool UNUSED_4 : 1;
+    bool config_disable_config_mode : 1;
     bool UNUSED_5 : 1;
     bool UNUSED_6 : 1;
     bool UNUSED_7 : 1;
@@ -155,6 +155,8 @@ struct misc_config_t {
     uint8_t PLACEHOLDER_3;
 };
 static_assert(sizeof(misc_config_t) == sizeof(uint32_t));
+
+#define MC_CONFIG_DISABLE_CONFIG_MODE 0x00000010  // config_disable_config_mode bit in struct above
 
 /* IMPORTANT: Update dump_persistent_memory (below) when changing data_t. */
 
@@ -386,6 +388,7 @@ namespace cache {
 void defaults() {
     cached_backup_ram = backup_ram_t();
 
+    // If the desired default is 0/false, then no need to set it here (buffer is initialized to 0)
     set_config_backlight_timer(backlight_config_t{});
     set_config_splash(true);
     set_config_disable_external_tcxo(false);
@@ -598,6 +601,10 @@ bool config_disable_external_tcxo() {
     return data->misc_config.config_disable_external_tcxo;
 }
 
+bool config_disable_config_mode() {
+    return data->misc_config.config_disable_config_mode;
+}
+
 bool config_sdcard_high_speed_io() {
     return data->misc_config.config_sdcard_high_speed_io;
 }
@@ -665,6 +672,10 @@ void set_config_speaker_disable(bool v) {
 
 void set_config_disable_external_tcxo(bool v) {
     data->misc_config.config_disable_external_tcxo = v;
+}
+
+void set_config_disable_config_mode(bool v) {
+    data->misc_config.config_disable_config_mode = v;
 }
 
 void set_config_sdcard_high_speed_io(bool v, bool save) {
@@ -954,11 +965,11 @@ uint32_t config_mode_storage_direct() {
 void set_config_mode_storage_direct(uint32_t v) {
     data_direct_access->config_mode_storage = v;
 }
-uint32_t config_mode_storage() {
-    return data->config_mode_storage;
-}
-void set_config_mode_storage(uint32_t v) {
-    data->config_mode_storage = v;
+bool config_disable_config_mode_direct() {
+    // "return data_direct_access->misc_config.config_disable_config_mode"
+    // Casting as U32 as workaround for misaligned memory access
+    uint32_t misc_config_u32 = *(uint32_t*)&data_direct_access->misc_config;
+    return ((misc_config_u32 & MC_CONFIG_DISABLE_CONFIG_MODE) != 0);
 }
 
 // PMem to sdcard settings
@@ -1094,8 +1105,9 @@ bool debug_dump() {
     // misc_config bits
     pmem_dump_file.write_line("misc_config config_audio_mute: " + to_string_dec_int(config_audio_mute()));
     pmem_dump_file.write_line("misc_config config_speaker_disable: " + to_string_dec_int(config_speaker_disable()));
-    pmem_dump_file.write_line("ui_config config_disable_external_tcxo: " + to_string_dec_uint(config_disable_external_tcxo()));
-    pmem_dump_file.write_line("ui_config config_sdcard_high_speed_io: " + to_string_dec_uint(config_sdcard_high_speed_io()));
+    pmem_dump_file.write_line("misc_config config_disable_external_tcxo: " + to_string_dec_uint(config_disable_external_tcxo()));
+    pmem_dump_file.write_line("misc_config config_sdcard_high_speed_io: " + to_string_dec_uint(config_sdcard_high_speed_io()));
+    pmem_dump_file.write_line("misc_config config_disable_config_mode: " + to_string_dec_uint(config_disable_config_mode()));
 
     // receiver_model
     pmem_dump_file.write_line("\n[Receiver Model]");

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -223,8 +223,11 @@ void set_disable_touchscreen(bool v);
 uint8_t config_encoder_dial_sensitivity();
 void set_encoder_dial_sensitivity(uint8_t v);
 
-#define CONFIG_MODE_GUARD_VALUE 2001
-#define CONFIG_MODE_NORMAL_VALUE 1999
+#define CONFIG_MODE_GUARD_VALUE 0xbadb007  // "bad boot"
+#define CONFIG_MODE_NORMAL_VALUE 0x7cf
+#define CONFIG_MODE_DISABLE_VALUE 0xd15ab1ed  // "disabled"
+uint32_t config_mode_storage_direct();
+void set_config_mode_storage_direct(uint32_t v);
 uint32_t config_mode_storage();
 void set_config_mode_storage(uint32_t v);
 

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -178,6 +178,8 @@ void set_config_cpld(uint8_t i);
 
 bool config_disable_external_tcxo();
 bool config_sdcard_high_speed_io();
+bool config_disable_config_mode();
+
 bool config_splash();
 bool config_converter();
 bool config_updown_converter();
@@ -198,6 +200,8 @@ void set_save_app_settings(bool v);
 void set_show_bigger_qr_code(bool v);
 void set_config_disable_external_tcxo(bool v);
 void set_config_sdcard_high_speed_io(bool v, bool save);
+void set_config_disable_config_mode(bool v);
+
 void set_config_splash(bool v);
 bool config_converter();
 bool config_updown_converter();
@@ -223,13 +227,11 @@ void set_disable_touchscreen(bool v);
 uint8_t config_encoder_dial_sensitivity();
 void set_encoder_dial_sensitivity(uint8_t v);
 
-#define CONFIG_MODE_GUARD_VALUE 0xbadb007  // "bad boot"
-#define CONFIG_MODE_NORMAL_VALUE 0x7cf
-#define CONFIG_MODE_DISABLE_VALUE 0xd15ab1ed  // "disabled"
+#define CONFIG_MODE_GUARD_VALUE 0x000007d1
+#define CONFIG_MODE_NORMAL_VALUE 0x000007cf
 uint32_t config_mode_storage_direct();
 void set_config_mode_storage_direct(uint32_t v);
-uint32_t config_mode_storage();
-void set_config_mode_storage(uint32_t v);
+bool config_disable_config_mode_direct();
 
 uint32_t pocsag_last_address();
 void set_pocsag_last_address(uint32_t address);


### PR DESCRIPTION
Since "Config Mode" was added in PR #1433 in n_230905 and in 1.8.0, I've been having intermittent issues with Config Mode being started when I plug in the USB cable.  Sometimes I need to plug in the cable several times to get the PortaPack to boot normally instead of into Config Mode.  I am not alone -- see #1693 and #1718.

Until a better fix is implemented to avoid starting Config Mode unnecessarily, the "Config Mode" app proposed herein adds a persistent memory setting to disable Config Mode from starting at boot.

Perhaps Config Mode should be disabled automatically after a successful boot versus needing to configure this setting manually, TBD.

One caveat to this app is the case where certain controllers ALWAYS boot up to Config Mode, in which case it will be impossible to run the app to set this bit.  (The user might need a special version of firmware just to set this bit, or a special button sequence not yet implemented.)

If a user is stuck and _really_ needs Config Mode after disabling it, they could pull out the coin cell to clear this setting in pmem.

A test version is available in Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1197007635099156593