### PR TITLE
Remove time from PPFW filename and modify Flash app to support .tar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ if ("${VERSION}" STREQUAL "")
 	set(VERSION_NOHASH "dev")
 else()
 	set(VERSION_NOHASH "${VERSION}")
-	set(PPFW_FILENAME "portapack-mayhem.ppfw.tar")
 endif()
 
 execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,16 +55,6 @@ execute_process(
 )
 set(VERSION_MD5 "0x${VERSION_MD5}")
 
-if (NOT DEFINED PPFW_FILENAME)
-	# Funny business here: trying to generate unique names to prevent renaming of shared test-drive builds by the browser on download to .ppfw-42.tar as it wont be recognized by the flasher
-	execute_process(
-		COMMAND date "+%y%m%d-%H%M"
-		OUTPUT_VARIABLE PPFW_FILENAME
-	)
-	string(STRIP ${PPFW_FILENAME} PPFW_FILENAME)
-	set(PPFW_FILENAME "portapack-mayhem_${PPFW_FILENAME}_OCI.ppfw.tar")
-endif()
-
 message("Building version: ${VERSION} MD5: ${VERSION_MD5}")
 
 set(LICENSE_PATH ${CMAKE_CURRENT_LIST_DIR}/LICENSE)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -35,7 +35,10 @@ set(LZ4 lz4)
 
 set(FIRMWARE_NAME portapack-h1_h2-mayhem)
 set(FIRMWARE_FILENAME ${FIRMWARE_NAME}.bin)
-set(PPFW_FILENAME "portapack-mayhem_OCI.ppfw.tar")
+
+if (NOT DEFINED PPFW_FILENAME)
+	set(PPFW_FILENAME "portapack-mayhem_OCI.ppfw.tar")
+endif()
 
 # In our current build container cmake need a little help to get the version :)
 if(NOT DEFINED ${CMAKE_CXX_COMPILER_VERSION})

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -35,10 +35,7 @@ set(LZ4 lz4)
 
 set(FIRMWARE_NAME portapack-h1_h2-mayhem)
 set(FIRMWARE_FILENAME ${FIRMWARE_NAME}.bin)
-
-if (NOT DEFINED PPFW_FILENAME)
-	set(PPFW_FILENAME "portapack-mayhem_OCI.ppfw.tar")
-endif()
+set(PPFW_FILENAME "portapack-mayhem_OCI.ppfw.tar")
 
 # In our current build container cmake need a little help to get the version :)
 if(NOT DEFINED ${CMAKE_CXX_COMPILER_VERSION})

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -36,6 +36,16 @@ set(LZ4 lz4)
 set(FIRMWARE_NAME portapack-h1_h2-mayhem)
 set(FIRMWARE_FILENAME ${FIRMWARE_NAME}.bin)
 
+if (NOT DEFINED PPFW_FILENAME)
+	# Funny business here: trying to generate unique names to prevent renaming of shared test-drive builds by the browser on download to .ppfw-42.tar as it wont be recognized by the flasher
+	execute_process(
+		COMMAND date "+%y%m%d-%H%M"
+		OUTPUT_VARIABLE PPFW_FILENAME
+	)
+	string(STRIP ${PPFW_FILENAME} PPFW_FILENAME)
+	set(PPFW_FILENAME "portapack-mayhem_${PPFW_FILENAME}_OCI.ppfw.tar")
+endif()
+
 # In our current build container cmake need a little help to get the version :)
 if(NOT DEFINED ${CMAKE_CXX_COMPILER_VERSION})
 	execute_process(COMMAND bash "-c" "arm-none-eabi-g++ -v 2>&1 | grep 'gcc version' | awk '{print $3}'" OUTPUT_VARIABLE CMAKE_CXX_COMPILER_VERSION)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -35,16 +35,7 @@ set(LZ4 lz4)
 
 set(FIRMWARE_NAME portapack-h1_h2-mayhem)
 set(FIRMWARE_FILENAME ${FIRMWARE_NAME}.bin)
-
-if (NOT DEFINED PPFW_FILENAME)
-	# Funny business here: trying to generate unique names to prevent renaming of shared test-drive builds by the browser on download to .ppfw-42.tar as it wont be recognized by the flasher
-	execute_process(
-		COMMAND date "+%y%m%d"
-		OUTPUT_VARIABLE PPFW_FILENAME
-	)
-	string(STRIP ${PPFW_FILENAME} PPFW_FILENAME)
-	set(PPFW_FILENAME "portapack-mayhem_${PPFW_FILENAME}_OCI.ppfw.tar")
-endif()
+set(PPFW_FILENAME "portapack-mayhem_OCI.ppfw.tar")
 
 # In our current build container cmake need a little help to get the version :)
 if(NOT DEFINED ${CMAKE_CXX_COMPILER_VERSION})

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -39,7 +39,7 @@ set(FIRMWARE_FILENAME ${FIRMWARE_NAME}.bin)
 if (NOT DEFINED PPFW_FILENAME)
 	# Funny business here: trying to generate unique names to prevent renaming of shared test-drive builds by the browser on download to .ppfw-42.tar as it wont be recognized by the flasher
 	execute_process(
-		COMMAND date "+%y%m%d-%H%M"
+		COMMAND date "+%y%m%d"
 		OUTPUT_VARIABLE PPFW_FILENAME
 	)
 	string(STRIP ${PPFW_FILENAME} PPFW_FILENAME)

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -50,7 +50,7 @@ FlashUtilityView::FlashUtilityView(NavigationView& nav)
                                 this->firmware_selected(path);
                             }});
     }
-    for (const auto& entry : std::filesystem::directory_iterator(firmware_folder, u"*.ppfw.tar")) {
+    for (const auto& entry : std::filesystem::directory_iterator(firmware_folder, u"*.tar")) {
         auto filename = entry.path().filename();
         auto path = entry.path().native();
 
@@ -108,7 +108,7 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
 }
 
 void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
-    if (endsWith(path, u".ppfw.tar")) {
+    if (endsWith(path, u".tar")) {
         // extract, then update
         path = extract_tar(u'/' + path).native();
         if (path.empty()) return;


### PR DESCRIPTION
Updated this PR to propose the following:
*  Modified the Flash app to accept any .tar file name in the FIRMWARE folder, similar to the original code that looked for any .bin file.  This resolves the concern that the Flash utility won't see a file named "portapack-mayhem_OCI.ppfw(2).tar" due to the (2) added when a second file or the same name is downloaded.  I'm not too worried about people putting non-firmware tar files in this folder and attempting to flash them; they could obviously rename any file to ppfw.tar and attempt this with the current code, or similarly put non-portapack .bin files in the folder.  Note that if there is no .bin file in the .tar file, then no flash operation will occur.
*  Modified the Cmakelists.txt file to omit the date and time from the PPFW file name.

History:
Initially I proposed changing the PPFW file name generation to reflect today's current "make" date & time versus the date & time that "cmake" was run, so the name would represent the current build date & time.  But this resulted in many PPFW files in the build folder when a developer is running make lots of times.  So I tried it with the time removed and only leaving the date.  However, the resulting file names were then too close to the nightly build file names which also has the date, and thus only differed by the "n_".  If people like the date stamp, perhaps an alternative would be to put "dev_" in the file name in place of the "n_" to more clearly distinguish them from the nightly builds.