### PR TITLE
Daylight Savings Time support

### DIFF
--- a/application/apps/ui_adsb_rx.cpp
+++ b/application/apps/ui_adsb_rx.cpp
@@ -1,0 +1,574 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2017 Furrtek
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <algorithm>
+
+#include "ui_adsb_rx.hpp"
+#include "ui_alphanum.hpp"
+
+#include "baseband_api.hpp"
+#include "portapack_persistent_memory.hpp"
+#include "rtc_time.hpp"
+#include "string_format.hpp"
+
+using namespace portapack;
+
+namespace ui {
+
+static std::string get_map_tag(const AircraftRecentEntry& entry) {
+    return trimr(entry.callsign.empty() ? entry.icao_str : entry.callsign);
+}
+
+template <>
+void RecentEntriesTable<AircraftRecentEntries>::draw(
+    const Entry& entry,
+    const Rect& target_rect,
+    Painter& painter,
+    const Style& style) {
+    Color target_color;
+    std::string entry_string;
+
+    switch (entry.state) {
+        case ADSBAgeState::Invalid:
+        case ADSBAgeState::Current:
+            entry_string = "";
+            target_color = Color::green();
+            break;
+        case ADSBAgeState::Recent:
+            entry_string = STR_COLOR_LIGHT_GREY;
+            target_color = Color::light_grey();
+            break;
+        default:
+            entry_string = STR_COLOR_DARK_GREY;
+            target_color = Color::grey();
+    };
+
+    entry_string +=
+        (entry.callsign.empty() ? entry.icao_str + "   " : entry.callsign + " ") +
+        to_string_dec_uint((unsigned int)(entry.pos.altitude / 100), 4) +
+        to_string_dec_uint((unsigned int)entry.velo.speed, 4) +
+        to_string_dec_uint((unsigned int)(entry.amp >> 9), 4) + " " +
+        (entry.hits <= 999 ? to_string_dec_uint(entry.hits, 3) + " " : "1k+ ") +
+        to_string_dec_uint(entry.age, 4);
+
+    painter.draw_string(
+        target_rect.location(),
+        style,
+        entry_string);
+
+    if (entry.pos.valid)
+        painter.draw_bitmap(target_rect.location() + Point(8 * 8, 0),
+                            bitmap_target, target_color, style.background);
+}
+
+/* ADSBLogger ********************************************/
+
+void ADSBLogger::log(const ADSBLogEntry& log_entry) {
+    std::string log_line;
+    log_line.reserve(100);
+
+    log_line = log_entry.raw_data;
+    log_line += "ICAO:" + log_entry.icao;
+
+    if (!log_entry.callsign.empty())
+        log_line += " " + log_entry.callsign;
+
+    if (log_entry.pos.valid)
+        log_line += " Alt:" + to_string_dec_int(log_entry.pos.altitude) +
+                    " Lat:" + to_string_decimal(log_entry.pos.latitude, 7) +
+                    " Lon:" + to_string_decimal(log_entry.pos.longitude, 7);
+
+    if (log_entry.vel.valid)
+        log_line += " Type:" + to_string_dec_uint(log_entry.vel_type) +
+                    " Hdg:" + to_string_dec_uint(log_entry.vel.heading) +
+                    " Spd: " + to_string_dec_int(log_entry.vel.speed);
+
+    log_file.write_entry(log_line);
+}
+
+/* ADSBRxAircraftDetailsView *****************************/
+
+ADSBRxAircraftDetailsView::ADSBRxAircraftDetailsView(
+    NavigationView& nav,
+    const AircraftRecentEntry& entry) {
+    add_children(
+        {&labels,
+         &text_icao_address,
+         &text_registration,
+         &text_manufacturer,
+         &text_model,
+         &text_type,
+         &text_number_of_engines,
+         &text_engine_type,
+         &text_owner,
+         &text_operator,
+         &button_close});
+
+    text_icao_address.set(entry.icao_str);
+
+    // Try getting the aircraft information from icao24.db
+    std::database db{};
+    std::database::AircraftDBRecord aircraft_record;
+    auto return_code = db.retrieve_aircraft_record(&aircraft_record, entry.icao_str);
+    switch (return_code) {
+        case DATABASE_RECORD_FOUND:
+            text_registration.set(aircraft_record.aircraft_registration);
+            text_manufacturer.set(aircraft_record.aircraft_manufacturer);
+            text_model.set(aircraft_record.aircraft_model);
+            text_owner.set(aircraft_record.aircraft_owner);
+            text_operator.set(aircraft_record.aircraft_operator);
+
+            // Check for ICAO type, e.g. L2J
+            if (strlen(aircraft_record.icao_type) == 3) {
+                switch (aircraft_record.icao_type[0]) {
+                    case 'L':
+                        text_type.set("Landplane");
+                        break;
+                    case 'S':
+                        text_type.set("Seaplane");
+                        break;
+                    case 'A':
+                        text_type.set("Amphibian");
+                        break;
+                    case 'H':
+                        text_type.set("Helicopter");
+                        break;
+                    case 'G':
+                        text_type.set("Gyrocopter");
+                        break;
+                    case 'T':
+                        text_type.set("Tilt-wing aircraft");
+                        break;
+                }
+
+                text_number_of_engines.set(std::string{1, aircraft_record.icao_type[1]});
+                switch (aircraft_record.icao_type[2]) {
+                    case 'P':
+                        text_engine_type.set("Piston engine");
+                        break;
+                    case 'T':
+                        text_engine_type.set("Turboprop/Turboshaft engine");
+                        break;
+                    case 'J':
+                        text_engine_type.set("Jet engine");
+                        break;
+                    case 'E':
+                        text_engine_type.set("Electric engine");
+                        break;
+                }
+            }
+
+            // Check for ICAO type designator
+            else if (strlen(aircraft_record.icao_type) == 4) {
+                if (strcmp(aircraft_record.icao_type, "SHIP") == 0)
+                    text_type.set("Airship");
+                else if (strcmp(aircraft_record.icao_type, "BALL") == 0)
+                    text_type.set("Balloon");
+                else if (strcmp(aircraft_record.icao_type, "GLID") == 0)
+                    text_type.set("Glider / sailplane");
+                else if (strcmp(aircraft_record.icao_type, "ULAC") == 0)
+                    text_type.set("Micro/ultralight aircraft");
+                else if (strcmp(aircraft_record.icao_type, "GYRO") == 0)
+                    text_type.set("Micro/ultralight autogyro");
+                else if (strcmp(aircraft_record.icao_type, "UHEL") == 0)
+                    text_type.set("Micro/ultralight helicopter");
+                else if (strcmp(aircraft_record.icao_type, "SHIP") == 0)
+                    text_type.set("Airship");
+                else if (strcmp(aircraft_record.icao_type, "PARA") == 0)
+                    text_type.set("Powered parachute/paraplane");
+            }
+            break;
+
+        case DATABASE_NOT_FOUND:
+            text_manufacturer.set("No icao24.db file");
+            break;
+    }
+
+    button_close.on_select = [&nav](Button&) {
+        nav.pop();
+    };
+}
+
+void ADSBRxAircraftDetailsView::focus() {
+    button_close.focus();
+}
+
+/* ADSBRxDetailsView *************************************/
+
+ADSBRxDetailsView::ADSBRxDetailsView(
+    NavigationView& nav,
+    const AircraftRecentEntry& entry)
+    : entry_(entry) {
+    add_children(
+        {&labels,
+         &text_icao_address,
+         &text_callsign,
+         &text_last_seen,
+         &text_airline,
+         &text_country,
+         &text_infos,
+         &text_info2,
+         &text_frame_pos_even,
+         &text_frame_pos_odd,
+         &button_aircraft_details,
+         &button_see_map});
+
+    // The following won't change for a given airborne aircraft.
+    // Try getting the airline's name from airlines.db.
+    // NB: Only works once callsign has been read and won't be updated.
+    std::database db;
+    std::database::AirlinesDBRecord airline_record;
+    std::string airline_code = entry_.callsign.substr(0, 3);
+    auto return_code = db.retrieve_airline_record(&airline_record, airline_code);
+
+    switch (return_code) {
+        case DATABASE_RECORD_FOUND:
+            text_airline.set(airline_record.airline);
+            text_country.set(airline_record.country);
+            break;
+        case DATABASE_NOT_FOUND:
+            text_airline.set("No airlines.db file");
+            break;
+    }
+
+    text_icao_address.set(entry_.icao_str);
+
+    button_aircraft_details.on_select = [this, &nav](Button&) {
+        aircraft_details_view_ = nav.push<ADSBRxAircraftDetailsView>(entry_);
+        nav.set_on_pop([this]() {
+            aircraft_details_view_ = nullptr;
+            refresh_ui();
+        });
+    };
+
+    button_see_map.on_select = [this, &nav](Button&) {
+        geomap_view_ = nav.push<GeoMapView>(
+            get_map_tag(entry_),
+            entry_.pos.altitude,
+            GeoPos::alt_unit::FEET,
+            GeoPos::spd_unit::MPH,
+            entry_.pos.latitude,
+            entry_.pos.longitude,
+            entry_.velo.heading);
+        nav.set_on_pop([this]() {
+            geomap_view_ = nullptr;
+            refresh_ui();
+        });
+    };
+
+    refresh_ui();
+};
+
+void ADSBRxDetailsView::focus() {
+    button_see_map.focus();
+}
+
+void ADSBRxDetailsView::update(const AircraftRecentEntry& entry) {
+    entry_ = entry;
+
+    if (aircraft_details_view_) {
+        // AC Details view is showing, nothing to update.
+    } else if (geomap_view_) {
+        // Map is showing, update the current item.
+        geomap_view_->update_tag(get_map_tag(entry_));
+        geomap_view_->update_position(entry.pos.latitude, entry.pos.longitude, entry.velo.heading, entry.pos.altitude, entry.velo.speed);
+    } else {
+        // Details is showing, update details.
+        refresh_ui();
+    }
+}
+
+void ADSBRxDetailsView::clear_map_markers() {
+    if (geomap_view_)
+        geomap_view_->clear_markers();
+}
+
+bool ADSBRxDetailsView::add_map_marker(const AircraftRecentEntry& entry) {
+    // Map not shown, can't add markers.
+    if (!geomap_view_)
+        return false;
+
+    GeoMarker marker{};
+    marker.lon = entry.pos.longitude;
+    marker.lat = entry.pos.latitude;
+    marker.angle = entry.velo.heading;
+    marker.tag = get_map_tag(entry);
+
+    auto markerStored = geomap_view_->store_marker(marker);
+    return markerStored == MARKER_STORED;
+}
+
+void ADSBRxDetailsView::on_gps(const GPSPosDataMessage* msg) {
+    if (!geomap_view_)
+        return;
+    geomap_view_->update_my_position(msg->lat, msg->lon, msg->altitude);
+}
+void ADSBRxDetailsView::on_orientation(const OrientationDataMessage* msg) {
+    if (!geomap_view_)
+        return;
+    geomap_view_->update_my_orientation(msg->angle);
+}
+
+void ADSBRxDetailsView::refresh_ui() {
+    auto age = entry_.age;
+    if (age < 60)
+        text_last_seen.set(to_string_dec_uint(age) + " seconds ago");
+    else
+        text_last_seen.set(to_string_dec_uint(age / 60) + " minutes ago");
+
+    text_callsign.set(entry_.callsign);
+    text_infos.set(entry_.info_string);
+    if (entry_.velo.heading < 360 && entry_.velo.speed >= 0)
+        text_info2.set("Hdg:" + to_string_dec_uint(entry_.velo.heading) +
+                       " Spd:" + to_string_dec_int(entry_.velo.speed));
+    else
+        text_info2.set("");
+
+    text_frame_pos_even.set(to_string_hex_array(entry_.frame_pos_even.get_raw_data(), 14));
+    text_frame_pos_odd.set(to_string_hex_array(entry_.frame_pos_odd.get_raw_data(), 14));
+}
+
+/* ADSBRxView ********************************************/
+
+ADSBRxView::ADSBRxView(NavigationView& nav) {
+    baseband::run_image(portapack::spi_flash::image_tag_adsb_rx);
+    add_children(
+        {&labels,
+         &field_lna,
+         &field_vga,
+         &field_rf_amp,
+         &rssi,
+         &recent_entries_view,
+         &status_frame,
+         &status_good_frame});
+
+    recent_entries_view.set_parent_rect({0, 16, 240, 272});
+    recent_entries_view.on_select = [this, &nav](const AircraftRecentEntry& entry) {
+        detail_key = entry.key();
+        details_view = nav.push<ADSBRxDetailsView>(entry);
+
+        nav.set_on_pop([this]() {
+            detail_key = AircraftRecentEntry::invalid_key;
+            details_view = nullptr;
+        });
+    };
+
+    signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
+        on_tick_second();
+    };
+
+    logger = std::make_unique<ADSBLogger>();
+    logger->append(LOG_ROOT_DIR "/ADSB.TXT");
+
+    receiver_model.enable();
+    baseband::set_adsb();
+}
+
+ADSBRxView::~ADSBRxView() {
+    rtc_time::signal_tick_second -= signal_token_tick_second;
+    receiver_model.disable();
+    baseband::shutdown();
+}
+
+void ADSBRxView::focus() {
+    field_vga.focus();
+}
+
+void ADSBRxView::on_frame(const ADSBFrameMessage* message) {
+    auto frame = message->frame;
+    uint32_t ICAO_address = frame.get_ICAO_address();
+    status_frame.toggle();
+
+    // Bad frame, skip it.
+    if (!frame.check_CRC() || ICAO_address == 0)
+        return;
+
+    ADSBLogEntry log_entry;
+    status_good_frame.toggle();
+
+    rtc::RTC datetime;
+    rtc_time::now(datetime);
+    frame.set_rx_timestamp(datetime.minute() * 60 + datetime.second());
+
+    // NB: Reference to update entry in-place.
+    auto& entry = find_or_create_entry(ICAO_address);
+    entry.inc_hit();
+    entry.reset_age();
+
+    // Store smoothed amplitude on updates.
+    entry.amp = entry.hits == 0
+                    ? message->amp
+                    : ((entry.amp * 15) + message->amp) >> 4;
+
+    log_entry.raw_data = to_string_hex_array(frame.get_raw_data(), 14);
+    log_entry.icao = entry.icao_str;
+
+    if (frame.get_DF() == DF_ADSB) {
+        uint8_t msg_type = frame.get_msg_type();
+        uint8_t msg_sub = frame.get_msg_sub();
+        uint8_t* raw_data = frame.get_raw_data();
+
+        // 4: // surveillance, altitude reply
+        if ((msg_type >= AIRCRAFT_ID_L) && (msg_type <= AIRCRAFT_ID_H)) {
+            entry.set_callsign(decode_frame_id(frame));
+            log_entry.callsign = entry.callsign;
+        }
+
+        // 9:
+        // 18: // Extended squitter/non-transponder
+        // 21: // Comm-B, identity reply
+        // 20: // Comm-B, altitude reply
+        else if (((msg_type >= AIRBORNE_POS_BARO_L) && (msg_type <= AIRBORNE_POS_BARO_H)) ||
+                 ((msg_type >= AIRBORNE_POS_GPS_L) && (msg_type <= AIRBORNE_POS_GPS_H))) {
+            entry.set_frame_pos(frame, raw_data[6] & 4);
+            log_entry.pos = entry.pos;
+
+            if (entry.pos.valid) {
+                std::string str_info =
+                    "Alt:" + to_string_dec_int(entry.pos.altitude) +
+                    " Lat:" + to_string_decimal(entry.pos.latitude, 2) +
+                    " Lon:" + to_string_decimal(entry.pos.longitude, 2);
+
+                entry.set_info_string(std::move(str_info));
+            }
+
+        } else if (msg_type == AIRBORNE_VEL && msg_sub >= VEL_GND_SUBSONIC && msg_sub <= VEL_AIR_SUPERSONIC) {
+            entry.set_frame_velo(frame);
+            log_entry.vel = entry.velo;
+            log_entry.vel_type = msg_sub;
+        }
+    }
+
+    logger->log(log_entry);
+}
+
+void ADSBRxView::on_tick_second() {
+    status_frame.reset();
+    status_good_frame.reset();
+
+    ++tick_count;
+    ++ticks_since_marker_refresh;
+
+    // Small list, update all at once.
+    if (recent.size() <= max_update_entries) {
+        update_recent_entries(/*age_delta*/ 1);
+        refresh_ui();
+        return;
+    }
+
+    // Too many items, split update work into two phases:
+    // Entry maintenance and UI update.
+    if ((tick_count & 1) == 0)
+        update_recent_entries(/*age_delta*/ 2);
+    else
+        refresh_ui();
+}
+
+void ADSBRxView::refresh_ui() {
+    // There's only one ticks handler, but 3 UIs that need to be updated.
+    // This code will dispatch updates to the currently active view.
+
+    if (details_view) {
+        // The details view is showing, forward updates to that UI.
+        bool current_updated = false;
+        bool map_needs_update = false;
+
+        if (details_view->map_active()) {
+            // Is it time to clear and refresh the map's markers?
+            if (ticks_since_marker_refresh >= MARKER_UPDATE_SECONDS) {
+                map_needs_update = true;
+                ticks_since_marker_refresh = 0;
+                details_view->clear_map_markers();
+            }
+        } else {
+            // Refresh map immediately once active.
+            ticks_since_marker_refresh = MARKER_UPDATE_SECONDS;
+        }
+
+        // Process the entries list.
+        for (const auto& entry : recent) {
+            // Found the entry being shown in details view. Update it.
+            if (entry.key() == detail_key) {
+                details_view->update(entry);
+                current_updated = true;
+            }
+
+            // NB: current entry also gets a marker so it shows up if map is panned.
+            if (map_needs_update && entry.pos.valid && entry.state <= ADSBAgeState::Recent) {
+                map_needs_update = details_view->add_map_marker(entry);
+            }
+
+            // Any work left to do?
+            if (current_updated && !map_needs_update)
+                break;
+        }
+    } else {
+        // Main page is the top view. Redraw the entries view.
+        recent_entries_view.set_dirty();
+    }
+}
+
+void ADSBRxView::update_recent_entries(int age_delta) {
+    for (auto& entry : recent)
+        entry.inc_age(age_delta);
+
+    // Sort and truncate the entries, grouped by state, newest first.
+    sort_entries_by_state();
+    truncate_entries(recent);
+    remove_expired_entries();
+}
+
+AircraftRecentEntry& ADSBRxView::find_or_create_entry(uint32_t ICAO_address) {
+    // Find ...
+    auto it = find(recent, ICAO_address);
+    if (it != recent.end())
+        return *it;
+
+    // ... or Create.
+    return recent.emplace_front(ICAO_address);
+}
+
+void ADSBRxView::sort_entries_by_state() {
+    recent.sort([](const auto& left, const auto& right) {
+        return (left.state < right.state);
+    });
+}
+
+void ADSBRxView::remove_expired_entries() {
+    // NB: Assumes entried are sorted with oldest last.
+    auto it = recent.rbegin();
+    auto end = recent.rend();
+
+    // Find the first !expired entry from the back.
+    while (it != end) {
+        if (it->state != ADSBAgeState::Expired)
+            break;
+
+        std::advance(it, 1);
+    }
+
+    // Remove the range of expired items.
+    recent.erase(it.base(), recent.end());
+}
+
+} /* namespace ui */

--- a/application/apps/ui_aprs_rx.cpp
+++ b/application/apps/ui_aprs_rx.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2017 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_aprs_rx.hpp"
+
+#include "audio.hpp"
+#include "rtc_time.hpp"
+#include "baseband_api.hpp"
+#include "string_format.hpp"
+#include "portapack_persistent_memory.hpp"
+
+using namespace portapack;
+
+void APRSLogger::log_raw_data(const std::string& data) {
+    log_file.write_entry(data);
+}
+
+namespace ui {
+
+template <>
+void RecentEntriesTable<APRSRecentEntries>::draw(
+    const Entry& entry,
+    const Rect& target_rect,
+    Painter& painter,
+    const Style& style) {
+    Color target_color;
+    // auto entry_age = entry.age;
+
+    target_color = Color::green();
+
+    std::string entry_string = "";
+
+    entry_string += entry.source_formatted;
+    entry_string.append(10 - entry.source_formatted.size(), ' ');
+    entry_string += "       ";
+    entry_string += (entry.hits <= 999 ? to_string_dec_uint(entry.hits, 4) : "999+");
+    entry_string += " ";
+    entry_string += entry.time_string;
+
+    painter.draw_string(
+        target_rect.location(),
+        style,
+        entry_string);
+
+    if (entry.has_position) {
+        painter.draw_bitmap(target_rect.location() + Point(12 * 8, 0), bitmap_target, target_color, style.background);
+    }
+}
+
+void APRSRxView::focus() {
+    options_region.focus();
+}
+
+APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
+    : View(parent_rect), nav_{nav} {
+    baseband::run_image(portapack::spi_flash::image_tag_aprs_rx);
+
+    add_children({&rssi,
+                  &channel,
+                  &field_rf_amp,
+                  &field_lna,
+                  &field_vga,
+                  &field_volume,
+                  &options_region,
+                  &field_frequency,
+                  &record_view,
+                  &console});
+
+    // DEBUG
+    record_view.on_error = [&nav](std::string message) {
+        nav.display_modal("Error", message);
+    };
+
+    record_view.set_sampling_rate(24000);
+
+    options_region.on_change = [this](size_t, int32_t i) {
+        if (i == 0) {
+            field_frequency.set_value(144390000);
+        } else if (i == 1) {
+            field_frequency.set_value(144800000);
+        } else if (i == 2) {
+            field_frequency.set_value(145175000);
+        } else if (i == 3) {
+            field_frequency.set_value(144575000);
+        }
+    };
+
+    field_frequency.set_step(100);
+    options_region.set_selected_index(0, true);
+
+    logger = std::make_unique<APRSLogger>();
+    if (logger)
+        logger->append(LOG_ROOT_DIR "/APRS.TXT");
+
+    baseband::set_aprs(1200);
+
+    audio::set_rate(audio::Rate::Hz_24000);
+    audio::output::start();
+
+    receiver_model.enable();
+}
+
+void APRSRxView::on_packet(const APRSPacketMessage* message) {
+    std::string str_console = "\x1B";
+
+    aprs::APRSPacket packet = message->packet;
+
+    std::string stream_text = packet.get_stream_text();
+    str_console += (char)((console_color++ & 3) + 9);
+    str_console += stream_text;
+
+    if (logger) {
+        logger->log_raw_data(stream_text);
+    }
+
+    // if(reset_console){ //having more than one console causes issues when switching tabs where one is disabled, and the other enabled breaking the scoll setup.
+    //	console.on_hide();
+    //	console.on_show();
+    //	reset_console = false;
+    // }
+
+    console.writeln(str_console);
+}
+
+void APRSRxView::on_data(uint32_t value, bool is_data) {
+    std::string str_console = "\x1B";
+    std::string str_byte = "";
+
+    if (is_data) {
+        // Colorize differently after message splits
+        str_console += (char)((console_color & 3) + 9);
+
+        if (value == '\n') {
+            // Message split
+            console.writeln("");
+            console_color++;
+
+            if (logger) {
+                logger->log_raw_data(str_log);
+                str_log = "";
+            }
+        } else {
+            if ((value >= 32) && (value < 127)) {
+                str_console += (char)value;  // Printable
+                str_byte += (char)value;
+            } else {
+                str_console += "[" + to_string_hex(value, 2) + "]";  // Not printable
+                str_byte += "[" + to_string_hex(value, 2) + "]";
+            }
+
+            console.write(str_console);
+
+            if (logger) str_log += str_byte;
+        }
+    } else {
+    }
+}
+
+void APRSRxView::on_show() {
+    // some bug where the display scroll area is set to the entire screen when switching from the list tab with details showing back to the stream view.
+    // reset_console = true;
+}
+
+APRSRxView::~APRSRxView() {
+    audio::output::stop();
+    receiver_model.disable();
+    baseband::shutdown();
+}
+
+void APRSTableView::on_show_list() {
+    details_view.hidden(true);
+    recent_entries_view.hidden(false);
+    send_updates = false;
+    focus();
+}
+
+void APRSTableView::on_show_detail(const APRSRecentEntry& entry) {
+    recent_entries_view.hidden(true);
+    details_view.hidden(false);
+    details_view.set_entry(entry);
+    details_view.update();
+    details_view.focus();
+    detailed_entry_key = entry.key();
+    send_updates = true;
+}
+
+APRSTableView::APRSTableView(NavigationView& nav, Rect parent_rec)
+    : View(parent_rec), nav_{nav} {
+    add_children({&recent_entries_view,
+                  &details_view});
+
+    hidden(true);
+
+    details_view.hidden(true);
+
+    recent_entries_view.set_parent_rect({0, 0, 240, 280});
+    details_view.set_parent_rect({0, 0, 240, 280});
+
+    recent_entries_view.on_select = [this](const APRSRecentEntry& entry) {
+        this->on_show_detail(entry);
+    };
+
+    details_view.on_close = [this]() {
+        this->on_show_list();
+    };
+
+    /*	for(size_t i = 0; i <32 ; i++){
+                std::string id = "test" + i;
+                auto& entry = ::on_packet(recent, i);
+                entry.set_source_formatted(id);
+        }
+
+        recent_entries_view.set_dirty(); 	*/
+
+    /*
+
+        std::string str1 = "test1";
+        std::string str12 = "test2";
+        std::string str13 = "test2";
+
+        auto& entry = ::on_packet(recent, 0x1);
+        entry.set_source_formatted(str1);
+
+        auto& entry2 = ::on_packet(recent, 0x2);
+        entry2.set_source_formatted(str12);
+
+        auto& entry3 = ::on_packet(recent, 0x2);
+        entry2.set_source_formatted(str13);
+
+        recent_entries_view.set_dirty();
+
+        */
+}
+
+void APRSTableView::on_pkt(const APRSPacketMessage* message) {
+    aprs::APRSPacket packet = message->packet;
+    rtc::RTC datetime;
+    std::string str_timestamp;
+    std::string source_formatted = packet.get_source_formatted();
+    std::string info_string = packet.get_stream_text();
+
+    rtc_time::now(datetime);
+    auto& entry = ::on_packet(recent, packet.get_source());
+    entry.reset_age();
+    entry.inc_hit();
+    str_timestamp = to_string_datetime(datetime, HMS);
+    entry.set_time_string(str_timestamp);
+    entry.set_info_string(info_string);
+
+    entry.set_source_formatted(source_formatted);
+
+    if (entry.has_position && !packet.has_position()) {
+        // maintain position info
+    } else {
+        entry.set_has_position(packet.has_position());
+        entry.set_pos(packet.get_position());
+    }
+
+    if (entry.key() == details_view.entry().key()) {
+        details_view.set_entry(entry);
+        details_view.update();
+    }
+
+    recent_entries_view.set_dirty();
+}
+
+void APRSTableView::on_show() {
+    on_show_list();
+}
+
+void APRSTableView::on_hide() {
+    details_view.hidden(true);
+}
+
+void APRSTableView::focus() {
+    recent_entries_view.focus();
+}
+
+APRSTableView::~APRSTableView() {
+}
+
+void APRSDetailsView::focus() {
+    button_done.focus();
+}
+
+void APRSDetailsView::set_entry(const APRSRecentEntry& entry) {
+    entry_copy = entry;
+}
+
+void APRSDetailsView::update() {
+    if (!hidden()) {
+        // uint32_t age = entry_copy.age;
+
+        console.clear(true);
+        console.write(entry_copy.info_string);
+
+        button_see_map.hidden(!entry_copy.has_position);
+    }
+
+    if (send_updates)
+        geomap_view->update_position(entry_copy.pos.latitude, entry_copy.pos.longitude, 0, 0, 0);
+}
+
+APRSDetailsView::~APRSDetailsView() {
+}
+
+APRSDetailsView::APRSDetailsView(
+    NavigationView& nav) {
+    add_children({&console,
+                  &button_done,
+                  &button_see_map});
+
+    button_done.on_select = [this, &nav](Button&) {
+        console.clear(true);
+        this->on_close();
+    };
+
+    button_see_map.on_select = [this, &nav](Button&) {
+        geomap_view = nav.push<GeoMapView>(
+            entry_copy.source_formatted,
+            0,  // entry_copy.pos.altitude,
+            GeoPos::alt_unit::FEET,
+            GeoPos::spd_unit::HIDDEN,
+            entry_copy.pos.latitude,
+            entry_copy.pos.longitude,
+            0, /*entry_copy.velo.heading,*/
+            [this]() {
+                send_updates = false;
+                hidden(false);
+                update();
+            });
+        send_updates = true;
+        hidden(true);
+    };
+};
+
+APRSRXView::APRSRXView(NavigationView& nav)
+    : nav_{nav} {
+    add_children({&tab_view,
+                  &view_stream,
+                  &view_table});
+}
+
+void APRSRXView::focus() {
+    tab_view.focus();
+}
+
+APRSRXView::~APRSRXView() {
+}
+} /* namespace ui */

--- a/application/apps/ui_numbers.cpp
+++ b/application/apps/ui_numbers.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_numbers.hpp"
+#include "ui_styles.hpp"
+#include "string_format.hpp"
+
+#include "portapack.hpp"
+#include "hackrf_hal.hpp"
+#include "portapack_shared_memory.hpp"
+
+#include <cstring>
+#include <stdio.h>
+
+using namespace portapack;
+
+namespace ui {
+
+// TODO: This app takes way too much space, find a way to shrink/simplify or make it an SD card module (loadable)
+
+void NumbersStationView::focus() {
+    if (file_error)
+        nav_.display_modal("No voices", "No valid voices found in\nthe /numbers directory.", ABORT);
+    else
+        button_exit.focus();
+}
+
+NumbersStationView::~NumbersStationView() {
+    transmitter_model.disable();
+    baseband::shutdown();
+}
+
+NumbersStationView::wav_file_t* NumbersStationView::get_wav(uint32_t index) {
+    return &current_voice->available_wavs[index];
+}
+
+void NumbersStationView::prepare_audio() {
+    uint8_t code;
+    wav_file_t* wav_file;
+
+    if (sample_counter >= sample_length) {
+        if (segment == ANNOUNCE) {
+            if (!announce_loop) {
+                code_index = 0;
+                segment = MESSAGE;
+            } else {
+                wav_file = get_wav(11);
+                reader->open(current_voice->dir + file_names[wav_file->index].name + ".wav");
+                sample_length = wav_file->length;
+                announce_loop--;
+            }
+        }
+
+        if (segment == MESSAGE) {
+            if (code_index == 25) {
+                transmitter_model.disable();
+                return;
+            }
+
+            code = symfield_code.get_offset(code_index);
+
+            if (code >= 10) {
+                memset(audio_buffer, 0, 1024);
+                if (code == 10) {
+                    pause = 11025;  // p: 0.25s @ 44100Hz
+                } else if (code == 11) {
+                    pause = 33075;  // P: 0.75s @ 44100Hz
+                } else if (code == 12) {
+                    transmitter_model.disable();
+                    return;
+                }
+            } else {
+                wav_file = get_wav(code);
+                reader->open(current_voice->dir + file_names[code].name + ".wav");
+                sample_length = wav_file->length;
+            }
+            code_index++;
+        }
+        sample_counter = 0;
+    }
+
+    if (!pause) {
+        auto bytes_read = reader->read(audio_buffer, 1024).value();
+
+        // Unsigned to signed, pretty stupid :/
+        for (size_t n = 0; n < bytes_read; n++)
+            audio_buffer[n] -= 0x80;
+        for (size_t n = bytes_read; n < 1024; n++)
+            audio_buffer[n] = 0;
+
+        sample_counter += 1024;
+    } else {
+        if (pause >= 1024) {
+            pause -= 1024;
+        } else {
+            sample_counter = sample_length;
+            pause = 0;
+        }
+    }
+
+    baseband::set_fifo_data(audio_buffer);
+}
+
+void NumbersStationView::start_tx() {
+    // sample_length = sound_sizes[10];		// Announce
+    sample_counter = sample_length;
+
+    code_index = 0;
+    announce_loop = 2;
+    segment = ANNOUNCE;
+
+    prepare_audio();
+
+    transmitter_model.set_rf_amp(true);
+    transmitter_model.enable();
+
+    baseband::set_audiotx_data(
+        (1536000 / 44100) - 1,  // TODO: Read wav file's samplerate
+        12000,
+        1,
+        false,
+        0);
+}
+
+void NumbersStationView::on_tick_second() {
+    armed_blink = not armed_blink;
+
+    if (armed_blink)
+        check_armed.set_style(&Styles::red);
+    else
+        check_armed.set_style(&style());
+
+    check_armed.set_dirty();
+}
+
+void NumbersStationView::on_voice_changed(size_t index) {
+    std::string code_list;
+
+    for (const auto& wavs : voices[index].available_wavs)
+        code_list += wavs.code;
+
+    symfield_code.set_symbol_list(code_list);
+    current_voice = &voices[index];
+}
+
+bool NumbersStationView::check_wav_validity(const std::string dir, const std::string file) {
+    if (reader->open("/numbers/" + dir + "/" + file)) {
+        // Check format (mono, 8 bits)
+        if ((reader->channels() == 1) && (reader->bits_per_sample() == 8))
+            return true;
+        else
+            return false;
+    } else
+        return false;
+}
+
+NumbersStationView::NumbersStationView(
+    NavigationView& nav)
+    : nav_(nav) {
+    std::vector<std::filesystem::path> directory_list;
+    using option_t = std::pair<std::string, int32_t>;
+    using options_t = std::vector<option_t>;
+    options_t voice_options;
+    voice_t temp_voice{};
+    bool valid;
+    uint32_t c;
+    // uint8_t y, m, d, dayofweek;
+
+    reader = std::make_unique<WAVFileReader>();
+
+    // Search for valid voice directories
+    directory_list = scan_root_directories("/numbers");
+    if (!directory_list.size()) {
+        file_error = true;
+        return;
+    }
+
+    for (const auto& dir : directory_list) {
+        c = 0;
+        for (const auto& file_name : file_names) {
+            valid = check_wav_validity(dir.string(), file_name.name + ".wav");
+            if ((!valid) && (file_name.required)) {
+                temp_voice.available_wavs.clear();
+                break;  // Invalid required file means invalid voice
+            } else if (valid) {
+                temp_voice.available_wavs.push_back({file_name.code, c++, 0, 0});  // TODO: Needs length and samplerate
+            }
+        }
+        if (!temp_voice.available_wavs.empty()) {
+            // Voice can be used, are there accent files ?
+            c = 0;
+            for (const auto& file_name : file_names) {
+                valid = check_wav_validity(dir.string(), file_name.name + "a.wav");
+                if ((!valid) && (file_name.required)) {
+                    c = 0;
+                    break;  // Invalid required file means accents can't be used
+                } else if (valid) {
+                    c++;
+                }
+            }
+
+            temp_voice.accent = c ? true : false;
+            temp_voice.dir = dir.string();
+
+            voices.push_back(temp_voice);
+        }
+    }
+
+    if (voices.empty()) {
+        file_error = true;
+        return;
+    }
+
+    baseband::run_image(portapack::spi_flash::image_tag_audio_tx);
+
+    add_children({&labels,
+                  &symfield_code,
+                  &check_armed,
+                  &options_voices,
+                  &text_voice_flags,
+                  //&button_tx_now,
+                  &button_exit});
+
+    for (const auto& voice : voices)
+        voice_options.emplace_back(voice.dir.substr(0, 4), 0);
+
+    options_voices.set_options(voice_options);
+    options_voices.on_change = [this](size_t i, int32_t) {
+        this->on_voice_changed(i);
+    };
+    options_voices.set_selected_index(0);
+
+    check_armed.set_value(false);
+
+    check_armed.on_select = [this](Checkbox&, bool v) {
+        if (v) {
+            armed_blink = false;
+            signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
+                this->on_tick_second();
+            };
+        } else {
+            check_armed.set_style(&style());
+            rtc_time::signal_tick_second -= signal_token_tick_second;
+        }
+    };
+
+    // DEBUG
+    symfield_code.set_offset(0, 10);
+    symfield_code.set_offset(1, 3);
+    symfield_code.set_offset(2, 4);
+    symfield_code.set_offset(3, 11);
+    symfield_code.set_offset(4, 6);
+    symfield_code.set_offset(5, 1);
+    symfield_code.set_offset(6, 9);
+    symfield_code.set_offset(7, 7);
+    symfield_code.set_offset(8, 8);
+    symfield_code.set_offset(9, 0);
+    symfield_code.set_offset(10, 12);  // End
+
+    /*
+        dayofweek = rtc_time::current_day_of_week();
+        text_title.set(day_of_week[dayofweek]);
+    */
+
+    button_exit.on_select = [&nav](Button&) {
+        nav.pop();
+    };
+}
+
+} /* namespace ui */

--- a/application/apps/ui_settings.cpp
+++ b/application/apps/ui_settings.cpp
@@ -1,0 +1,753 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2023 gullradriel, Nilorea Studio Inc.
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_settings.hpp"
+
+#include "ui_navigation.hpp"
+#include "ui_receiver.hpp"
+#include "ui_touch_calibration.hpp"
+#include "ui_text_editor.hpp"
+
+#include "portapack_persistent_memory.hpp"
+#include "lpc43xx_cpp.hpp"
+using namespace lpc43xx;
+
+#include "audio.hpp"
+#include "portapack.hpp"
+using namespace portapack;
+
+#include "file.hpp"
+namespace fs = std::filesystem;
+
+#include "string_format.hpp"
+#include "ui_styles.hpp"
+#include "cpld_update.hpp"
+#include "config_mode.hpp"
+
+namespace pmem = portapack::persistent_memory;
+
+namespace ui {
+
+/* Sends a UI refresh message to cause the status bar to redraw. */
+static void send_system_refresh() {
+    StatusRefreshMessage message{};
+    EventDispatcher::send_message(message);
+}
+
+/* SetDateTimeView ***************************************/
+
+SetDateTimeView::SetDateTimeView(
+    NavigationView& nav) {
+    button_save.on_select = [&nav, this](Button&) {
+        const auto model = this->form_collect();
+        rtc::RTC new_datetime{model.year, model.month, model.day, model.hour, model.minute, model.second};
+        pmem::set_config_dst(model.dst);
+        rtc_time::set(new_datetime);  // NB: 1 hour will be subtracted if value is stored in RTC during DST
+        nav.pop();
+    },
+
+    button_cancel.on_select = [&nav](Button&) {
+        nav.pop();
+    },
+
+    add_children({
+        &labels,
+        &field_year,
+        &field_month,
+        &field_day,
+        &field_hour,
+        &field_minute,
+        &field_second,
+        &text_weekday,
+        &text_day_of_year,
+        &checkbox_dst_enable,
+        &options_dst_start_which,
+        &options_dst_start_weekday,
+        &options_dst_start_month,
+        &options_dst_end_which,
+        &options_dst_end_weekday,
+        &options_dst_end_month,
+        &button_save,
+        &button_cancel,
+    });
+
+    // Populate DST options (same string text for start & end)
+    options_dst_start_which.set_options(which_options);
+    options_dst_end_which.set_options(which_options);
+    options_dst_start_weekday.set_options(weekday_options);
+    options_dst_end_weekday.set_options(weekday_options);
+    options_dst_start_month.set_options(month_options);
+    options_dst_end_month.set_options(month_options);
+
+    const auto date_changed_fn = [this](int32_t) {
+        auto weekday = rtc_time::day_of_week(field_year.value(), field_month.value(), field_day.value());
+        auto doy = rtc_time::day_of_year(field_year.value(), field_month.value(), field_day.value());
+        bool valid_date = (field_day.value() <= rtc_time::days_per_month(field_year.value(), field_month.value()));
+        text_weekday.set(valid_date ? weekday_options[weekday].first : "-");
+        text_day_of_year.set(valid_date ? to_string_dec_uint(doy, 3) : "-");
+    };
+
+    field_year.on_change = date_changed_fn;
+    field_month.on_change = date_changed_fn;
+    field_day.on_change = date_changed_fn;
+
+    rtc::RTC datetime;
+    rtc_time::now(datetime);
+    SetDateTimeModel model{
+        datetime.year(),
+        datetime.month(),
+        datetime.day(),
+        datetime.hour(),
+        datetime.minute(),
+        datetime.second(),
+        pmem::config_dst()};
+    form_init(model);
+}
+
+void SetDateTimeView::focus() {
+    button_cancel.focus();
+}
+
+void SetDateTimeView::form_init(const SetDateTimeModel& model) {
+    field_year.set_value(model.year);
+    field_month.set_value(model.month);
+    field_day.set_value(model.day);
+    field_hour.set_value(model.hour);
+    field_minute.set_value(model.minute);
+    field_second.set_value(model.second);
+    checkbox_dst_enable.set_value(model.dst.b.dst_enabled);
+    options_dst_start_which.set_by_value(model.dst.b.start_which);
+    options_dst_start_weekday.set_by_value(model.dst.b.start_weekday);
+    options_dst_start_month.set_by_value(model.dst.b.start_month);
+    options_dst_end_which.set_by_value(model.dst.b.end_which);
+    options_dst_end_weekday.set_by_value(model.dst.b.end_weekday);
+    options_dst_end_month.set_by_value(model.dst.b.end_month);
+}
+
+SetDateTimeModel SetDateTimeView::form_collect() {
+    pmem::dst_config_t dst;
+    dst.b.dst_enabled = static_cast<uint8_t>(checkbox_dst_enable.value());
+    dst.b.start_which = static_cast<uint8_t>(options_dst_start_which.selected_index_value());
+    dst.b.start_weekday = static_cast<uint8_t>(options_dst_start_weekday.selected_index_value());
+    dst.b.start_month = static_cast<uint8_t>(options_dst_start_month.selected_index_value());
+    dst.b.end_which = static_cast<uint8_t>(options_dst_end_which.selected_index_value());
+    dst.b.end_weekday = static_cast<uint8_t>(options_dst_end_weekday.selected_index_value());
+    dst.b.end_month = static_cast<uint8_t>(options_dst_end_month.selected_index_value());
+    return {
+        .year = static_cast<uint16_t>(field_year.value()),
+        .month = static_cast<uint8_t>(field_month.value()),
+        .day = static_cast<uint8_t>(field_day.value()),
+        .hour = static_cast<uint8_t>(field_hour.value()),
+        .minute = static_cast<uint8_t>(field_minute.value()),
+        .second = static_cast<uint8_t>(field_second.value()),
+        .dst = dst};
+}
+
+/* SetRadioView ******************************************/
+
+SetRadioView::SetRadioView(
+    NavigationView& nav) {
+    button_cancel.on_select = [&nav](Button&) {
+        nav.pop();
+    };
+
+    add_children({
+        &label_source,
+        &value_source,
+        &value_source_frequency,
+        &check_clkout,
+        &field_clkout_freq,
+        &labels_clkout_khz,
+        &labels_bias,
+        &check_bias,
+        &disable_external_tcxo,  // TODO: always show?
+        &button_save,
+        &button_cancel,
+    });
+
+    const auto reference = clock_manager.get_reference();
+
+    if (reference.source == ClockManager::ReferenceSource::Xtal) {
+        add_children({
+            &labels_correction,
+            &field_ppm,
+        });
+    }
+
+    std::string source_name = clock_manager.get_source();
+
+    value_source.set(source_name);
+    value_source_frequency.set(clock_manager.get_freq());
+
+    // Make these Text controls look like Labels.
+    label_source.set_style(&Styles::light_grey);
+    value_source.set_style(&Styles::light_grey);
+    value_source_frequency.set_style(&Styles::light_grey);
+
+    SetFrequencyCorrectionModel model{
+        static_cast<int8_t>(pmem::correction_ppb() / 1000), 0};
+
+    form_init(model);
+
+    check_clkout.set_value(pmem::clkout_enabled());
+    check_clkout.on_select = [this](Checkbox&, bool v) {
+        clock_manager.enable_clock_output(v);
+        pmem::set_clkout_enabled(v);
+        send_system_refresh();
+    };
+
+    // Disallow CLKOUT freq change on hackrf_r9 due to dependencies on GP_CLKIN (same Si5351A clock);
+    // see comments in ClockManager::enable_clock_output()
+    if (hackrf_r9) {
+        if (pmem::clkout_freq() != 10000)
+            pmem::set_clkout_freq(10000);
+        field_clkout_freq.set_focusable(false);
+    }
+
+    field_clkout_freq.set_value(pmem::clkout_freq());
+    field_clkout_freq.on_change = [this](SymField&) {
+        if (field_clkout_freq.to_integer() < 4)  // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz.
+            field_clkout_freq.set_value(4);
+        if (field_clkout_freq.to_integer() > 60000)
+            field_clkout_freq.set_value(60000);
+    };
+
+    check_bias.set_value(get_antenna_bias());
+    check_bias.on_select = [this](Checkbox&, bool v) {
+        set_antenna_bias(v);
+
+        // Update the radio.
+        receiver_model.set_antenna_bias();
+        transmitter_model.set_antenna_bias();
+        // The models won't actually disable this if they are not 'enabled_'.
+        // Be extra sure this is turned off.
+        if (!v)
+            radio::set_antenna_bias(false);
+
+        send_system_refresh();
+    };
+
+    disable_external_tcxo.set_value(pmem::config_disable_external_tcxo());
+
+    button_save.on_select = [this, &nav](Button&) {
+        const auto model = this->form_collect();
+        pmem::set_correction_ppb(model.ppm * 1000);
+        pmem::set_clkout_freq(model.freq);
+        pmem::set_config_disable_external_tcxo(disable_external_tcxo.value());
+        clock_manager.enable_clock_output(pmem::clkout_enabled());
+        nav.pop();
+    };
+}
+
+void SetRadioView::focus() {
+    button_save.focus();
+}
+
+void SetRadioView::form_init(const SetFrequencyCorrectionModel& model) {
+    field_ppm.set_value(model.ppm);
+}
+
+SetFrequencyCorrectionModel SetRadioView::form_collect() {
+    return {
+        .ppm = static_cast<int8_t>(field_ppm.value()),
+        .freq = static_cast<uint32_t>(field_clkout_freq.to_integer()),
+    };
+}
+
+/* SetUIView *********************************************/
+
+SetUIView::SetUIView(NavigationView& nav) {
+    add_children({&checkbox_disable_touchscreen,
+                  &checkbox_bloff,
+                  &options_bloff,
+                  &checkbox_showsplash,
+                  &checkbox_showclock,
+                  &options_clockformat,
+                  &checkbox_guireturnflag,
+                  &labels,
+                  &toggle_camera,
+                  &toggle_sleep,
+                  &toggle_stealth,
+                  &toggle_converter,
+                  &toggle_bias_tee,
+                  &toggle_clock,
+                  &toggle_mute,
+                  &toggle_sd_card,
+                  &button_save,
+                  &button_cancel});
+
+    // Display "Disable speaker" option only if AK4951 Codec which has separate speaker/headphone control
+    if (audio::speaker_disable_supported()) {
+        add_child(&toggle_speaker);
+    }
+
+    checkbox_disable_touchscreen.set_value(pmem::disable_touchscreen());
+    checkbox_showsplash.set_value(pmem::config_splash());
+    checkbox_showclock.set_value(!pmem::hide_clock());
+    checkbox_guireturnflag.set_value(pmem::show_gui_return_icon());
+
+    const auto backlight_config = pmem::config_backlight_timer();
+    checkbox_bloff.set_value(backlight_config.timeout_enabled());
+    options_bloff.set_by_value(backlight_config.timeout_enum());
+
+    if (pmem::clock_with_date()) {
+        options_clockformat.set_selected_index(1);
+    } else {
+        options_clockformat.set_selected_index(0);
+    }
+
+    // NB: Invert so "active" == "not hidden"
+    toggle_camera.set_value(!pmem::ui_hide_camera());
+    toggle_sleep.set_value(!pmem::ui_hide_sleep());
+    toggle_stealth.set_value(!pmem::ui_hide_stealth());
+    toggle_converter.set_value(!pmem::ui_hide_converter());
+    toggle_bias_tee.set_value(!pmem::ui_hide_bias_tee());
+    toggle_clock.set_value(!pmem::ui_hide_clock());
+    toggle_speaker.set_value(!pmem::ui_hide_speaker());
+    toggle_mute.set_value(!pmem::ui_hide_mute());
+    toggle_sd_card.set_value(!pmem::ui_hide_sd_card());
+
+    button_save.on_select = [&nav, this](Button&) {
+        pmem::set_config_backlight_timer({(pmem::backlight_timeout_t)options_bloff.selected_index_value(),
+                                          checkbox_bloff.value()});
+
+        if (checkbox_showclock.value()) {
+            if (options_clockformat.selected_index() == 1)
+                pmem::set_clock_with_date(true);
+            else
+                pmem::set_clock_with_date(false);
+        }
+
+        pmem::set_config_splash(checkbox_showsplash.value());
+        pmem::set_clock_hidden(!checkbox_showclock.value());
+        pmem::set_gui_return_icon(checkbox_guireturnflag.value());
+        pmem::set_disable_touchscreen(checkbox_disable_touchscreen.value());
+
+        pmem::set_ui_hide_camera(!toggle_camera.value());
+        pmem::set_ui_hide_sleep(!toggle_sleep.value());
+        pmem::set_ui_hide_stealth(!toggle_stealth.value());
+        pmem::set_ui_hide_converter(!toggle_converter.value());
+        pmem::set_ui_hide_bias_tee(!toggle_bias_tee.value());
+        pmem::set_ui_hide_clock(!toggle_clock.value());
+        pmem::set_ui_hide_speaker(!toggle_speaker.value());
+        pmem::set_ui_hide_mute(!toggle_mute.value());
+        pmem::set_ui_hide_sd_card(!toggle_sd_card.value());
+        send_system_refresh();
+
+        nav.pop();
+    };
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetUIView::focus() {
+    button_save.focus();
+}
+
+/* SetSDCardView *********************************************/
+
+SetSDCardView::SetSDCardView(NavigationView& nav) {
+    add_children({&labels,
+                  &checkbox_sdcard_speed,
+                  &button_test_sdcard_high_speed,
+                  &text_sdcard_test_status,
+                  &button_save,
+                  &button_cancel});
+
+    checkbox_sdcard_speed.set_value(pmem::config_sdcard_high_speed_io());
+
+    button_test_sdcard_high_speed.on_select = [&nav, this](Button&) {
+        pmem::set_config_sdcard_high_speed_io(true, false);
+        text_sdcard_test_status.set("!! HIGH SPEED MODE ON !!");
+    };
+
+    button_save.on_select = [&nav, this](Button&) {
+        pmem::set_config_sdcard_high_speed_io(checkbox_sdcard_speed.value(), true);
+        send_system_refresh();
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetSDCardView::focus() {
+    button_save.focus();
+}
+
+/* SetConverterSettingsView ******************************/
+
+SetConverterSettingsView::SetConverterSettingsView(NavigationView& nav) {
+    add_children({
+        &labels,
+        &check_show_converter,
+        &check_converter,
+        &opt_converter_mode,
+        &field_converter_freq,
+        &button_return,
+    });
+
+    check_show_converter.set_value(!pmem::ui_hide_converter());
+    check_show_converter.on_select = [this](Checkbox&, bool v) {
+        pmem::set_ui_hide_converter(!v);
+        if (!v) {
+            check_converter.set_value(false);
+        }
+        // Retune to take converter change in account.
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
+        // Refresh status bar converter icon.
+        send_system_refresh();
+    };
+
+    check_converter.set_value(pmem::config_converter());
+    check_converter.on_select = [this](Checkbox&, bool v) {
+        if (v) {
+            check_show_converter.set_value(true);
+            pmem::set_ui_hide_converter(false);
+        }
+        pmem::set_config_converter(v);
+        // Retune to take converter change in account.
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
+        // Refresh status bar converter icon.
+        send_system_refresh();
+    };
+
+    opt_converter_mode.set_by_value(pmem::config_updown_converter());
+    opt_converter_mode.on_change = [this](size_t, OptionsField::value_t v) {
+        pmem::set_config_updown_converter(v);
+        // Refresh status bar with up or down icon.
+        send_system_refresh();
+    };
+
+    field_converter_freq.set_step(1'000'000);
+    field_converter_freq.set_value(pmem::config_converter_freq());
+    field_converter_freq.on_change = [this](rf::Frequency f) {
+        pmem::set_config_converter_freq(f);
+        // Retune to take converter change in account.
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
+    };
+    field_converter_freq.on_edit = [this, &nav]() {
+        auto new_view = nav.push<FrequencyKeypadView>(field_converter_freq.value());
+        new_view->on_changed = [this](rf::Frequency f) {
+            field_converter_freq.set_value(f);
+        };
+    };
+
+    button_return.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetConverterSettingsView::focus() {
+    button_return.focus();
+}
+
+/* SetFrequencyCorrectionView ****************************/
+
+SetFrequencyCorrectionView::SetFrequencyCorrectionView(NavigationView& nav) {
+    add_children({
+        &labels,
+        &opt_rx_correction_mode,
+        &field_rx_correction,
+        &opt_tx_correction_mode,
+        &field_tx_correction,
+        &button_return,
+    });
+
+    opt_rx_correction_mode.set_by_value(pmem::config_freq_rx_correction_updown());
+    opt_rx_correction_mode.on_change = [this](size_t, OptionsField::value_t v) {
+        pmem::set_freq_rx_correction_updown(v);
+    };
+
+    opt_tx_correction_mode.set_by_value(pmem::config_freq_tx_correction_updown());
+    opt_tx_correction_mode.on_change = [this](size_t, OptionsField::value_t v) {
+        pmem::set_freq_tx_correction_updown(v);
+    };
+
+    field_rx_correction.set_step(100'000);
+    field_rx_correction.set_value(pmem::config_freq_rx_correction());
+    field_rx_correction.on_change = [this](rf::Frequency f) {
+        pmem::set_config_freq_rx_correction(f);
+        // Retune to take converter change in account.
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
+    };
+    field_rx_correction.on_edit = [this, &nav]() {
+        auto new_view = nav.push<FrequencyKeypadView>(field_rx_correction.value());
+        new_view->on_changed = [this](rf::Frequency f) {
+            field_rx_correction.set_value(f);
+        };
+    };
+
+    field_tx_correction.set_step(100'000);
+    field_tx_correction.set_value(pmem::config_freq_tx_correction());
+    field_tx_correction.on_change = [this](rf::Frequency f) {
+        pmem::set_config_freq_tx_correction(f);
+        // Retune to take converter change in account. NB: receiver_model.
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
+    };
+    field_tx_correction.on_edit = [this, &nav]() {
+        auto new_view = nav.push<FrequencyKeypadView>(field_tx_correction.value());
+        new_view->on_changed = [this](rf::Frequency f) {
+            field_tx_correction.set_value(f);
+        };
+    };
+
+    button_return.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetFrequencyCorrectionView::focus() {
+    button_return.focus();
+}
+
+/* SetPersistentMemoryView *******************************/
+
+SetPersistentMemoryView::SetPersistentMemoryView(NavigationView& nav) {
+    add_children({
+        &labels,
+        &text_pmem_status,
+        &check_use_sdcard_for_pmem,
+        &button_save_mem_to_file,
+        &button_load_mem_from_file,
+        &button_load_mem_defaults,
+        &button_return,
+    });
+
+    text_pmem_status.set_style(&Styles::yellow);
+
+    check_use_sdcard_for_pmem.set_value(pmem::should_use_sdcard_for_pmem());
+    check_use_sdcard_for_pmem.on_select = [this](Checkbox&, bool v) {
+        File pmem_flag_file_handle;
+        if (v) {
+            if (fs::file_exists(PMEM_FILEFLAG)) {
+                text_pmem_status.set("P.Mem flag file present.");
+            } else {
+                auto error = pmem_flag_file_handle.create(PMEM_FILEFLAG);
+                if (error)
+                    text_pmem_status.set("Error creating P.Mem File!");
+                else
+                    text_pmem_status.set("P.Mem flag file created.");
+            }
+        } else {
+            auto result = delete_file(PMEM_FILEFLAG);
+            if (result.code() != FR_OK)
+                text_pmem_status.set("Error deleting P.Mem flag!");
+            else
+                text_pmem_status.set("P.Mem flag file deleted.");
+        }
+    };
+
+    button_save_mem_to_file.on_select = [&nav, this](Button&) {
+        if (!pmem::save_persistent_settings_to_file())
+            text_pmem_status.set("Error saving settings!");
+        else
+            text_pmem_status.set("Settings saved.");
+    };
+
+    button_load_mem_from_file.on_select = [&nav, this](Button&) {
+        if (!pmem::load_persistent_settings_from_file()) {
+            text_pmem_status.set("Error loading settings!");
+        } else {
+            text_pmem_status.set("Settings loaded.");
+            // Refresh status bar with icon up or down
+            send_system_refresh();
+        }
+    };
+
+    button_load_mem_defaults.on_select = [&nav, this](Button&) {
+        nav.push<ModalMessageView>(
+            "Warning!",
+            "This will reset the P.Mem\nto default settings.",
+            YESNO,
+            [this](bool choice) {
+                if (choice) {
+                    pmem::cache::defaults();
+                }
+            });
+    };
+
+    button_return.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetPersistentMemoryView::focus() {
+    button_return.focus();
+}
+
+/* SetAudioView ******************************************/
+
+SetAudioView::SetAudioView(NavigationView& nav) {
+    add_children({&labels,
+                  &field_tone_mix,
+                  &button_save,
+                  &button_cancel});
+
+    field_tone_mix.set_value(pmem::tone_mix());
+
+    button_save.on_select = [&nav, this](Button&) {
+        pmem::set_tone_mix(field_tone_mix.value());
+        audio::output::update_audio_mute();
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetAudioView::focus() {
+    button_save.focus();
+}
+
+/* SetQRCodeView *****************************************/
+
+SetQRCodeView::SetQRCodeView(NavigationView& nav) {
+    add_children({
+        &labels,
+        &checkbox_bigger_qr,
+        &button_save,
+        &button_cancel,
+    });
+
+    checkbox_bigger_qr.set_value(pmem::show_bigger_qr_code());
+
+    button_save.on_select = [&nav, this](Button&) {
+        pmem::set_show_bigger_qr_code(checkbox_bigger_qr.value());
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetQRCodeView::focus() {
+    button_save.focus();
+}
+
+/* SetEncoderDialView ************************************/
+
+SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
+    add_children({&labels,
+                  &field_encoder_dial_sensitivity,
+                  &button_save,
+                  &button_cancel});
+
+    field_encoder_dial_sensitivity.set_by_value(pmem::config_encoder_dial_sensitivity());
+
+    button_save.on_select = [&nav, this](Button&) {
+        pmem::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetEncoderDialView::focus() {
+    button_save.focus();
+}
+
+/* AppSettingsView ************************************/
+
+AppSettingsView::AppSettingsView(
+    NavigationView& nav)
+    : nav_{nav} {
+    add_children({&labels,
+                  &menu_view});
+
+    menu_view.set_parent_rect({0, 3 * 8, 240, 33 * 8});
+
+    ensure_directory(SETTINGS_DIR);
+
+    for (const auto& entry : std::filesystem::directory_iterator(SETTINGS_DIR, u"*.ini")) {
+        auto path = (std::filesystem::path)SETTINGS_DIR / entry.path();
+
+        menu_view.add_item({path.filename().string().substr(0, 26),
+                            ui::Color::dark_cyan(),
+                            &bitmap_icon_file_text,
+                            [this, path](KeyEvent) {
+                                nav_.push<TextEditorView>(path);
+                            }});
+    }
+}
+
+void AppSettingsView::focus() {
+    menu_view.focus();
+}
+
+/* SetConfigModeView ************************************/
+
+SetConfigModeView::SetConfigModeView(NavigationView& nav) {
+    add_children({&labels,
+                  &checkbox_config_mode_enabled,
+                  &button_save,
+                  &button_cancel});
+
+    checkbox_config_mode_enabled.set_value(!pmem::config_disable_config_mode());
+
+    button_save.on_select = [&nav, this](Button&) {
+        pmem::set_config_disable_config_mode(!checkbox_config_mode_enabled.value());
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetConfigModeView::focus() {
+    button_save.focus();
+}
+
+/* SettingsMenuView **************************************/
+
+SettingsMenuView::SettingsMenuView(NavigationView& nav) {
+    if (pmem::show_gui_return_icon()) {
+        add_items({{"..", ui::Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
+    }
+    add_items({
+        {"App Settings", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<AppSettingsView>(); }},
+        {"Audio", ui::Color::dark_cyan(), &bitmap_icon_speaker, [&nav]() { nav.push<SetAudioView>(); }},
+        {"Calibration", ui::Color::dark_cyan(), &bitmap_icon_options_touch, [&nav]() { nav.push<TouchCalibrationView>(); }},
+        {"Config Mode", ui::Color::dark_cyan(), &bitmap_icon_clk_ext, [&nav]() { nav.push<SetConfigModeView>(); }},
+        {"Converter", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetConverterSettingsView>(); }},
+        {"Date/Time", ui::Color::dark_cyan(), &bitmap_icon_options_datetime, [&nav]() { nav.push<SetDateTimeView>(); }},
+        {"Encoder Dial", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetEncoderDialView>(); }},
+        {"Freq. Correct", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetFrequencyCorrectionView>(); }},
+        {"P.Memory Mgmt", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<SetPersistentMemoryView>(); }},
+        {"Radio", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetRadioView>(); }},
+        {"SD Card", ui::Color::dark_cyan(), &bitmap_icon_sdcard, [&nav]() { nav.push<SetSDCardView>(); }},
+        {"User Interface", ui::Color::dark_cyan(), &bitmap_icon_options_ui, [&nav]() { nav.push<SetUIView>(); }},
+        {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [&nav]() { nav.push<SetQRCodeView>(); }},
+    });
+    set_max_rows(2);  // allow wider buttons
+}
+
+} /* namespace ui */

--- a/application/apps/ui_settings.hpp
+++ b/application/apps/ui_settings.hpp
@@ -1,0 +1,679 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2023 gullradriel, Nilorea Studio Inc.
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __UI_SETTINGS_H__
+#define __UI_SETTINGS_H__
+
+#include "ui_widget.hpp"
+#include "ui_menu.hpp"
+#include "ui_receiver.hpp"
+#include "ui_navigation.hpp"
+#include "bitmap.hpp"
+#include "ff.h"
+#include "portapack_persistent_memory.hpp"
+
+#include <cstdint>
+
+namespace ui {
+
+struct SetDateTimeModel {
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+    portapack::persistent_memory::dst_config_t dst;
+};
+
+class SetDateTimeView : public View {
+   public:
+    SetDateTimeView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Date/Time"; };
+
+   private:
+    using option_t = std::pair<std::string, int32_t>;
+    std::vector<option_t> which_options = {{"1st", 0}, {"2nd", 1}, {"3rd", 2}, {"4th", 3}, {"Last", 4}};
+    std::vector<option_t> weekday_options = {{"Sun", 0}, {"Mon", 1}, {"Tue", 2}, {"Wed", 3}, {"Thu", 4}, {"Fri", 5}, {"Sat", 6}};
+    std::vector<option_t> month_options = {{"Jan", 1}, {"Feb", 2}, {"Mar", 3}, {"Apr", 4}, {"May", 5}, {"Jun", 6}, {"Jul", 7}, {"Aug", 8}, {"Sep", 9}, {"Oct", 10}, {"Nov", 11}, {"Dec", 12}};
+
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Adjust the RTC clock date &", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "time. If clock resets after", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "reboot, coin batt. is dead. ", Color::light_grey()},
+        {{1 * 8, 5 * 16 - 2}, "YYYY-MM-DD HH:MM:SS  DoW DoY", Color::grey()},
+        {{5 * 8, 6 * 16}, "-  -     :  :", Color::light_grey()},
+        {{1 * 8, 11 * 16}, "DST adds 1 hour to RTC time.", Color::light_grey()},
+        {{0 * 8, 12 * 16}, "Start: 0:00 on Nth  DDD in", Color::light_grey()},
+        {{0 * 8, 13 * 16}, "End:   1:00 on Nth  DDD in", Color::light_grey()}};
+
+    NumberField field_year{
+        {1 * 8, 6 * 16},
+        4,
+        {2015, 2099},
+        1,
+        '0',
+        true,
+    };
+    NumberField field_month{
+        {6 * 8, 6 * 16},
+        2,
+        {1, 12},
+        1,
+        '0',
+        true,
+    };
+    NumberField field_day{
+        {9 * 8, 6 * 16},
+        2,
+        {1, 31},
+        1,
+        '0',
+        true,
+    };
+
+    NumberField field_hour{
+        {12 * 8, 6 * 16},
+        2,
+        {0, 23},
+        1,
+        '0',
+        true,
+    };
+    NumberField field_minute{
+        {15 * 8, 6 * 16},
+        2,
+        {0, 59},
+        1,
+        '0',
+        true,
+    };
+    NumberField field_second{
+        {18 * 8, 6 * 16},
+        2,
+        {0, 59},
+        1,
+        '0',
+        true,
+    };
+    Text text_weekday{
+        {22 * 8, 6 * 16, 3 * 8, 16},
+        ""};
+    Text text_day_of_year{
+        {26 * 8, 6 * 16, 3 * 8, 16},
+        ""};
+
+    Checkbox checkbox_dst_enable{
+        {2 * 8, 9 * 16},
+        23,
+        "Enable Daylight Savings"};
+
+    OptionsField options_dst_start_which{
+        {15 * 8, 12 * 16},
+        4,
+        {}};
+
+    OptionsField options_dst_start_weekday{
+        {20 * 8, 12 * 16},
+        3,
+        {}};
+
+    OptionsField options_dst_start_month{
+        {27 * 8, 12 * 16},
+        3,
+        {}};
+
+    OptionsField options_dst_end_which{
+        {15 * 8, 13 * 16},
+        4,
+        {}};
+
+    OptionsField options_dst_end_weekday{
+        {20 * 8, 13 * 16},
+        3,
+        {}};
+
+    OptionsField options_dst_end_month{
+        {27 * 8, 13 * 16},
+        3,
+        {}};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel"};
+
+    void form_init(const SetDateTimeModel& model);
+    SetDateTimeModel form_collect();
+};
+
+struct SetFrequencyCorrectionModel {
+    int8_t ppm;
+    uint32_t freq;
+};
+
+class SetRadioView : public View {
+   public:
+    SetRadioView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Radio"; };
+
+   private:
+    uint8_t freq_step_khz = 3;
+
+    Text label_source{
+        {1 * 8, 1 * 16, 17 * 8, 16},
+        "Reference Source:"};
+
+    Text value_source{
+        {18 * 8, 1 * 16, 11 * 8, 16},
+        ""};
+
+    Text value_source_frequency{
+        {18 * 8, 2 * 16, 11 * 8, 16},
+        ""};
+
+    Labels labels_correction{
+        {{2 * 8, 3 * 16}, "Frequency correction:", Color::light_grey()},
+        {{6 * 8, 4 * 16}, "PPM", Color::light_grey()},
+    };
+
+    NumberField field_ppm{
+        {2 * 8, 4 * 16},
+        3,
+        {-50, 50},
+        1,
+        '0',
+    };
+
+    Checkbox check_clkout{
+        {18, (6 * 16 - 4)},
+        13,
+        "Enable CLKOUT"};
+
+    SymField field_clkout_freq{
+        {20 * 8, 6 * 16},
+        5,
+        SymField::Type::Dec};
+
+    Labels labels_clkout_khz{
+        {{26 * 8, 6 * 16}, "kHz", Color::light_grey()}};
+
+    Labels labels_bias{
+        {{4 * 8 + 4, 8 * 16}, "CAUTION: Ensure that all", Color::red()},
+        {{5 * 8 + 0, 9 * 16}, "devices attached to the", Color::red()},
+        {{6 * 8 + 0, 10 * 16}, "antenna connector can", Color::red()},
+        {{6 * 8 + 4, 11 * 16}, "accept a DC voltage!", Color::red()}};
+
+    Checkbox check_bias{
+        {18, 12 * 16},
+        5,
+        "Enable DC bias voltage"};
+
+    Checkbox disable_external_tcxo{
+        {18, 14 * 16},
+        5,
+        "Disable external TCXO"};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+
+    void form_init(const SetFrequencyCorrectionModel& model);
+    SetFrequencyCorrectionModel form_collect();
+};
+
+using portapack::persistent_memory::backlight_timeout_t;
+
+class SetUIView : public View {
+   public:
+    SetUIView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "UI"; };
+
+   private:
+    Checkbox checkbox_disable_touchscreen{
+        {3 * 8, 1 * 16},
+        20,
+        "Disable touchscreen"};
+
+    Checkbox checkbox_bloff{
+        {3 * 8, 3 * 16},
+        20,
+        "Backlight off after:"};
+    OptionsField options_bloff{
+        {60, 4 * 16 + 8},
+        20,
+        {
+            {"5 seconds", backlight_timeout_t::Timeout5Sec},
+            {"15 seconds", backlight_timeout_t::Timeout15Sec},
+            {"30 seconds", backlight_timeout_t::Timeout30Sec},
+            {"1 minute", backlight_timeout_t::Timeout60Sec},
+            {"3 minutes", backlight_timeout_t::Timeout180Sec},
+            {"5 minutes", backlight_timeout_t::Timeout300Sec},
+            {"10 minutes", backlight_timeout_t::Timeout600Sec},
+            {"1 hour", backlight_timeout_t::Timeout3600Sec},
+        }};
+
+    Checkbox checkbox_showsplash{
+        {3 * 8, 6 * 16},
+        20,
+        "Show splash"};
+
+    Checkbox checkbox_showclock{
+        {3 * 8, 8 * 16},
+        20,
+        "Show clock with:"};
+
+    OptionsField options_clockformat{
+        {60, 9 * 16 + 8},
+        20,
+        {{"time only", 0},
+         {"time and date", 1}}};
+
+    Checkbox checkbox_guireturnflag{
+        {3 * 8, 11 * 16},
+        20,
+        "Back button in menu"};
+
+    Labels labels{
+        {{3 * 8, 13 * 16}, "Show/Hide Status Icons", Color::light_grey()},
+    };
+
+    ImageToggle toggle_camera{
+        {7 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_camera};
+
+    ImageToggle toggle_sleep{
+        {9 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_sleep};
+
+    ImageToggle toggle_stealth{
+        {11 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_stealth};
+
+    ImageToggle toggle_converter{
+        {13 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_upconvert};
+
+    ImageToggle toggle_bias_tee{
+        {15 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_biast_off};
+
+    ImageToggle toggle_clock{
+        {17 * 8, 14 * 16 + 2, 8, 16},
+        &bitmap_icon_clk_ext};
+
+    ImageToggle toggle_mute{
+        {18 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_speaker_and_headphones_mute};
+
+    ImageToggle toggle_speaker{
+        {20 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_speaker_mute};
+
+    ImageToggle toggle_sd_card{
+        {22 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_sd_card_ok};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel"};
+};
+
+class SetSDCardView : public View {
+   public:
+    SetSDCardView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "SD Card"; };
+
+   private:
+    Labels labels{
+        // 01234567890123456789012345678
+        {{1 * 8, 120 - 48}, "    HIGH SPEED SDCARD IO     ", Color::light_grey()},
+        {{1 * 8, 120 - 32}, "   May or may not work !!    ", Color::light_grey()}};
+
+    Checkbox checkbox_sdcard_speed{
+        {2 * 8, 120},
+        20,
+        "enable high speed IO"};
+
+    Button button_test_sdcard_high_speed{
+        {2 * 8, 152, 27 * 8, 32},
+        "TEST BUTTON (NO PMEM SAVE)"};
+
+    Text text_sdcard_test_status{
+        {2 * 8, 198, 28 * 8, 16},
+        ""};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel"};
+};
+
+class SetConverterSettingsView : public View {
+   public:
+    SetConverterSettingsView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Converter"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Options for working with", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "up/down converter hardware", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "like a Ham It Up.", Color::light_grey()},
+        {{2 * 8, 9 * 16 - 2}, "Conversion frequency:", Color::light_grey()},
+        {{18 * 8, 10 * 16}, "MHz", Color::light_grey()},
+    };
+
+    Checkbox check_show_converter{
+        {2 * 8, 5 * 16},
+        19,
+        "Show converter icon"};
+
+    Checkbox check_converter{
+        {2 * 8, 7 * 16},
+        16,
+        "Enable converter"};
+
+    OptionsField opt_converter_mode{
+        {5 * 8, 10 * 16},
+        3,
+        {
+            {" + ", 0},  // up converter
+            {" - ", 1},  // down converter
+        }};
+
+    FrequencyField field_converter_freq{
+        {8 * 8, 10 * 16}};
+
+    Button button_return{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Return",
+    };
+};
+
+class SetFrequencyCorrectionView : public View {
+   public:
+    SetFrequencyCorrectionView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Freq Correct"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Frequency correction allows", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "RX and TX frequencies to be", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "adjusted for all apps.", Color::light_grey()},
+        {{2 * 8, 6 * 16}, "RX Adjustment Frequency", Color::light_grey()},
+        {{18 * 8, 7 * 16}, "MHz", Color::light_grey()},
+        {{2 * 8, 9 * 16}, "TX Adjustment Frequency", Color::light_grey()},
+        {{18 * 8, 10 * 16}, "MHz", Color::light_grey()},
+    };
+
+    OptionsField opt_rx_correction_mode{
+        {5 * 8, 7 * 16},
+        3,
+        {{" + ", 0},
+         {" - ", 1}}};
+
+    FrequencyField field_rx_correction{
+        {8 * 8, 7 * 16}};
+
+    OptionsField opt_tx_correction_mode{
+        {5 * 8, 10 * 16},
+        3,
+        {{" + ", 0},
+         {" - ", 1}}};
+
+    FrequencyField field_tx_correction{
+        {8 * 8, 10 * 16}};
+
+    Button button_return{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Return",
+    };
+};
+
+class SetAudioView : public View {
+   public:
+    SetAudioView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Audio"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Controls the volume of the", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "tone when transmitting in", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "Soundboard or Mic apps.", Color::light_grey()},
+        {{2 * 8, 5 * 16}, "Tone key mix:   %", Color::light_grey()},
+    };
+
+    NumberField field_tone_mix{
+        {16 * 8, 5 * 16},
+        2,
+        {10, 99},
+        1,
+        '0'};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+};
+
+class SetQRCodeView : public View {
+   public:
+    SetQRCodeView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "QR Code"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Change the size of the QR", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "code shown in Radiosonde.", Color::light_grey()},
+    };
+
+    Checkbox checkbox_bigger_qr{
+        {3 * 8, 4 * 16},
+        20,
+        "Show large QR code"};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+};
+
+using portapack::persistent_memory::encoder_dial_sensitivity;
+
+class SetEncoderDialView : public View {
+   public:
+    SetEncoderDialView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Encoder Dial"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Adjusts how many steps to", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "change the encoder value.", Color::light_grey()},
+        {{2 * 8, 4 * 16}, "Dial sensitivity:", Color::light_grey()},
+    };
+
+    OptionsField field_encoder_dial_sensitivity{
+        {20 * 8, 4 * 16},
+        6,
+        {{"LOW", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOW},
+         {"NORMAL", encoder_dial_sensitivity::DIAL_SENSITIVITY_NORMAL},
+         {"HIGH", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGH}}};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+};
+
+class SetPersistentMemoryView : public View {
+   public:
+    SetPersistentMemoryView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "P.Mem Mgmt"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Save persistent memory on SD", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "card. Needed when device has", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "dead/missing coin battery.", Color::light_grey()},
+    };
+
+    Text text_pmem_status{
+        {1 * 8, 4 * 16 + 8, 28 * 8, 16},
+        ""};
+
+    Checkbox check_use_sdcard_for_pmem{
+        {2 * 8, 6 * 16},
+        21,
+        "Use SD card for P.Mem"};
+
+    Button button_save_mem_to_file{
+        {1 * 8, 8 * 16, 28 * 8, 2 * 16},
+        "Save P.Mem to SD card"};
+
+    Button button_load_mem_from_file{
+        {1 * 8, 10 * 16 + 2, 28 * 8, 2 * 16},
+        "Load P.Mem from SD Card"};
+
+    Button button_load_mem_defaults{
+        {1 * 8, 12 * 16 + 4, 28 * 8, 2 * 16},
+        "Reset P.Mem to defaults"};
+
+    Button button_return{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Return",
+    };
+};
+
+class AppSettingsView : public View {
+   public:
+    AppSettingsView(NavigationView& nav);
+    std::string title() const override { return "App Settings"; };
+    void focus() override;
+
+   private:
+    NavigationView& nav_;
+
+    Labels labels{
+        {{0, 4}, "Select file to edit:", Color::white()}};
+
+    MenuView menu_view{
+        {0, 2 * 8, 240, 26 * 8},
+        true};
+};
+
+class SetConfigModeView : public View {
+   public:
+    SetConfigModeView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Config Mode"; };
+
+   private:
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Controls whether firmware", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "will enter Config Mode", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "after a boot failure.", Color::light_grey()},
+    };
+
+    Checkbox checkbox_config_mode_enabled{
+        {2 * 8, 6 * 16},
+        16,
+        "Config Mode enable"};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+};
+
+class SettingsMenuView : public BtnGridView {
+   public:
+    SettingsMenuView(NavigationView& nav);
+
+    std::string title() const override { return "Settings"; };
+};
+
+} /* namespace ui */
+
+#endif /*__UI_SETTINGS_H__*/

--- a/application/portapack.cpp
+++ b/application/portapack.cpp
@@ -1,0 +1,550 @@
+/*
+ * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "portapack.hpp"
+#include "portapack_hal.hpp"
+#include "portapack_dma.hpp"
+#include "portapack_cpld_data.hpp"
+#include "portapack_persistent_memory.hpp"
+
+#include "hackrf_hal.hpp"
+#include "hackrf_gpio.hpp"
+using namespace hackrf::one;
+
+#include "clock_manager.hpp"
+#include "event_m0.hpp"
+
+#include "backlight.hpp"
+#include "touch_adc.hpp"
+#include "audio.hpp"
+
+#include "wm8731.hpp"
+using wolfson::wm8731::WM8731;
+
+#include "ak4951.hpp"
+using asahi_kasei::ak4951::AK4951;
+
+#include "cpld_update.hpp"
+
+#include "optional.hpp"
+#include "irq_controls.hpp"
+
+#include "file.hpp"
+#include "sd_card.hpp"
+#include "string_format.hpp"
+
+namespace portapack {
+
+portapack::IO io{
+    portapack::gpio_dir,
+    portapack::gpio_lcd_rdx,
+    portapack::gpio_lcd_wrx,
+    portapack::gpio_io_stbx,
+    portapack::gpio_addr,
+    portapack::gpio_lcd_te,
+    portapack::gpio_dfu,
+};
+
+portapack::BacklightCAT4004 backlight_cat4004;
+portapack::BacklightOnOff backlight_on_off;
+
+lcd::ILI9341 display;
+
+I2C i2c0(&I2CD0);
+SPI ssp1(&SPID2);
+portapack::USBSerial usb_serial;
+
+si5351::Si5351 clock_generator{
+    i2c0, hackrf::one::si5351_i2c_address};
+
+ClockManager clock_manager{
+    i2c0, clock_generator};
+
+WM8731 audio_codec_wm8731{i2c0, 0x1a};
+AK4951 audio_codec_ak4951{i2c0, 0x12};
+
+ReceiverModel receiver_model;
+TransmitterModel transmitter_model;
+
+TemperatureLogger temperature_logger;
+
+bool antenna_bias{false};
+uint32_t bl_tick_counter{0};
+
+void set_antenna_bias(const bool v) {
+    antenna_bias = v;
+}
+
+bool get_antenna_bias() {
+    return antenna_bias;
+}
+
+static constexpr uint32_t systick_count(const uint32_t clock_source_f) {
+    return clock_source_f / CH_FREQUENCY;
+}
+
+static constexpr uint32_t systick_load(const uint32_t clock_source_f) {
+    return systick_count(clock_source_f) - 1;
+}
+
+constexpr uint32_t i2c0_bus_f = 400000;
+constexpr uint32_t i2c0_high_period_ns = 900;
+
+typedef struct {
+    uint32_t clock_f;
+    uint32_t systick_count;
+    uint32_t idivb;
+    uint32_t idivc;
+} clock_config_t;
+
+static constexpr uint32_t idiv_config(const cgu::CLK_SEL clk_sel, const uint32_t idiv) {
+    return cgu::IDIV_CTRL{0, idiv - 1, 1, clk_sel};
+}
+
+constexpr clock_config_t clock_config_irc{
+    12000000,
+    systick_load(12000000),
+    idiv_config(cgu::CLK_SEL::IRC, 1),
+    idiv_config(cgu::CLK_SEL::IRC, 1),
+};
+
+constexpr clock_config_t clock_config_pll1_boot{
+    96000000,
+    systick_load(96000000),
+    idiv_config(cgu::CLK_SEL::PLL1, 9),
+    idiv_config(cgu::CLK_SEL::PLL1, 3),
+};
+
+constexpr clock_config_t clock_config_pll1_step{
+    100000000,
+    systick_load(100000000),
+    idiv_config(cgu::CLK_SEL::PLL1, 1),
+    idiv_config(cgu::CLK_SEL::PLL1, 1),
+};
+
+constexpr clock_config_t clock_config_pll1{
+    200000000,
+    systick_load(200000000),
+    idiv_config(cgu::CLK_SEL::PLL1, 2),
+    idiv_config(cgu::CLK_SEL::PLL1, 1),
+};
+
+constexpr I2CClockConfig i2c_clock_config_400k_boot_clock{
+    .clock_source_f = clock_config_pll1_boot.clock_f,
+    .bus_f = i2c0_bus_f,
+    .high_period_ns = i2c0_high_period_ns,
+};
+
+constexpr I2CClockConfig i2c_clock_config_400k_fast_clock{
+    .clock_source_f = clock_config_pll1.clock_f,
+    .bus_f = i2c0_bus_f,
+    .high_period_ns = i2c0_high_period_ns,
+};
+
+constexpr I2CConfig i2c_config_boot_clock{
+    .high_count = i2c_clock_config_400k_boot_clock.i2c_high_count(),
+    .low_count = i2c_clock_config_400k_boot_clock.i2c_low_count(),
+};
+
+constexpr I2CConfig i2c_config_fast_clock{
+    .high_count = i2c_clock_config_400k_fast_clock.i2c_high_count(),
+    .low_count = i2c_clock_config_400k_fast_clock.i2c_low_count(),
+};
+
+enum class PortaPackModel {
+    R1_20150901,
+    R2_20170522,
+};
+
+static bool save_config(int8_t value) {
+    persistent_memory::set_config_cpld(value);
+    if (sd_card::status() == sd_card::Status::Mounted) {
+        ensure_directory("/hardware");
+        File file;
+        auto sucess = file.create("/hardware/settings.txt");
+        if (!sucess.is_valid()) {
+            file.write_line(to_string_dec_uint(value));
+        }
+    }
+    return true;
+}
+
+int read_file(std::string name) {
+    std::string return_string = "";
+    File file;
+    auto success = file.open(name);
+
+    if (!success.is_valid()) {
+        char one_char[1];
+        for (size_t pointer = 0; pointer < file.size(); pointer++) {
+            file.seek(pointer);
+            file.read(one_char, 1);
+            return_string += one_char[0];
+        }
+        return std::stoi(return_string);
+    }
+    return -1;
+}
+
+static int load_config() {
+    static Optional<int> config_value;
+    if (!config_value.is_valid()) {
+        int8_t value = portapack::persistent_memory::config_cpld();
+        if ((value <= 0 || value >= 5) && sd_card::status() == sd_card::Status::Mounted) {
+            int data = read_file("/hardware/settings.txt");
+            if (data != -1) {
+                config_value = data;
+            }
+        } else {
+            config_value = value;
+        }
+    }
+    return config_value.value();
+}
+
+static PortaPackModel portapack_model() {
+    static Optional<PortaPackModel> model;
+
+    if (!model.is_valid()) {
+        const auto switches_state = get_switches_state();
+        // Only save config if no other multi key boot action is triggered (like pmem reset)
+        if (switches_state.count() == 1) {
+            if (switches_state[(size_t)ui::KeyEvent::Up]) {
+                save_config(1);
+                // model = PortaPackModel::R2_20170522; // Commented these out as they should be set down below anyway
+            } else if (switches_state[(size_t)ui::KeyEvent::Down]) {
+                save_config(2);
+                // model = PortaPackModel::R1_20150901;
+            } else if (switches_state[(size_t)ui::KeyEvent::Left]) {
+                save_config(3);
+                // model = PortaPackModel::R1_20150901;
+            } else if (switches_state[(size_t)ui::KeyEvent::Right]) {
+                save_config(4);
+                // model = PortaPackModel::R2_20170522;
+            } else if (switches_state[(size_t)ui::KeyEvent::Select]) {
+                save_config(0);
+            }
+        }
+
+        if (load_config() == 1) {
+            model = PortaPackModel::R2_20170522;
+        } else if (load_config() == 2) {
+            model = PortaPackModel::R1_20150901;
+        } else if (load_config() == 3) {
+            model = PortaPackModel::R1_20150901;
+        } else if (load_config() == 4) {
+            model = PortaPackModel::R2_20170522;
+        } else {
+            if (audio_codec_wm8731.detected()) {
+                model = PortaPackModel::R1_20150901;  // H1R1
+            } else {
+                model = PortaPackModel::R2_20170522;  // H1R2, H2, H2+
+            }
+        }
+    }
+
+    return model.value();
+}
+
+// audio_codec_wm8731 = H1R1 & H2+
+// audio_codec_ak4951 = H1R2
+
+static audio::Codec* portapack_audio_codec() {
+    /* I2C ready OK, Automatic recognition of audio chip */
+    return (audio_codec_wm8731.detected())
+               ? static_cast<audio::Codec*>(&audio_codec_wm8731)
+               : static_cast<audio::Codec*>(&audio_codec_ak4951);
+}
+
+static const portapack::cpld::Config& portapack_cpld_config() {
+    return (portapack_model() == PortaPackModel::R2_20170522)
+               ? portapack::cpld::rev_20170522::config
+               : portapack::cpld::rev_20150901::config;
+}
+
+Backlight* backlight() {
+    return (portapack_model() == PortaPackModel::R2_20170522)
+               ? static_cast<portapack::Backlight*>(&backlight_cat4004)  // R2_20170522
+               : static_cast<portapack::Backlight*>(&backlight_on_off);  // R1_20150901
+}
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+static LPC_CGU_BASE_CLK_Type* const base_clocks_idivc[] = {
+    &LPC_CGU->BASE_PERIPH_CLK,
+    &LPC_CGU->BASE_M4_CLK,
+    &LPC_CGU->BASE_APB1_CLK,
+    &LPC_CGU->BASE_APB3_CLK,
+    &LPC_CGU->BASE_SDIO_CLK,
+    &LPC_CGU->BASE_SSP1_CLK,
+};
+
+static void set_idivc_base_clocks(const cgu::CLK_SEL clock_source) {
+    for (uint32_t i = 0; i < ARRAY_SIZE(base_clocks_idivc); i++) {
+        base_clocks_idivc[i]->AUTOBLOCK = 1;
+        base_clocks_idivc[i]->CLK_SEL = toUType(clock_source);
+    }
+}
+
+static void set_clock_config(const clock_config_t& config) {
+    LPC_CGU->IDIVB_CTRL.word = config.idivb;
+    LPC_CGU->IDIVC_CTRL.word = config.idivc;
+    systick_adjust_period(config.systick_count);
+    halLPCSetSystemClock(config.clock_f);
+}
+
+static void shutdown_base() {
+    i2c0.stop();
+
+    set_clock_config(clock_config_irc);
+
+    cgu::pll1::disable();
+
+    set_idivc_base_clocks(cgu::CLK_SEL::IRC);
+
+    cgu::pll1::ctrl({
+        .pd = 1,
+        .bypass = 0,
+        .fbsel = 0,
+        .direct = 1,
+        .psel = 0,
+        .autoblock = 1,
+        .nsel = 0,
+        .msel = 23,
+        .clk_sel = cgu::CLK_SEL::IRC,
+    });
+
+    cgu::pll1::enable();
+    while (!cgu::pll1::is_locked())
+        ;
+
+    set_clock_config(clock_config_pll1_boot);
+
+    i2c0.start(i2c_config_boot_clock);
+
+    clock_manager.shutdown();
+}
+
+/* Clock scheme after exiting bootloader in SPIFI mode:
+ *
+ * XTAL_OSC = powered down
+ *
+ * PLL0USB = powered down
+ * PLL0AUDIO = powered down
+ * PLL1 = IRC * 24 = 288 MHz
+ *
+ * IDIVA = IRC / 1 = 12 MHz
+ * IDIVB = PLL1 / 9 = 32 MHz
+ * IDIVC = PLL1 / 3 = 96 MHz
+ * IDIVD = IRC / 1 = 12 MHz
+ * IDIVE = IRC / 1 = 12 MHz
+ *
+ * BASE_USB0_CLK = PLL0USB
+ * BASE_PERIPH_CLK = IRC
+ * BASE_M4_CLK = IDIVC (96 MHz)
+ * BASE_SPIFI_CLK = IDIVB (32 MHZ)
+ *
+ * everything else = IRC
+ */
+
+/* Clock scheme during PortaPack operation:
+ *
+ * XTAL_OSC = powered down
+ *
+ * PLL0USB = XTAL, 480 MHz
+ * PLL0AUDIO = GP_CLKIN, Fcco=491.52 MHz, Fout=12.288 MHz
+ * PLL1 =
+ * 	OG: GP_CLKIN * 10 = 200 MHz
+ *	r9: GP_CLKIN * 20 = 200 MHz
+ * IDIVA = IRC / 1 = 12 MHz
+ * IDIVB = PLL1 / 2 = 100 MHz
+ * IDIVC = PLL1 / 1 = 200 MHz
+ * IDIVD = PLL0AUDIO / N (where N is varied depending on decimation factor)
+ * IDIVE = IRC / 1 = 12 MHz
+ *
+ * BASE_USB0_CLK = PLL0USB
+ * BASE_PERIPH_CLK = IRC
+ * BASE_M4_CLK = IDIVC (200 MHz)
+ * BASE_SPIFI_CLK = IDIVB (100 MHZ)
+ * BASE_AUDIO_CLK = IDIVD
+ *
+ * everything else = IRC
+ */
+
+bool init() {
+    set_idivc_base_clocks(cgu::CLK_SEL::IDIVC);
+
+    i2c0.start(i2c_config_boot_clock);
+
+    // Keeping this here for now incase we need to revert
+    // if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
+    // 	shutdown_base();
+    // 	return false;
+    // }
+
+    // if( !hackrf::cpld::load_sram() ) {
+    // 	chSysHalt();
+    // }
+    chThdSleepMilliseconds(100);
+
+    configure_pins_portapack();
+
+    portapack::io.init();
+
+    /* Cache some configuration data from persistent memory. */
+    persistent_memory::cache::init();
+    rtc_time::dst_init();
+    chThdSleepMilliseconds(10);
+
+    clock_manager.init_clock_generator();
+
+    i2c0.stop();
+
+    chThdSleepMilliseconds(10);
+
+    set_clock_config(clock_config_irc);
+    cgu::pll1::disable();
+
+    /* Incantation from LPC43xx UM10503 section 12.2.1.1, to bring the M4
+     * core clock speed to the 110 - 204MHz range.
+     */
+
+    /* Step into the 90-110MHz M4 clock range */
+    /* OG:
+     * 	Fclkin = 40M
+     * 		/N=2 = 20M = PFDin
+     * 	Fcco = PFDin * (M=10) = 200M
+     * r9:
+     * 	Fclkin = 10M
+     * 		/N=1 = 10M = PFDin
+     * 	Fcco = PFDin * (M=20) = 200M
+     * Fclk = Fcco / (2*(P=1)) = 100M
+     */
+    cgu::pll1::ctrl({
+        .pd = 1,
+        .bypass = 0,
+        .fbsel = 0,
+        .direct = 0,
+        .psel = 0,
+        .autoblock = 1,
+        .nsel = hackrf_r9 ? 0UL : 1UL,
+        .msel = hackrf_r9 ? 19UL : 9UL,
+        .clk_sel = cgu::CLK_SEL::GP_CLKIN,
+    });
+
+    cgu::pll1::enable();
+    while (!cgu::pll1::is_locked())
+        ;
+
+    set_clock_config(clock_config_pll1_step);
+
+    /* Delay >50us at 90-110MHz clock speed */
+    volatile uint32_t delay = 1400;
+    while (delay--)
+        ;
+
+    set_clock_config(clock_config_pll1);
+
+    /* Remove /2P divider from PLL1 output to achieve full speed */
+    cgu::pll1::direct();
+
+    usb_serial.initialize();
+
+    i2c0.start(i2c_config_fast_clock);
+    chThdSleepMilliseconds(10);
+
+    /* Check if portapack is attached by checking if any of the two audio chips is present. */
+    systime_t timeout = 50;
+    uint8_t wm8731_reset_command[] = {0x0f, 0x00};
+    if (i2c0.transmit(0x1a /* wm8731 */, wm8731_reset_command, 2, timeout) == false) {
+        audio_codec_ak4951.reset();
+        uint8_t ak4951_init_command[] = {0x00, 0x00};
+        i2c0.transmit(0x12 /* ak4951 */, ak4951_init_command, 2, timeout);
+        chThdSleepMilliseconds(10);
+        if (i2c0.transmit(0x12 /* ak4951 */, ak4951_init_command, 2, timeout) == false) {
+            shutdown_base();
+            return false;
+        }
+    }
+
+    touch::adc::init();
+    controls_init();
+    chThdSleepMilliseconds(10);
+
+    clock_manager.set_reference_ppb(persistent_memory::correction_ppb());
+    clock_manager.enable_if_clocks();
+    clock_manager.enable_codec_clocks();
+    radio::init();
+
+    sdcStart(&SDCD1, nullptr);
+    sd_card::poll_inserted();
+
+    chThdSleepMilliseconds(10);
+
+    portapack::cpld::CpldUpdateStatus result = portapack::cpld::update_if_necessary(portapack_cpld_config());
+    if (result == portapack::cpld::CpldUpdateStatus::Program_failed) {
+        chThdSleepMilliseconds(10);
+        // Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
+        // Mode center (autodetect), up (R1) and down (R2,H2,H2+) will go into hackrf mode after failing CPLD update
+        if (load_config() != 3 /* left */ && load_config() != 4 /* right */) {
+            shutdown_base();
+            return false;
+        }
+    }
+
+    if (!hackrf::cpld::load_sram()) {
+        chSysHalt();
+    }
+
+    chThdSleepMilliseconds(10);  // This delay seems to solve white noise audio issues
+
+    LPC_CREG->DMAMUX = portapack::gpdma_mux;
+    gpdma::controller.enable();
+
+    chThdSleepMilliseconds(10);
+
+    audio::init(portapack_audio_codec());
+
+    return true;
+}
+
+void shutdown(const bool leave_screen_on) {
+    gpdma::controller.disable();
+
+    if (!leave_screen_on) {
+        backlight()->off();
+        display.shutdown();
+    }
+
+    receiver_model.disable();
+    transmitter_model.disable();
+    audio::shutdown();
+
+    hackrf::cpld::init_from_eeprom();
+
+    shutdown_base();
+}
+
+void setEventDispatcherToUSBSerial(EventDispatcher* evt) {
+    usb_serial.setEventDispatcher(evt);
+}
+
+} /* namespace portapack */

--- a/application/rtc_time.cpp
+++ b/application/rtc_time.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2023 Mark Thompson
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "rtc_time.hpp"
+#include "portapack_persistent_memory.hpp"
+
+using namespace portapack;
+namespace pmem = portapack::persistent_memory;
+
+namespace rtc_time {
+
+Signal<> signal_tick_second;
+
+bool dst_enabled{false};
+bool dst_dates_reversed;
+bool dst_in_range{false};
+uint16_t dst_start_doy;
+uint16_t dst_end_doy;
+uint16_t dst_current_doy{0xFFFF};
+uint16_t dst_current_year{0xFFFF};
+
+static const uint16_t months_with_31 = 0x0AD5;  // Bits represents months with 31 days (bit 0 for January, etc)
+
+void on_tick_second() {
+    signal_tick_second.emit();
+}
+
+// Check if DST is configured and active (called at power-up)
+void dst_init() {
+    rtc::RTC datetime;
+    rtcGetTime(&RTCD1, &datetime);
+    dst_update_date_range(datetime.year(), LPC_RTC->DOY);
+}
+
+// Return current time & date (adjusted for DST if enabled)
+rtc::RTC now() {
+    rtc::RTC datetime;
+    rtcGetTime(&RTCD1, &datetime);
+    if (dst_enabled) {
+        datetime = dst_adjust_returned_time(datetime);
+    }
+    return datetime;
+}
+
+rtc::RTC now(rtc::RTC& out_datetime) {
+    rtcGetTime(&RTCD1, &out_datetime);
+    if (dst_enabled) {
+        out_datetime = dst_adjust_returned_time(out_datetime);
+    }
+    return out_datetime;
+}
+
+// Add 1 hour (spring forward) if needed for DST (called whenever RTC is read if DST is enabled)
+rtc::RTC dst_adjust_returned_time(rtc::RTC& datetime) {
+    // Read day of year from RTC and check for change
+    uint32_t doy = LPC_RTC->DOY;
+
+    // Update DST start/end day-of-year only when year changes, otherwise just check if in range when day changes
+    if (doy != dst_current_doy) {
+        if (datetime.year() != dst_current_year)
+            dst_update_date_range(datetime.year(), doy);
+        else
+            dst_check_date_range(doy);
+    }
+
+    // Not in DST date range
+    if (!dst_in_range)
+        return datetime;
+
+    // Add 1 hour to RTC time
+    uint16_t year = datetime.year();
+    uint8_t month = datetime.month();
+    uint8_t day = datetime.day();
+    uint8_t hour = datetime.hour();
+
+    if (++hour > 23) {
+        hour = 0;
+        if (++day > days_per_month(year, month)) {
+            day = 1;
+            if (++month > 12) {
+                year++;
+            }
+        }
+    }
+    rtc::RTC dst_datetime{year, month, day, hour, datetime.minute(), datetime.second()};
+    return dst_datetime;
+}
+
+// Check if current date is within the DST range (called when date changes)
+void dst_check_date_range(uint16_t doy) {
+    bool in_range = true;
+    dst_current_doy = doy;
+
+    // Check if date is within DST range
+    if (!dst_dates_reversed) {
+        if ((doy < dst_start_doy) || (doy >= dst_end_doy))
+            in_range = false;
+    } else {
+        if ((doy < dst_start_doy) && (doy >= dst_end_doy))
+            in_range = false;
+    }
+    dst_in_range = in_range;
+}
+
+// Update DST parameters (called at power-up, when year changes, or DST settings are changed)
+void dst_update_date_range(uint16_t year, uint16_t doy) {
+    dst_enabled = pmem::dst_enabled();
+    if (dst_enabled) {
+        const pmem::dst_config_t dst = pmem::config_dst();
+        dst_current_year = year;
+        dst_start_doy = day_of_year_of_nth_weekday(dst_current_year, dst.b.start_month, dst.b.start_which, dst.b.start_weekday);
+        dst_end_doy = day_of_year_of_nth_weekday(dst_current_year, dst.b.end_month, dst.b.end_which, dst.b.end_weekday);
+        dst_dates_reversed = (dst_start_doy > dst_end_doy);  // Summer starts in December in Southern hemisphere
+
+        dst_check_date_range(doy);
+    } else {
+        dst_in_range = false;
+    }
+}
+
+// Set RTC clock.
+// If the user has enabled DST, the time entered and passed to this function is interpreted as having been adjusted for DST.
+// When DST functionality is enabled in pmem, the value stored in the RTC hardware is non-DST time, and we only fudge the time when read.
+// Thus, it's necessary to subtract an hour before storing it in the RTC if we're in the DST date range.
+// (If RTC is desired to represent UTC, then DST should obviously be disabled in settings.)
+// NB: Firmware should not change RTC without going through this function.
+void set(rtc::RTC& new_datetime) {
+    uint16_t year = new_datetime.year();
+    uint8_t month = new_datetime.month();
+    uint8_t day = new_datetime.day();
+    uint8_t hour = new_datetime.hour();
+
+    // NB: DST code relies on the Day of Year (DOY) value to be initialized in the RTC by firmware (RTC hardware only does increment and wrap)
+    uint16_t doy = day_of_year(year, month, day);
+    dst_update_date_range(year, doy);
+
+    // NB: Currently we only support the DST transition at midnight RTC time (not configurable to hour granularity).
+    // Note on handling the the hour before/after DST time change:
+    //
+    //   If entered hour==0 on dst_start_day:
+    //      Time entered is INVALID due to spring-forward; code below rolls back RTC to last hour of previous day.
+    //
+    //   If entered hour==0 on dst_end_doy:
+    //      This hour occurs twice due to fall-back; code below treats as if DST has ended (the second occurrence) and doesn't roll back RTC
+    //
+    if (!dst_in_range) {
+        LPC_RTC->DOY = doy;
+        // NB: Writing RTC twice takes a second, but ensures that new value can be read back immediately
+        // (if not written twice, the old value will be returned if read back in the following 1-2 seconds)
+        // (you will notice with older Mayhem versions that running the Date/Time Settings app again quickly will show the old time)
+        rtcSetTime(&RTCD1, &new_datetime);
+        rtcSetTime(&RTCD1, &new_datetime);
+        return;
+    }
+
+    // If within the DST date range, subtract 1 hour from requested time before storing in RTC.
+    if (hour-- == 0) {
+        hour = 23;
+        if (day-- == 0) {
+            if (month-- == 0) {
+                month = 12;
+                year--;
+            }
+            day = days_per_month(year, month);
+        }
+    }
+
+    // Update day-of-year if date was changed above
+    if (day != new_datetime.day()) {
+        doy = day_of_year(year, month, day);
+        dst_update_date_range(year, doy);
+    }
+
+    // NB: Writing RTC twice takes a second, but ensures that new value can be read back immediately
+    // (if not written twice, the old value will be returned if read back in the following 1-2 seconds)
+    // (you will notice with older Mayhem versions that running the Date/Time Settings app again quickly will show the old time)
+    LPC_RTC->DOY = doy;
+    rtc::RTC adjusted_datetime{year, month, day, hour, new_datetime.minute(), new_datetime.second()};
+    rtcSetTime(&RTCD1, &adjusted_datetime);
+    rtcSetTime(&RTCD1, &adjusted_datetime);
+}
+
+// Calculates 1-based day of year for Nth weekday in month (weekday and n are 0-based, month is 1-based)
+uint16_t day_of_year_of_nth_weekday(uint16_t year, uint8_t month, uint8_t n, uint8_t weekday) {
+    uint8_t w = day_of_week(year, month, 1);
+    uint8_t nn = n;
+
+    // special handling for "last" weekday - are there 4 or 5 in the month?
+    if (n == 4) {
+        if (month == 2) {
+            // February
+            // only weekday w occurs 5 times on the 29th on leap years only
+            if ((weekday != w) || !leap_year(year))
+                nn = 3;
+        } else {
+            // Other months have either 30 or 31 days;
+            // weekdays w and w+1 occur 5 times (on the 29th & 30th); weekday w+2 occurs 5 times only if month has 31 days
+            if ((weekday != w) && (weekday != (w + 1) % 7) &&
+                ((weekday != (w + 2) % 7) || ((months_with_31 & (1 << (month - 1))) == 0)))
+                nn = 3;
+        }
+    }
+    return day_of_year(year, month, 1) + (nn * 7) + weekday + ((weekday < w) ? 7 : 0) - w;
+}
+
+// Calculates 1-based day of year (input month & day are 1-based)
+uint16_t day_of_year(uint16_t year, uint8_t month, uint8_t day) {
+    // 1-based day of year for 1st day or month (index is 1-based month)
+    static uint16_t month_to_day_in_year[13] = {
+        0,  // placeholder for 1-based indexing
+        1,
+        1 + 31,
+        1 + 31 + 28,
+        1 + 31 + 28 + 31,
+        1 + 31 + 28 + 31 + 30,
+        1 + 31 + 28 + 31 + 30 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
+    };
+    return month_to_day_in_year[month] + day - (((month > 2) && leap_year(year)) ? 0 : 1);
+}
+
+bool leap_year(uint16_t year) {
+    // Technically should be: ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)
+    // but year 2100 is a long way off and the LPC43xx RTC doesn't bother handling it either
+    return ((year & 3) == 0);
+}
+
+uint8_t days_per_month(uint16_t year, uint8_t month) {
+    if (month == 2)
+        return leap_year(year) ? 29 : 28;
+    else
+        return ((months_with_31 & (1 << (month - 1))) != 0) ? 31 : 30;
+}
+
+uint8_t current_day_of_week() {
+    rtc::RTC datetime;
+    now(datetime);
+    return day_of_week(datetime.year(), datetime.month(), datetime.day());
+}
+
+// Returns 0-based weekday for date (0=Sunday, 1=Monday, etc) - using Zeller's Congruence formula
+// (month and day are 1-based)
+uint8_t day_of_week(uint16_t year, uint8_t month, uint8_t day) {
+    int m = (month < 3) ? month + 13 : month + 1;
+    int y = (month < 3) ? year - 1 : year;
+    return (day - 1 + (13 * m / 5) + y + (y / 4) - (y / 100) + (y / 400)) % 7;
+}
+
+} /* namespace rtc_time */

--- a/application/rtc_time.hpp
+++ b/application/rtc_time.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __RTC_TIME_H__
+#define __RTC_TIME_H__
+
+#include "signal.hpp"
+
+#include "lpc43xx_cpp.hpp"
+using namespace lpc43xx;
+
+namespace rtc_time {
+
+extern Signal<> signal_tick_second;
+
+void on_tick_second();
+
+/* Sets the current RTCTime in the RTC. */
+void set(rtc::RTC& new_datetime);
+
+/* Returns the current RTCTime from the RTC. */
+rtc::RTC now();
+
+/* Returns the current RTCTime from the RTC. */
+rtc::RTC now(rtc::RTC& out_datetime);
+
+/* Daylight Savings Time functions */
+void dst_init();
+rtc::RTC dst_adjust_returned_time(rtc::RTC& datetime);
+void dst_check_date_range(uint16_t doy);
+void dst_update_date_range(uint16_t year, uint16_t doy);
+uint8_t days_per_month(uint16_t year, uint8_t month);
+uint8_t current_day_of_week();
+uint8_t day_of_week(uint16_t year, uint8_t month, uint8_t day);
+bool leap_year(uint16_t year);
+uint16_t day_of_year(uint16_t year, uint8_t month, uint8_t day);
+uint16_t day_of_year_of_nth_weekday(uint16_t year, uint8_t month, uint8_t n, uint8_t weekday);
+
+} /* namespace rtc_time */
+
+#endif /*__RTC_TIME_H__*/

--- a/application/ui_record_view.cpp
+++ b/application/ui_record_view.cpp
@@ -1,0 +1,358 @@
+/*
+ * Copyright (C) 2016 Jared Boone, ShareBrained Technology, Inc.
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_record_view.hpp"
+
+#include "portapack.hpp"
+using namespace portapack;
+
+#include "io_file.hpp"
+#include "io_wave.hpp"
+#include "io_convert.hpp"
+
+#include "baseband_api.hpp"
+#include "metadata_file.hpp"
+#include "oversample.hpp"
+#include "rtc_time.hpp"
+#include "string_format.hpp"
+#include "utility.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace ui {
+
+/*void RecordView::toggle_pitch_rssi() {
+        pitch_rssi_enabled = !pitch_rssi_enabled;
+
+        // Send to RSSI widget
+        const PitchRSSIConfigureMessage message {
+                pitch_rssi_enabled,
+                0
+        };
+        shared_memory.application_queue.push(message);
+
+        if( !pitch_rssi_enabled ) {
+                button_pitch_rssi.set_foreground(Color::orange());
+        } else {
+                button_pitch_rssi.set_foreground(Color::green());
+        }
+}*/
+
+RecordView::RecordView(
+    const Rect parent_rect,
+    const std::filesystem::path& filename_stem_pattern,
+    const std::filesystem::path& folder,
+    const FileType file_type,
+    const size_t write_size,
+    const size_t buffer_count)
+    : View{parent_rect},
+      filename_stem_pattern{filename_stem_pattern},
+      folder{folder},
+      file_type{file_type},
+      write_size{write_size},
+      buffer_count{buffer_count} {
+    ensure_directory(folder);
+    add_children({
+        &rect_background,
+        //&button_pitch_rssi,
+        &button_record,
+        &text_record_filename,
+        &text_record_dropped,
+        &text_time_available,
+    });
+
+    rect_background.set_parent_rect({{0, 0}, size()});
+
+    /*button_pitch_rssi.on_select = [this](ImageButton&) {
+                this->toggle_pitch_rssi();
+        };*/
+
+    button_record.on_select = [this](ImageButton&) {
+        this->toggle();
+    };
+
+    signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
+        this->on_tick_second();
+    };
+}
+
+RecordView::~RecordView() {
+    rtc_time::signal_tick_second -= signal_token_tick_second;
+}
+
+void RecordView::focus() {
+    button_record.focus();
+}
+
+uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
+    // Determine the oversampling needed (if any) and the actual sampling rate.
+    auto oversample_rate = get_oversample_rate(new_sampling_rate);
+    auto actual_sampling_rate = new_sampling_rate * toUType(oversample_rate);
+
+    // Change the "REC" icon background to yellow when the selected rate exceeds hardware limits.
+    // Above this threshold, samples will be dropped resulting incomplete capture files.
+    if (new_sampling_rate > 1'250'000) {
+        button_record.set_background(ui::Color::yellow());
+    } else {
+        button_record.set_background(ui::Color::black());
+    }
+
+    if (sampling_rate != new_sampling_rate) {
+        stop();
+
+        sampling_rate = new_sampling_rate;
+        baseband::set_sample_rate(sampling_rate, oversample_rate);
+
+        button_record.hidden(sampling_rate == 0);
+        text_record_filename.hidden(sampling_rate == 0);
+        text_record_dropped.hidden(sampling_rate == 0);
+        text_time_available.hidden(sampling_rate == 0);
+        rect_background.hidden(sampling_rate != 0);
+
+        update_status_display();
+    }
+
+    return actual_sampling_rate;
+}
+
+OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
+    // No oversampling necessary for baseband audio processors.
+    if (file_type == FileType::WAV)
+        return OversampleRate::None;
+
+    return ::get_oversample_rate(sample_rate);
+}
+
+// Setter for datetime and frequency filename
+void RecordView::set_filename_date_frequency(bool set) {
+    filename_date_frequency = set;
+    if (set)
+        filename_as_is = false;
+}
+
+// Setter for leaving the filename untouched
+void RecordView::set_filename_as_is(bool set) {
+    filename_as_is = set;
+    if (set)
+        filename_date_frequency = false;
+}
+
+bool RecordView::is_active() const {
+    return (bool)capture_thread;
+}
+
+void RecordView::toggle() {
+    if (is_active()) {
+        stop();
+    } else {
+        start();
+    }
+}
+
+void RecordView::start() {
+    stop();
+
+    text_record_filename.set("");
+    text_record_dropped.set("");
+    trim_path = {};
+
+    if (sampling_rate == 0) {
+        return;
+    }
+
+    std::filesystem::path base_path;
+    if (filename_date_frequency) {
+        rtc_time::now(datetime);
+
+        // ISO 8601
+        std::string date_time =
+            to_string_dec_uint(datetime.year(), 4, '0') +
+            to_string_dec_uint(datetime.month(), 2, '0') +
+            to_string_dec_uint(datetime.day(), 2, '0') + "T" +
+            to_string_dec_uint(datetime.hour()) +
+            to_string_dec_uint(datetime.minute()) +
+            to_string_dec_uint(datetime.second());
+
+        base_path = filename_stem_pattern.string() + "_" + date_time + "_" +
+                    trim(to_string_freq(receiver_model.target_frequency())) + "Hz";
+        base_path = folder / base_path;
+    } else if (filename_as_is) {
+        base_path = filename_stem_pattern.string();
+        base_path = folder / base_path;
+    } else
+        base_path = next_filename_matching_pattern(folder / filename_stem_pattern);
+
+    if (base_path.empty()) {
+        return;
+    }
+
+    std::unique_ptr<stream::Writer> writer;
+    switch (file_type) {
+        case FileType::WAV: {
+            auto p = std::make_unique<WAVFileWriter>();
+            auto create_error = p->create(
+                base_path.replace_extension(u".WAV"),
+                sampling_rate,
+                to_string_dec_uint(receiver_model.target_frequency()) + "Hz");
+            if (create_error.is_valid()) {
+                handle_error(create_error.value());
+            } else {
+                writer = std::move(p);
+            }
+        } break;
+
+        case FileType::RawS8:
+        case FileType::RawS16: {
+            const auto metadata_file_error = write_metadata_file(
+                get_metadata_path(base_path), {receiver_model.target_frequency(), sampling_rate});
+            if (metadata_file_error.is_valid()) {
+                handle_error(metadata_file_error.value());
+                return;
+            }
+
+            auto p = std::make_unique<FileConvertWriter>();
+            trim_path = base_path.replace_extension((file_type == FileType::RawS8) ? u".C8" : u".C16");
+            auto create_error = p->create(trim_path);
+            if (create_error.is_valid()) {
+                handle_error(create_error.value());
+            } else {
+                writer = std::move(p);
+            }
+        } break;
+
+        default:
+            break;
+    };
+
+    if (writer) {
+        text_record_filename.set(truncate(base_path.filename().string(), 8));
+        button_record.set_bitmap(&bitmap_stop);
+        capture_thread = std::make_unique<CaptureThread>(
+            std::move(writer),
+            write_size, buffer_count,
+            []() {
+                CaptureThreadDoneMessage message{};
+                EventDispatcher::send_message(message);
+            },
+            [](File::Error error) {
+                CaptureThreadDoneMessage message{error.code()};
+                EventDispatcher::send_message(message);
+            });
+    }
+
+    update_status_display();
+}
+
+void RecordView::on_hide() {
+    stop();  // Stop current recording
+    View::on_hide();
+}
+
+void RecordView::stop() {
+    if (is_active()) {
+        capture_thread.reset();
+        button_record.set_bitmap(&bitmap_record);
+        trim_capture();
+    }
+
+    update_status_display();
+}
+
+void RecordView::on_tick_second() {
+    update_status_display();
+}
+
+void RecordView::update_status_display() {
+    if (is_active()) {
+        const auto dropped_percent = std::min(99U, capture_thread->state().dropped_percent());
+        const auto s = to_string_dec_uint(dropped_percent, 2, ' ') + "%";
+        text_record_dropped.set(s);
+    }
+
+    /*
+    if (pitch_rssi_enabled) {
+        button_pitch_rssi.invert_colors();
+    }
+    */
+
+    if (sampling_rate > 0) {
+        const auto space_info = std::filesystem::space(u"");
+        // - Audio is 1 int16_t per sample or '2' bytes per sample.
+        // - C8 captures 2 (I,Q) int8_t per sample or '2' bytes per sample.
+        // - C16 captures 2 (I,Q) int16_t per sample or '4' bytes per sample.
+        const auto bytes_per_sample = file_type == FileType::RawS16 ? 4 : 2;
+        const uint32_t bytes_per_second = sampling_rate * bytes_per_sample;
+        const uint32_t available_seconds = space_info.free / bytes_per_second;
+        const uint32_t seconds = available_seconds % 60;
+        const uint32_t available_minutes = available_seconds / 60;
+        const uint32_t minutes = available_minutes % 60;
+        const uint32_t hours = available_minutes / 60;
+        const std::string available_time =
+            to_string_dec_uint(hours, 3, ' ') + ":" +
+            to_string_dec_uint(minutes, 2, '0') + ":" +
+            to_string_dec_uint(seconds, 2, '0');
+        text_time_available.set(available_time);
+    }
+}
+
+void RecordView::trim_capture() {
+    using bucket_t = iq::PowerBuckets::Bucket;
+
+    if (file_type != FileType::WAV && auto_trim && !trim_path.empty()) {
+        // Need to heap alloc the buckets in this case. The large static buffer overflows the stack.
+        std::vector<bucket_t> buckets(size_t(255), bucket_t{});
+        ;
+        iq::PowerBuckets power_buckets{
+            .p = &buckets[0],
+            .size = buckets.size()};
+
+        trim_ui.show_reading();
+        auto info = iq::profile_capture(trim_path, power_buckets);
+
+        if (info) {
+            // 7% - decent trimming without being too aggressive.
+            auto trim_range = iq::compute_trim_range(*info, power_buckets, 7);
+
+            trim_ui.show_trimming();
+            iq::trim_capture_with_range(trim_path, trim_range, trim_ui.get_callback(), 1);
+        }
+
+        trim_ui.clear();
+    }
+
+    trim_path = {};
+}
+
+void RecordView::handle_capture_thread_done(const File::Error error) {
+    stop();
+    if (error.code()) {
+        handle_error(error);
+    }
+}
+
+void RecordView::handle_error(const File::Error error) {
+    if (on_error) {
+        on_error(error.what());
+    }
+}
+
+} /* namespace ui */

--- a/application/usb_serial_shell.cpp
+++ b/application/usb_serial_shell.cpp
@@ -1,0 +1,1083 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "usb_serial_shell.hpp"
+#include "event_m0.hpp"
+#include "baseband_api.hpp"
+#include "core_control.hpp"
+#include "bitmap.hpp"
+#include "png_writer.hpp"
+#include "irq_controls.hpp"
+
+#include "portapack.hpp"
+#include "portapack_hal.hpp"
+#include "hackrf_gpio.hpp"
+#include "jtag_target_gpio.hpp"
+#include "cpld_max5.hpp"
+#include "portapack_cpld_data.hpp"
+#include "crc.hpp"
+#include "hackrf_cpld_data.hpp"
+#include "performance_counter.hpp"
+
+#include "usb_serial_device_to_host.h"
+#include "chprintf.h"
+#include "chqueues.h"
+#include "ui_external_items_menu_loader.hpp"
+#include "untar.hpp"
+#include "ui_widget.hpp"
+
+#include "ui_navigation.hpp"
+#include "usb_serial_shell_filesystem.hpp"
+
+#include "portapack_persistent_memory.hpp"
+
+#include <string>
+#include <cstring>
+#include <libopencm3/lpc43xx/wwdt.h>
+
+#define SHELL_WA_SIZE THD_WA_SIZE(1024 * 3)
+#define palOutputPad(port, pad) (LPC_GPIO->DIR[(port)] |= 1 << (pad))
+
+static EventDispatcher* _eventDispatcherInstance = NULL;
+static EventDispatcher* getEventDispatcherInstance() {
+    return _eventDispatcherInstance;
+}
+
+static void cmd_reboot(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)chp;
+    (void)argc;
+    (void)argv;
+
+    m4_request_shutdown();
+    chThdSleepMilliseconds(50);
+
+    LPC_RGU->RESET_CTRL[0] = (1 << 0);
+}
+
+static void cmd_dfu(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)chp;
+    (void)argc;
+    (void)argv;
+
+    m4_request_shutdown();
+    chThdSleepMilliseconds(50);
+
+    LPC_SCU->SFSP2_8 = (LPC_SCU->SFSP2_8 & ~(7)) | 4;
+    palOutputPad(5, 7);
+    palSetPad(5, 7);
+
+    LPC_RGU->RESET_CTRL[0] = (1 << 0);
+}
+
+static void cmd_hackrf(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)chp;
+    (void)argc;
+    (void)argv;
+
+    m4_request_shutdown();
+    chThdSleepMilliseconds(50);
+    EventDispatcher::request_stop();
+}
+
+static void cmd_sd_over_usb(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)chp;
+    (void)argc;
+    (void)argv;
+
+    ui::Painter painter;
+    painter.fill_rectangle(
+        {0, 0, portapack::display.width(), portapack::display.height()},
+        ui::Color::black());
+
+    painter.draw_bitmap(
+        {portapack::display.width() / 2 - 8, portapack::display.height() / 2 - 8},
+        ui::bitmap_icon_hackrf,
+        ui::Color::yellow(),
+        ui::Color::black());
+
+    sdcDisconnect(&SDCD1);
+    sdcStop(&SDCD1);
+
+    m4_request_shutdown();
+    chThdSleepMilliseconds(50);
+    portapack::shutdown(true);
+    m4_init(portapack::spi_flash::image_tag_usb_sd, portapack::memory::map::m4_code, false);
+    m0_halt();
+}
+
+bool strEndsWith(const std::u16string& str, const std::u16string& suffix) {
+    if (str.length() >= suffix.length()) {
+        std::u16string endOfString = str.substr(str.length() - suffix.length());
+        return endOfString == suffix;
+    } else {
+        return false;
+    }
+}
+
+static void cmd_flash(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 1) {
+        chprintf(chp, "Usage: flash /FIRMWARE/portapack-h1_h2-mayhem.bin\r\n");
+        return;
+    }
+
+    auto path = path_from_string8(argv[0]);
+
+    if (!std::filesystem::file_exists(path)) {
+        chprintf(chp, "file not found.\r\n");
+        return;
+    }
+
+    auto evtd = getEventDispatcherInstance();
+    if (!evtd) return;
+    auto top_widget = evtd->getTopWidget();
+    if (!top_widget) return;
+    auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
+    if (!nav) return;
+    nav->display_modal("Flashing", "Flashing from serial.\r\nPlease wait!\r\nDevice will restart.");
+    // check file extensions
+    if (strEndsWith(path.native(), u".ppfw.tar")) {
+        // extract tar
+        chprintf(chp, "Extracting TAR file.\r\n");
+        auto res = UnTar::untar(
+            path.native(), [chp](const std::string fileName) {
+                chprintf(chp, fileName.c_str());
+                chprintf(chp, "\r\n");
+            });
+        if (res.empty()) {
+            chprintf(chp, "error bad TAR file.\r\n");
+            nav->pop();
+            return;
+        }
+        path = res;  // it will contain the last bin file in tar
+    } else if (strEndsWith(path.native(), u".bin")) {
+        // nothing to do for this case yet.
+    } else {
+        chprintf(chp, "error only .bin or .ppfw.tar files canbe flashed.\r\n");
+        nav->pop();
+        return;
+    }
+
+    chprintf(chp, "Flashing: ");
+    chprintf(chp, path.string().c_str());
+    chprintf(chp, "\r\n");
+    chThdSleepMilliseconds(50);
+    std::memcpy(&shared_memory.bb_data.data[0], path.native().c_str(), (path.native().length() + 1) * 2);
+    m4_request_shutdown();
+    chThdSleepMilliseconds(50);
+    m4_init(portapack::spi_flash::image_tag_flash_utility, portapack::memory::map::m4_code, false);
+    m0_halt();
+}
+
+static void cmd_screenshot(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    ensure_directory("SCREENSHOTS");
+    auto path = next_filename_matching_pattern(u"SCREENSHOTS/SCR_????.PNG");
+
+    if (path.empty())
+        return;
+
+    PNGWriter png;
+    auto error = png.create(path);
+    if (error)
+        return;
+
+    for (int i = 0; i < ui::screen_height; i++) {
+        std::array<ui::ColorRGB888, ui::screen_width> row;
+        portapack::display.read_pixels({0, i, ui::screen_width, 1}, row);
+        png.write_scanline(row);
+    }
+
+    chprintf(chp, "generated %s\r\n", path.string().c_str());
+}
+
+// gives full color.
+static void cmd_screenframe(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    auto evtd = getEventDispatcherInstance();
+    evtd->enter_shell_working_mode();
+
+    for (int i = 0; i < ui::screen_height; i++) {
+        std::array<ui::ColorRGB888, ui::screen_width> row;
+        portapack::display.read_pixels({0, i, ui::screen_width, 1}, row);
+        for (int px = 0; px < ui::screen_width; px += 5) {
+            char buffer[5 * 3 * 2];
+            sprintf(buffer, "%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", row[px].r, row[px].g, row[px].b, row[px + 1].r, row[px + 1].g, row[px + 1].b, row[px + 2].r, row[px + 2].g, row[px + 2].b, row[px + 3].r, row[px + 3].g, row[px + 3].b, row[px + 4].r, row[px + 4].g, row[px + 4].b);
+            fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)buffer, 5 * 3 * 2);
+        }
+        chprintf(chp, "\r\n");
+    }
+
+    evtd->exit_shell_working_mode();
+
+    chprintf(chp, "ok\r\n");
+}
+
+static char getChrFromRgb(uint8_t r, uint8_t g, uint8_t b) {
+    uint8_t chR = r >> 6;  // 3bit
+    uint8_t chG = g >> 6;  // 3bit
+    uint8_t chB = b >> 6;  // 3bit
+    uint8_t res = chR << 4 | chG << 2 | chB;
+    res += 32;
+    return res;
+}
+
+// sends only 1 byte (printable only) per pixel, so around 96 colors
+static void cmd_screenframeshort(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    auto evtd = getEventDispatcherInstance();
+    evtd->enter_shell_working_mode();
+
+    for (int y = 0; y < ui::screen_height; y++) {
+        std::array<ui::ColorRGB888, ui::screen_width> row;
+        portapack::display.read_pixels({0, y, ui::screen_width, 1}, row);
+        char buffer[242];
+        for (int i = 0; i < 240; ++i) {
+            buffer[i] = getChrFromRgb(row[i].r, row[i].g, row[i].b);
+        }
+        buffer[240] = '\r';
+        buffer[241] = '\n';
+        fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)buffer, 242);
+    }
+
+    evtd->exit_shell_working_mode();
+    chprintf(chp, "\r\nok\r\n");
+}
+
+static void cmd_write_memory(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 2) {
+        chprintf(chp, "usage: write_memory <address> <value (1 or 4 bytes)>\r\n");
+        chprintf(chp, "example: write_memory 0x40004008 0x00000002\r\n");
+        return;
+    }
+
+    int value_length = strlen(argv[1]);
+    if (value_length != 10 && value_length != 4) {
+        chprintf(chp, "usage: write_memory <address> <value (1 or 4 bytes)>\r\n");
+        chprintf(chp, "example: write_memory 0x40004008 0x00000002\r\n");
+        return;
+    }
+
+    uint32_t address = (uint32_t)strtol(argv[0], NULL, 16);
+    uint32_t value = (uint32_t)strtol(argv[1], NULL, 16);
+
+    if (value_length == 10) {
+        uint32_t* data_pointer = (uint32_t*)address;
+        *data_pointer = value;
+    } else {
+        uint8_t* data_pointer = (uint8_t*)address;
+        *data_pointer = (uint8_t)value;
+    }
+
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_read_memory(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 1) {
+        chprintf(chp, "usage: read_memory 0x40004008\r\n");
+        return;
+    }
+
+    int address = (int)strtol(argv[0], NULL, 16);
+    uint32_t* data_pointer = (uint32_t*)address;
+
+    chprintf(chp, "%x\r\n", *data_pointer);
+}
+
+static void cmd_button(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 1) {
+        chprintf(chp, "usage: button 1\r\n");
+        return;
+    }
+
+    int button = (int)strtol(argv[0], NULL, 10);
+    if (button < 1 || button > 8) {
+        chprintf(chp, "usage: button <number 1 to 8>\r\n");
+        return;
+    }
+
+    control::debug::inject_switch(button);
+
+    // Wait two frame syncs to ensure action has painted
+    auto evtd = getEventDispatcherInstance();
+    evtd->wait_finish_frame();
+    evtd->wait_finish_frame();
+
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_touch(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 2) {
+        chprintf(chp, "usage: touch x y\r\n");
+        return;
+    }
+
+    int x = (int)strtol(argv[0], NULL, 10);
+    int y = (int)strtol(argv[1], NULL, 10);
+    if (x < 0 || x > ui::screen_width || y < 0 || y > ui::screen_height) {
+        chprintf(chp, "usage: touch x y\r\n");
+        return;
+    }
+
+    auto evtd = getEventDispatcherInstance();
+    if (evtd == NULL) {
+        chprintf(chp, "error\r\n");
+    }
+    evtd->emulateTouch({{x, y}, ui::TouchEvent::Type::Start});
+    evtd->emulateTouch({{x, y}, ui::TouchEvent::Type::End});
+
+    // Wait two frame syncs to ensure action has painted
+    evtd->wait_finish_frame();
+    evtd->wait_finish_frame();
+
+    chprintf(chp, "ok\r\n");
+}
+
+// send ascii keys in 2 char hex representation. Can send multiple keys at once like: keyboard 414243 (this will be ABC)
+static void cmd_keyboard(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 1) {
+        chprintf(chp, "usage: keyboard XX\r\n");
+        return;
+    }
+
+    auto evtd = getEventDispatcherInstance();
+    if (evtd == NULL) {
+        chprintf(chp, "error\r\n");
+    }
+
+    size_t data_string_len = strlen(argv[0]);
+    if (data_string_len % 2 != 0) {
+        chprintf(chp, "usage: keyboard XXXX\r\n");
+        return;
+    }
+
+    for (size_t i = 0; i < data_string_len; i++) {
+        char c = argv[0][i];
+        if ((c < '0' || c > '9') && (c < 'A' || c > 'F')) {
+            chprintf(chp, "usage: keyboard XX\r\n");
+            return;
+        }
+    }
+
+    char buffer[3] = {0, 0, 0};
+
+    for (size_t i = 0; i < data_string_len / 2; i++) {
+        buffer[0] = argv[0][i * 2];
+        buffer[1] = argv[0][i * 2 + 1];
+        uint8_t chr = (uint8_t)strtol(buffer, NULL, 16);
+        evtd->emulateKeyboard(chr);
+    }
+
+    // Wait two frame syncs to ensure action has painted
+    evtd->wait_finish_frame();
+    evtd->wait_finish_frame();
+
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_rtcget(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)chp;
+    (void)argc;
+    (void)argv;
+
+    rtc::RTC datetime;
+    rtc_time::now(datetime);
+
+    chprintf(chp, "Current time: %04d-%02d-%02d %02d:%02d:%02d\r\n", datetime.year(), datetime.month(), datetime.day(), datetime.hour(), datetime.minute(), datetime.second());
+}
+
+static void cmd_rtcset(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage =
+        "usage: rtcset [year] [month] [day] [hour] [minute] [second]\r\n"
+        "  all fields are required; milliseconds zero when set\r\n"
+        "  (fractional seconds are not supported)\r\n";
+
+    if (argc != 6) {
+        chprintf(chp, usage);
+        return;
+    }
+
+    // TODO: additional commands/parameters for DST?
+    rtc::RTC new_datetime{
+        (uint16_t)strtol(argv[0], NULL, 10), (uint8_t)strtol(argv[1], NULL, 10),
+        (uint8_t)strtol(argv[2], NULL, 10), (uint32_t)strtol(argv[3], NULL, 10),
+        (uint32_t)strtol(argv[4], NULL, 10), (uint32_t)strtol(argv[5], NULL, 10)};
+    rtc_time::set(new_datetime);
+
+    chprintf(chp, "ok\r\n");
+}
+
+static void cpld_info(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage =
+        "usage: cpld_info <device>\r\n"
+        "  supported modes:\r\n"
+        "    cpld_info hackrf\r\n"
+        "    cpld_info portapack\r\n";
+    if (argc != 1) {
+        chprintf(chp, usage);
+        return;
+    }
+
+    if (strncmp(argv[0], "hackrf", 5) == 0) {
+        jtag::GPIOTarget jtag_target_hackrf_cpld{
+            hackrf::one::gpio_cpld_tck,
+            hackrf::one::gpio_cpld_tms,
+            hackrf::one::gpio_cpld_tdi,
+            hackrf::one::gpio_cpld_tdo,
+        };
+
+        hackrf::one::cpld::CPLD hackrf_cpld{jtag_target_hackrf_cpld};
+        {
+            CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+
+            hackrf_cpld.prepare_read_eeprom();
+
+            for (const auto& block : hackrf::one::cpld::verify_blocks) {
+                auto from_device = hackrf_cpld.read_block_eeprom(block.id);
+
+                for (std::array<bool, 274UL>::reverse_iterator i = from_device.rbegin(); i != from_device.rend(); ++i) {
+                    auto bit = *i;
+                    crc.process_bit(bit);
+                }
+            }
+
+            hackrf_cpld.finalize_read_eeprom();
+            chprintf(chp, "CPLD eeprom firmware checksum: 0x%08X\r\n", crc.checksum());
+        }
+
+        {
+            CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+
+            hackrf_cpld.prepare_read_sram();
+
+            for (const auto& block : hackrf::one::cpld::verify_blocks) {
+                auto from_device = hackrf_cpld.read_block_sram(block);
+
+                for (std::array<bool, 274UL>::reverse_iterator i = from_device.rbegin(); i != from_device.rend(); ++i) {
+                    auto bit = *i;
+                    crc.process_bit(bit);
+                }
+            }
+
+            hackrf_cpld.finalize_read_sram(hackrf::one::cpld::verify_blocks[0].id);
+            chprintf(chp, "CPLD sram firmware checksum: 0x%08X\r\n", crc.checksum());
+        }
+
+    } else if (strncmp(argv[0], "portapack", 5) == 0) {
+        jtag::GPIOTarget target{
+            portapack::gpio_cpld_tck,
+            portapack::gpio_cpld_tms,
+            portapack::gpio_cpld_tdi,
+            portapack::gpio_cpld_tdo};
+        jtag::JTAG jtag{target};
+        portapack::cpld::CPLD cpld{jtag};
+
+        cpld.reset();
+        cpld.run_test_idle();
+        uint32_t idcode = cpld.get_idcode();
+
+        chprintf(chp, "CPLD IDCODE: 0x%08X\r\n", idcode);
+
+        if (idcode == 0x20A50DD) {
+            chprintf(chp, "CPLD Model: Altera MAX V 5M40Z\r\n");
+            cpld.reset();
+            cpld.run_test_idle();
+            cpld.sample();
+            cpld.bypass();
+            cpld.enable();
+
+            CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+            cpld.prepare_read(0x0000);
+
+            for (size_t i = 0; i < 3328; i++) {
+                uint16_t data = cpld.read();
+                crc.process_byte((data >> 0) & 0xff);
+                crc.process_byte((data >> 8) & 0xff);
+                crc.process_byte((data >> 16) & 0xff);
+                crc.process_byte((data >> 24) & 0xff);
+            }
+
+            cpld.prepare_read(0x0001);
+
+            for (size_t i = 0; i < 512; i++) {
+                uint16_t data = cpld.read();
+                crc.process_byte((data >> 0) & 0xff);
+                crc.process_byte((data >> 8) & 0xff);
+                crc.process_byte((data >> 16) & 0xff);
+                crc.process_byte((data >> 24) & 0xff);
+            }
+
+            chprintf(chp, "CPLD firmware checksum: 0x%08X\r\n", crc.checksum());
+
+            m4_request_shutdown();
+            chThdSleepMilliseconds(1000);
+
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
+
+        } else if (idcode == 0x00025610) {
+            chprintf(chp, "CPLD Model: AGM AG256SL100\r\n");
+
+            if (cpld.AGM_enter_maintenance_mode() == false) {
+                return;
+            }
+
+            cpld.AGM_enter_read_mode();
+
+            CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+            for (size_t i = 0; i < 2048; i++) {
+                uint32_t data = cpld.AGM_read(i);
+                crc.process_byte((data >> 0) & 0xff);
+                crc.process_byte((data >> 8) & 0xff);
+                crc.process_byte((data >> 16) & 0xff);
+                crc.process_byte((data >> 24) & 0xff);
+            }
+
+            cpld.AGM_exit_maintenance_mode();
+
+            chprintf(chp, "CPLD firmware checksum: 0x%08X\r\n", crc.checksum());
+
+            m4_request_shutdown();
+            chThdSleepMilliseconds(1000);
+
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
+
+        } else {
+            chprintf(chp, "CPLD Model: unknown\r\n");
+        }
+
+    } else {
+        chprintf(chp, usage);
+    }
+}
+
+// walks throught the given widget's childs in recurse to get all support text and pass it to a callback function
+static void widget_collect_accessibility(BaseSequentialStream* chp, ui::Widget* w, void (*callback)(BaseSequentialStream*, const std::string&, const std::string&), ui::Widget* focusedWidget) {
+    for (auto child : w->children()) {
+        if (!child->hidden()) {
+            std::string res = "";
+            child->getAccessibilityText(res);
+            std::string strtype = "";
+            child->getWidgetName(strtype);
+            if (child == focusedWidget) strtype += "*";
+            if (callback != NULL && !res.empty()) callback(chp, res, strtype);
+            widget_collect_accessibility(chp, child, callback, focusedWidget);
+        }
+    }
+}
+
+// callback when it found any response from a widget
+static void accessibility_callback(BaseSequentialStream* chp, const std::string& strResult, const std::string& wgType) {
+    if (!wgType.empty()) {
+        chprintf(chp, "[");
+        chprintf(chp, wgType.c_str());
+        chprintf(chp, "] ");
+    }
+    chprintf(chp, "%s\r\n", strResult.c_str());
+}
+
+// gets all widget's accessibility helper text
+static void cmd_accessibility_readall(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    auto evtd = getEventDispatcherInstance();
+    if (evtd == NULL) {
+        chprintf(chp, "error Can't get Event Dispatcherr\n");
+        return;
+    }
+    auto wg = evtd->getTopWidget();
+    if (wg == NULL) {
+        chprintf(chp, "error Can't get top Widget\r\n");
+        return;
+    }
+    auto focused = evtd->getFocusedWidget();
+    widget_collect_accessibility(chp, wg, accessibility_callback, focused);
+    chprintf(chp, "ok\r\n");
+}
+
+// gets focused widget's accessibility helper text
+static void cmd_accessibility_readcurr(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    auto evtd = getEventDispatcherInstance();
+    if (evtd == NULL) {
+        chprintf(chp, "error Can't get Event Dispatcher\r\n");
+        return;
+    }
+    auto wg = evtd->getFocusedWidget();
+    if (wg == NULL) {
+        chprintf(chp, "error Can't get focused Widget\r\n");
+        return;
+    }
+    std::string res = "";
+    wg->getAccessibilityText(res);
+    if (res.empty()) {
+        // try with parent
+        wg = wg->parent();
+        if (wg == NULL) {
+            chprintf(chp, "error Widget not providing accessibility info\r\n");
+            return;
+        }
+        wg->getAccessibilityText(res);
+        if (res.empty()) {
+            chprintf(chp, "error Widget not providing accessibility info\r\n");
+            return;
+        }
+    }
+    std::string strtype = "";
+    wg->getWidgetName(strtype);
+    accessibility_callback(chp, res, strtype);
+    chprintf(chp, "\r\nok\r\n");
+}
+
+static void cmd_appstart(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+    if (argc != 1) {
+        chprintf(chp, "Usage: appstart APPCALLNAME");
+        return;
+    }
+    auto evtd = getEventDispatcherInstance();
+    if (!evtd) return;
+    auto top_widget = evtd->getTopWidget();
+    if (!top_widget) return;
+    auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
+    if (!nav) return;
+    if (nav->StartAppByName(argv[0])) {
+        chprintf(chp, "ok\r\n");
+        return;
+    }
+    // since ext app loader changed, we can just pass the string to it, and it"ll return if started or not.
+    std::string appwithpath = "/APPS/";
+    appwithpath += argv[0];
+    appwithpath += ".ppma";
+    bool ret = ui::ExternalItemsMenuLoader::run_external_app(*nav, path_from_string8((char*)appwithpath.c_str()));
+    if (!ret) {
+        chprintf(chp, "error\r\n");
+        return;
+    }
+    chprintf(chp, "ok\r\n");
+}
+
+static void printAppInfo(BaseSequentialStream* chp, ui::AppInfoConsole& element) {
+    if (strlen(element.appCallName) == 0) return;
+    chprintf(chp, element.appCallName);
+    chprintf(chp, " ");
+    chprintf(chp, element.appFriendlyName);
+    chprintf(chp, " ");
+    switch (element.appLocation) {
+        case RX:
+            chprintf(chp, "[RX]\r\n");
+            break;
+        case TX:
+            chprintf(chp, "[TX]\r\n");
+            break;
+        case UTILITIES:
+            chprintf(chp, "[UTIL]\r\n");
+            break;
+        case DEBUG:
+            chprintf(chp, "[DEBUG]\r\n");
+            break;
+        default:
+            break;
+    }
+}
+
+static void printAppInfo(BaseSequentialStream* chp, const ui::AppInfo& element) {
+    if (strlen(element.id) == 0) return;
+    chprintf(chp, element.id);
+    chprintf(chp, " ");
+    chprintf(chp, element.displayName);
+    chprintf(chp, " ");
+    switch (element.menuLocation) {
+        case RX:
+            chprintf(chp, "[RX]\r\n");
+            break;
+        case TX:
+            chprintf(chp, "[TX]\r\n");
+            break;
+        case UTILITIES:
+            chprintf(chp, "[UTIL]\r\n");
+            break;
+        case DEBUG:
+            chprintf(chp, "[DEBUG]\r\n");
+            break;
+        default:
+            break;
+    }
+}
+
+// returns the installed apps, those can be called by appstart APPNAME
+static void cmd_applist(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+    auto evtd = getEventDispatcherInstance();
+    if (!evtd) return;
+    auto top_widget = evtd->getTopWidget();
+    if (!top_widget) return;
+    auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
+    if (!nav) return;
+    // TODO(u-foka): Somehow order static and dynamic app lists together
+    for (auto& element : ui::NavigationView::appMap) {  // Use the map as its ordered by id
+        printAppInfo(chp, element.second);
+    }
+    ui::ExternalItemsMenuLoader::load_all_external_items_callback([chp](ui::AppInfoConsole& info) {
+        printAppInfo(chp, info);
+    });
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_cpld_read(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage =
+        "usage: cpld_read <device> <target>\r\n"
+        "  device can be: hackrf, portapack\r\n"
+        "  target can be: sram (hackrf only), eeprom\r\n";
+
+    if (argc != 2) {
+        chprintf(chp, usage);
+        return;
+    }
+
+    if (strncmp(argv[0], "hackrf", 5) == 0) {
+        if (strncmp(argv[1], "eeprom", 5) == 0) {
+            jtag::GPIOTarget jtag_target_hackrf_cpld{
+                hackrf::one::gpio_cpld_tck,
+                hackrf::one::gpio_cpld_tms,
+                hackrf::one::gpio_cpld_tdi,
+                hackrf::one::gpio_cpld_tdo,
+            };
+
+            hackrf::one::cpld::CPLD hackrf_cpld{jtag_target_hackrf_cpld};
+
+            hackrf_cpld.prepare_read_eeprom();
+
+            for (const auto& block : hackrf::one::cpld::verify_blocks) {
+                auto from_device = hackrf_cpld.read_block_eeprom(block.id);
+
+                chprintf(chp, "bank %04X: ", block.id);
+                uint32_t n = 6;
+                uint8_t byte = 0;
+                for (std::array<bool, 274UL>::reverse_iterator i = from_device.rbegin(); i != from_device.rend(); ++i) {
+                    auto bit = *i;
+                    byte |= bit << (7 - (n % 8));
+                    if (n % 8 == 7) {
+                        chprintf(chp, "%02X ", byte);
+                        byte = 0;
+                    }
+                    n++;
+                }
+                chprintf(chp, "\r\n");
+            }
+
+            hackrf_cpld.finalize_read_eeprom();
+        }
+
+        else if (strncmp(argv[1], "sram", 5) == 0) {
+            jtag::GPIOTarget jtag_target_hackrf_cpld{
+                hackrf::one::gpio_cpld_tck,
+                hackrf::one::gpio_cpld_tms,
+                hackrf::one::gpio_cpld_tdi,
+                hackrf::one::gpio_cpld_tdo,
+            };
+
+            hackrf::one::cpld::CPLD hackrf_cpld{jtag_target_hackrf_cpld};
+
+            hackrf_cpld.prepare_read_sram();
+
+            for (const auto& block : hackrf::one::cpld::verify_blocks) {
+                auto from_device = hackrf_cpld.read_block_sram(block);
+
+                chprintf(chp, "bank %04X: ", block.id);
+                uint32_t n = 6;
+                uint8_t byte = 0;
+                for (std::array<bool, 274UL>::reverse_iterator i = from_device.rbegin(); i != from_device.rend(); ++i) {
+                    auto bit = *i;
+                    byte |= bit << (7 - (n % 8));
+                    if (n % 8 == 7) {
+                        chprintf(chp, "%02X ", byte);
+                        byte = 0;
+                    }
+                    n++;
+                }
+                chprintf(chp, "\r\n");
+            }
+
+            hackrf_cpld.finalize_read_sram(hackrf::one::cpld::verify_blocks[0].id);
+        }
+    } else if (strncmp(argv[0], "portapack", 5) == 0) {
+        jtag::GPIOTarget target{
+            portapack::gpio_cpld_tck,
+            portapack::gpio_cpld_tms,
+            portapack::gpio_cpld_tdi,
+            portapack::gpio_cpld_tdo};
+        jtag::JTAG jtag{target};
+        portapack::cpld::CPLD cpld{jtag};
+
+        cpld.reset();
+        cpld.run_test_idle();
+        uint32_t idcode = cpld.get_idcode();
+
+        chprintf(chp, "CPLD IDCODE: 0x%08X\r\n", idcode);
+
+        if (idcode == 0x20A50DD) {
+            chprintf(chp, "CPLD Model: Altera MAX V 5M40Z\r\n");
+            cpld.reset();
+            cpld.run_test_idle();
+            cpld.sample();
+            cpld.bypass();
+            cpld.enable();
+
+            cpld.prepare_read(0x0000);
+
+            for (size_t i = 0; i < 3328; i++) {
+                uint16_t data = cpld.read();
+                chprintf(chp, "%d: 0x%04X\r\n", i, data);
+            }
+
+            cpld.prepare_read(0x0001);
+
+            for (size_t i = 0; i < 512; i++) {
+                uint16_t data = cpld.read();
+                chprintf(chp, "%d: 0x%04X\r\n", i, data);
+            }
+
+            m4_request_shutdown();
+            chThdSleepMilliseconds(1000);
+
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
+
+        } else if (idcode == 0x00025610) {
+            chprintf(chp, "CPLD Model: AGM AG256SL100\r\n");
+
+            if (cpld.AGM_enter_maintenance_mode() == false) {
+                return;
+            }
+
+            cpld.AGM_enter_read_mode();
+
+            for (size_t i = 0; i < 2048; i++) {
+                uint32_t data = cpld.AGM_read(i);
+                if (i % 4 == 0)
+                    chprintf(chp, "%5d: ", i * 4);
+
+                chprintf(chp, "0x%08X", data);
+
+                if (i % 4 == 3)
+                    chprintf(chp, "\r\n");
+                else
+                    chprintf(chp, " ");
+            }
+
+            cpld.AGM_exit_maintenance_mode();
+
+            m4_request_shutdown();
+            chThdSleepMilliseconds(1000);
+
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
+
+        } else {
+            chprintf(chp, "CPLD Model: unknown\r\n");
+        }
+
+    } else {
+        chprintf(chp, usage);
+    }
+}
+
+static void cmd_gotgps(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: gotgps <lat> <lon> [altitude] [speed]\r\n";
+    if (argc < 2 || argc > 4) {
+        chprintf(chp, usage);
+        return;
+    }
+    float lat = atof(argv[0]);
+    float lon = atof(argv[1]);
+    int32_t altitude = 0;
+    int32_t speed = 0;
+    if (argc >= 3) altitude = strtol(argv[2], NULL, 10);
+    if (argc >= 4) speed = strtol(argv[3], NULL, 10);
+    GPSPosDataMessage msg{lat, lon, altitude, speed};
+    EventDispatcher::send_message(msg);
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_gotorientation(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: gotorientation <angle>\r\n";
+    if (argc != 1) {
+        chprintf(chp, usage);
+        return;
+    }
+    uint16_t angle = strtol(argv[0], NULL, 10);
+    OrientationDataMessage msg{angle};
+    EventDispatcher::send_message(msg);
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_sysinfo(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: sysinfo\r\n";
+    (void)argv;
+    if (argc > 0) {
+        chprintf(chp, usage);
+        return;
+    }
+    auto utilisation = get_cpu_utilisation_in_percent();
+    std::string info =
+        "M0 heap: " + to_string_dec_uint(chCoreStatus()) + "\r\n" +
+        "M0 stack: " + to_string_dec_uint((uint32_t)get_free_stack_space()) + "\r\n" +
+        "M0 cpu%: " + to_string_dec_uint(utilisation) + "\r\n" +
+        "M4 heap: " + to_string_dec_uint(shared_memory.m4_heap_usage) + "\r\n" +
+        "M4 stack: " + to_string_dec_uint(shared_memory.m4_stack_usage) + "\r\n" +
+        "M0 cpu%: " + to_string_dec_uint(shared_memory.m4_performance_counter) + "\r\n" +
+        "M4 miss: " + to_string_dec_uint(shared_memory.m4_buffer_missed) + "\r\n" +
+        "uptime: " + to_string_dec_uint(chTimeNow() / 1000) + "\r\n";
+
+    fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)info.c_str(), info.length());
+    return;
+}
+
+static void cmd_radioinfo(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: radioinfo\r\n";
+    (void)argv;
+    if (argc > 0) {
+        chprintf(chp, usage);
+        return;
+    }
+    std::string info =
+        "receiver_model.target_frequency: " + to_string_dec_uint(portapack::receiver_model.target_frequency()) + "\r\n" +
+        "receiver_model.baseband_bandwidth: " + to_string_dec_uint(portapack::receiver_model.baseband_bandwidth()) + "\r\n" +
+        "receiver_model.sampling_rate: " + to_string_dec_uint(portapack::receiver_model.sampling_rate()) + "\r\n" +
+        "receiver_model.modulation: " + to_string_dec_uint((uint32_t)portapack::receiver_model.modulation()) + "\r\n" +
+        "receiver_model.am_configuration: " + to_string_dec_uint(portapack::receiver_model.am_configuration()) + "\r\n" +
+        "receiver_model.nbfm_configuration: " + to_string_dec_uint(portapack::receiver_model.nbfm_configuration()) + "\r\n" +
+        "receiver_model.wfm_configuration: " + to_string_dec_uint(portapack::receiver_model.wfm_configuration()) + "\r\n" +
+        "transmitter_model.target_frequency: " + to_string_dec_uint(portapack::transmitter_model.target_frequency()) + "\r\n" +
+        "transmitter_model.baseband_bandwidth: " + to_string_dec_uint(portapack::transmitter_model.baseband_bandwidth()) + "\r\n" +
+        "transmitter_model.sampling_rate: " + to_string_dec_uint(portapack::transmitter_model.sampling_rate()) + "\r\n";
+
+    fillOBuffer(&((SerialUSBDriver*)chp)->oqueue, (const uint8_t*)info.c_str(), info.length());
+    return;
+}
+
+static void cmd_pmemreset(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: pmemreset yes\r\nThis will reset pmem to defaults!\r\n";
+    (void)argv;
+    if (argc != 1 || strcmp(argv[0], "yes") != 0) {
+        chprintf(chp, usage);
+        return;
+    }
+    auto evtd = getEventDispatcherInstance();
+    if (!evtd) return;
+    auto top_widget = evtd->getTopWidget();
+    if (!top_widget) return;
+    auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
+    if (!nav) return;
+    nav->home(true);
+
+    portapack::persistent_memory::cache::defaults();
+    // system refresh
+    StatusRefreshMessage message{};
+    EventDispatcher::send_message(message);
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_settingsreset(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: settingsreset yes\r\nThis will reset all app settings to defaults!\r\n";
+    (void)argv;
+    if (argc != 1 || strcmp(argv[0], "yes") != 0) {
+        chprintf(chp, usage);
+        return;
+    }
+    auto evtd = getEventDispatcherInstance();
+    if (!evtd) return;
+    auto top_widget = evtd->getTopWidget();
+    if (!top_widget) return;
+    auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
+    if (!nav) return;
+    nav->home(true);  // to exit all running apps
+
+    for (const auto& entry : std::filesystem::directory_iterator(SETTINGS_DIR, u"*.ini")) {
+        if (std::filesystem::is_regular_file(entry.status())) {
+            std::filesystem::path pth = SETTINGS_DIR;
+            pth += u"/" + entry.path();
+            chprintf(chp, pth.string().c_str());
+            chprintf(chp, "\r\n");
+            f_unlink(pth.tchar());
+        }
+    }
+    // system refresh
+    StatusRefreshMessage message{};
+    EventDispatcher::send_message(message);
+    chprintf(chp, "ok\r\n");
+}
+
+static const ShellCommand commands[] = {
+    {"reboot", cmd_reboot},
+    {"dfu", cmd_dfu},
+    {"hackrf", cmd_hackrf},
+    {"sd_over_usb", cmd_sd_over_usb},
+    {"flash", cmd_flash},
+    {"screenshot", cmd_screenshot},
+    {"screenframe", cmd_screenframe},
+    {"screenframeshort", cmd_screenframeshort},
+    {"write_memory", cmd_write_memory},
+    {"read_memory", cmd_read_memory},
+    {"button", cmd_button},
+    {"touch", cmd_touch},
+    {"keyboard", cmd_keyboard},
+    USB_SERIAL_SHELL_SD_COMMANDS,
+    {"rtcget", cmd_rtcget},
+    {"rtcset", cmd_rtcset},
+    {"cpld_info", cpld_info},
+    {"cpld_read", cmd_cpld_read},
+    {"accessibility_readall", cmd_accessibility_readall},
+    {"accessibility_readcurr", cmd_accessibility_readcurr},
+    {"applist", cmd_applist},
+    {"appstart", cmd_appstart},
+    {"gotgps", cmd_gotgps},
+    {"gotorientation", cmd_gotorientation},
+    {"sysinfo", cmd_sysinfo},
+    {"radioinfo", cmd_radioinfo},
+    {"pmemreset", cmd_pmemreset},
+    {"settingsreset", cmd_settingsreset},
+    {NULL, NULL}};
+
+static const ShellConfig shell_cfg1 = {
+    (BaseSequentialStream*)&SUSBD1,
+    commands};
+
+void create_shell(EventDispatcher* evtd) {
+    _eventDispatcherInstance = evtd;
+    shellCreate(&shell_cfg1, SHELL_WA_SIZE, NORMALPRIO + 10);
+}

--- a/common/portapack_persistent_memory.cpp
+++ b/common/portapack_persistent_memory.cpp
@@ -1,0 +1,1183 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "portapack_persistent_memory.hpp"
+
+#include "audio.hpp"
+#include "crc.hpp"
+#include "file.hpp"
+#include "hal.h"
+#include "irq_controls.hpp"
+#include "memory_map.hpp"
+#include "portapack.hpp"
+#include "string_format.hpp"
+#include "ui_styles.hpp"
+#include "ui_painter.hpp"
+#include "utility.hpp"
+#include "rtc_time.hpp"
+
+#include <algorithm>
+#include <string>
+#include <fstream>
+#include <utility>
+
+#include <ch.h>
+#include <hal.h>
+
+using namespace std;
+
+namespace portapack {
+namespace persistent_memory {
+
+constexpr rf::Frequency target_frequency_reset_value{100000000};
+
+using ppb_range_t = range_t<ppb_t>;
+constexpr ppb_range_t ppb_range{-99000, 99000};
+constexpr ppb_t ppb_reset_value{0};
+
+using tone_mix_range_t = range_t<int32_t>;
+constexpr tone_mix_range_t tone_mix_range{10, 99};
+constexpr int32_t tone_mix_reset_value{20};
+
+using afsk_freq_range_t = range_t<int32_t>;
+constexpr afsk_freq_range_t afsk_freq_range{1, 4000};
+constexpr int32_t afsk_mark_reset_value{1200};
+constexpr int32_t afsk_space_reset_value{2200};
+
+using modem_baudrate_range_t = range_t<int32_t>;
+constexpr modem_baudrate_range_t modem_baudrate_range{50, 9600};
+constexpr int32_t modem_baudrate_reset_value{1200};
+
+/*
+using modem_bw_range_t = range_t<int32_t>;
+constexpr modem_bw_range_t modem_bw_range { 1000, 50000 };
+constexpr int32_t modem_bw_reset_value { 15000 };
+*/
+
+using modem_repeat_range_t = range_t<int32_t>;
+constexpr modem_repeat_range_t modem_repeat_range{1, 99};
+constexpr int32_t modem_repeat_reset_value{5};
+
+using clkout_freq_range_t = range_t<uint32_t>;
+constexpr clkout_freq_range_t clkout_freq_range{4, 60000};  // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz.
+constexpr uint16_t clkout_freq_reset_value{10000};
+
+enum data_structure_version_enum : uint32_t {
+    VERSION_CURRENT = 0x10000005,
+};
+
+static const uint32_t TOUCH_CALIBRATION_MAGIC = 0x074af82f;
+
+/* UI config.
+ * NB: Will be default init - override in defaults(). */
+struct ui_config_t {
+    uint16_t clkout_freq;
+
+    // NB: bitsfields have to be the same type or the compiler will
+    // split into a new byte hence uint8_t for these booleans.
+    uint8_t backlight_timeout : 3;
+    uint8_t enable_backlight_timeout : 1;
+    uint8_t show_gui_return_icon : 1;
+    uint8_t load_app_settings : 1;
+    uint8_t save_app_settings : 1;
+    uint8_t show_large_qr_code : 1;
+
+    bool disable_touchscreen : 1;
+    bool hide_clock : 1;
+    bool clock_show_date : 1;
+    bool clkout_enabled : 1;
+    bool UNUSED_1 : 1;
+    bool stealth_mode : 1;
+    bool config_login : 1;
+    bool config_splash : 1;
+};
+static_assert(sizeof(ui_config_t) == sizeof(uint32_t));
+
+/* Additional UI config.
+ * NB: Will be default init - override in defaults(). */
+struct ui_config2_t {
+    /* Top icon bar */
+    bool hide_speaker : 1;
+    bool hide_converter : 1;
+    bool hide_stealth : 1;
+    bool hide_camera : 1;
+    bool hide_sleep : 1;
+    bool hide_bias_tee : 1;
+    bool hide_clock : 1;
+    bool hide_sd_card : 1;
+
+    bool hide_mute : 1;
+    bool UNUSED_1 : 1;
+    bool UNUSED_2 : 1;
+    bool UNUSED_3 : 1;
+    bool UNUSED_4 : 1;
+    bool UNUSED_5 : 1;
+    bool UNUSED_6 : 1;
+    bool UNUSED_7 : 1;
+
+    uint8_t PLACEHOLDER_2;
+    uint8_t PLACEHOLDER_3;
+};
+static_assert(sizeof(ui_config2_t) == sizeof(uint32_t));
+
+/* Additional config.
+ * NB: Will be default init - override in defaults(). */
+struct misc_config_t {
+    bool mute_audio : 1;
+    bool disable_speaker : 1;
+    bool config_disable_external_tcxo : 1;
+    bool config_sdcard_high_speed_io : 1;
+    bool config_disable_config_mode : 1;
+    bool UNUSED_5 : 1;
+    bool UNUSED_6 : 1;
+    bool UNUSED_7 : 1;
+
+    uint8_t PLACEHOLDER_1;
+    uint8_t PLACEHOLDER_2;
+    uint8_t PLACEHOLDER_3;
+};
+static_assert(sizeof(misc_config_t) == sizeof(uint32_t));
+
+#define MC_CONFIG_DISABLE_CONFIG_MODE 0x00000010  // config_disable_config_mode bit in struct above
+
+/* IMPORTANT: Update dump_persistent_memory (below) when changing data_t. */
+
+/* Struct must pack the same way on M4 and M0 cores.
+ * NB: When adding new members, keep 32bit-aligned.*/
+
+struct data_t {
+    data_structure_version_enum structure_version;
+    int64_t target_frequency;
+    int32_t correction_ppb;
+    uint32_t touch_calibration_magic;
+    touch::Calibration touch_calibration;  // 7 * 32 bits.
+
+    // Modem
+    uint32_t modem_def_index;
+    serial_format_t serial_format;
+    int32_t modem_bw;
+    int32_t afsk_mark_freq;
+    int32_t afsk_space_freq;
+    int32_t modem_baudrate;
+    int32_t modem_repeat;
+
+    // Play dead unlock (Used?)
+    uint32_t playdead_magic;
+    uint32_t playing_dead;
+    uint32_t playdead_sequence;
+
+    // UI Config
+    ui_config_t ui_config;
+
+    uint32_t pocsag_last_address;
+    uint32_t pocsag_ignore_address;
+
+    int32_t tone_mix;
+
+    // Hardware
+    uint32_t hardware_config;
+
+    // Recon App
+    uint64_t recon_config;
+    int8_t recon_repeat_nb;
+    int8_t recon_repeat_gain;
+    uint8_t recon_repeat_delay;
+
+    // enable or disable converter
+    bool converter;
+    // set up converter (false) or down converter (true) converter
+    bool updown_converter;
+    bool updown_frequency_rx_correction;
+    bool updown_frequency_tx_correction;
+    bool UNUSED_4 : 1;
+    bool UNUSED_5 : 1;
+    bool UNUSED_6 : 1;
+    bool UNUSED_7 : 1;
+
+    // up/down converter offset
+    int64_t converter_frequency_offset;
+
+    // frequency correction
+    uint32_t frequency_rx_correction;
+    uint32_t frequency_tx_correction;
+
+    // Rotary encoder dial sensitivity (encoder.cpp/hpp)
+    uint16_t encoder_dial_sensitivity : 4;
+    uint16_t UNUSED_8 : 12;
+
+    // Headphone volume in centibels.
+    int16_t headphone_volume_cb;
+
+    // Misc flags
+    misc_config_t misc_config;
+
+    // Additional UI settings.
+    ui_config2_t ui_config2;
+
+    // recovery mode magic value storage
+    uint32_t config_mode_storage;
+
+    // Daylight savings time
+    dst_config_t dst_config;
+
+    constexpr data_t()
+        : structure_version(data_structure_version_enum::VERSION_CURRENT),
+          target_frequency(target_frequency_reset_value),
+          correction_ppb(ppb_reset_value),
+          touch_calibration_magic(TOUCH_CALIBRATION_MAGIC),
+          touch_calibration(touch::Calibration()),
+
+          modem_def_index(0),  // TODO: Unused?
+          serial_format(),
+          modem_bw(15000),  // TODO: Unused?
+          afsk_mark_freq(afsk_mark_reset_value),
+          afsk_space_freq(afsk_space_reset_value),
+          modem_baudrate(modem_baudrate_reset_value),
+          modem_repeat(modem_repeat_reset_value),
+
+          playdead_magic(),     // TODO: Unused?
+          playing_dead(),       // TODO: Unused?
+          playdead_sequence(),  // TODO: Unused?
+
+          ui_config(),
+
+          pocsag_last_address(0),    // TODO: A better default?
+          pocsag_ignore_address(0),  // TODO: A better default?
+
+          tone_mix(tone_mix_reset_value),
+
+          hardware_config(0),
+
+          recon_config(0),
+          recon_repeat_nb(0),
+          recon_repeat_gain(0),
+          recon_repeat_delay(0),
+
+          converter(false),
+          updown_converter(false),
+          updown_frequency_rx_correction(false),
+          updown_frequency_tx_correction(false),
+          UNUSED_4(false),
+          UNUSED_5(false),
+          UNUSED_6(false),
+          UNUSED_7(false),
+
+          converter_frequency_offset(0),
+
+          frequency_rx_correction(0),
+          frequency_tx_correction(0),
+
+          encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL),
+          UNUSED_8(0),
+          headphone_volume_cb(-600),
+          misc_config(),
+          ui_config2(),
+          config_mode_storage(CONFIG_MODE_NORMAL_VALUE),
+          dst_config() {
+    }
+};
+
+struct backup_ram_t {
+   private:
+    volatile uint32_t regfile[PMEM_SIZE_WORDS - 1];
+    volatile uint32_t check_value;
+
+    static void copy(const backup_ram_t& src, backup_ram_t& dst) {
+        for (size_t i = 0; i < PMEM_SIZE_WORDS - 1; i++) {
+            dst.regfile[i] = src.regfile[i];
+        }
+        dst.check_value = src.check_value;
+    }
+
+    static void copy_from_data_t(const data_t& src, backup_ram_t& dst) {
+        const uint32_t* const src_words = (uint32_t*)&src;
+        const size_t word_count = (sizeof(data_t) + 3) / 4;
+        for (size_t i = 0; i < PMEM_SIZE_WORDS - 1; i++) {
+            if (i < word_count) {
+                dst.regfile[i] = src_words[i];
+            } else {
+                dst.regfile[i] = 0;
+            }
+        }
+    }
+
+    uint32_t compute_check_value() {
+        CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+        for (size_t i = 0; i < PMEM_SIZE_WORDS - 1; i++) {
+            const auto word = regfile[i];
+            crc.process_byte((word >> 0) & 0xff);
+            crc.process_byte((word >> 8) & 0xff);
+            crc.process_byte((word >> 16) & 0xff);
+            crc.process_byte((word >> 24) & 0xff);
+        }
+        return crc.checksum();
+    }
+
+   public:
+    /* default constructor */
+    backup_ram_t()
+        : check_value(0) {
+        const data_t defaults = data_t();
+        copy_from_data_t(defaults, *this);
+    }
+
+    /* copy-assignment operator */
+    backup_ram_t& operator=(const backup_ram_t& src) {
+        copy(src, *this);
+        return *this;
+    }
+
+    /* Calculate a check value from `this`, and check against
+     * the stored value.
+     */
+    bool is_valid() {
+        return compute_check_value() == check_value;
+    }
+
+    /* Assuming `this` contains valid data, update the checksum
+     * and copy to the destination.
+     */
+    void persist_to(backup_ram_t& dst) {
+        check_value = compute_check_value();
+        copy(*this, dst);
+    }
+
+    /* Access functions for DebugPmemView */
+    uint32_t pmem_data_word(uint32_t index) {
+        return (index > sizeof(regfile) / sizeof(uint32_t)) ? 0xFFFFFFFF : regfile[index];
+    }
+
+    uint32_t pmem_stored_checksum(void) {
+        return check_value;
+    }
+
+    uint32_t pmem_calculated_checksum(void) {
+        return compute_check_value();
+    }
+};
+
+static_assert(sizeof(backup_ram_t) == memory::map::backup_ram.size());
+static_assert(sizeof(data_t) <= sizeof(backup_ram_t) - sizeof(uint32_t));
+
+/* Uncomment to get a compiler error with the data_t size. */
+// template <size_t N>
+// struct ShowSize;
+// ShowSize<sizeof(data_t)> __data_t_size;
+
+static backup_ram_t* const backup_ram = reinterpret_cast<backup_ram_t*>(memory::map::backup_ram.base());
+
+static backup_ram_t cached_backup_ram;
+static data_t* data = reinterpret_cast<data_t*>(&cached_backup_ram);
+
+namespace cache {
+
+void defaults() {
+    cached_backup_ram = backup_ram_t();
+
+    // If the desired default is 0/false, then no need to set it here (buffer is initialized to 0)
+    set_config_backlight_timer(backlight_config_t{});
+    set_config_splash(true);
+    set_config_disable_external_tcxo(false);
+    set_encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL);
+    set_config_speaker_disable(true);  // Disable AK4951 speaker by default (in case of OpenSourceSDRLab H2)
+
+    // Default values for recon app.
+    set_recon_autosave_freqs(false);
+    set_recon_autostart_recon(true);
+    set_recon_continuous(true);
+    set_recon_clear_output(false);
+    set_recon_load_freqs(true);
+    set_recon_load_repeaters(true);
+    set_recon_load_ranges(true);
+    set_recon_update_ranges_when_recon(true);
+    set_recon_load_hamradios(true);
+    set_recon_match_mode(0);
+    set_recon_repeat_recorded(false);
+    set_recon_repeat_amp(false);
+    set_recon_repeat_gain(35);
+    set_recon_repeat_nb(3);
+    set_recon_repeat_delay(1);
+
+    set_config_sdcard_high_speed_io(false, true);
+}
+
+void init() {
+    const auto switches_state = get_switches_state();
+
+    // ignore for valid check
+    auto config_mode_backup = config_mode_storage_direct();
+    set_config_mode_storage_direct(CONFIG_MODE_NORMAL_VALUE);
+
+    if (!(switches_state[(size_t)ui::KeyEvent::Left] && switches_state[(size_t)ui::KeyEvent::Right]) && backup_ram->is_valid()) {
+        // Copy valid persistent data into cache.
+        cached_backup_ram = *backup_ram;
+
+        // Check that structure data we copied into cache is the expected
+        // version. If not, initialize cache to defaults.
+        if (data->structure_version != data_structure_version_enum::VERSION_CURRENT) {
+            // TODO: Can provide version-to-version upgrade functions here,
+            // if we want to be fancy.
+            defaults();
+        }
+    } else {
+        // Copy defaults into cache.
+        defaults();
+    }
+    set_config_mode_storage_direct(config_mode_backup);
+}
+
+void persist() {
+    cached_backup_ram.persist_to(*backup_ram);
+}
+
+} /* namespace cache */
+
+uint32_t pmem_data_word(uint32_t index) {
+    return backup_ram->pmem_data_word(index);
+}
+
+uint32_t pmem_stored_checksum(void) {
+    return backup_ram->pmem_stored_checksum();
+}
+
+uint32_t pmem_calculated_checksum(void) {
+    return backup_ram->pmem_calculated_checksum();
+}
+
+rf::Frequency target_frequency() {
+    rf::tuning_range.reset_if_outside(data->target_frequency, target_frequency_reset_value);
+    return data->target_frequency;
+}
+
+void set_target_frequency(const rf::Frequency new_value) {
+    data->target_frequency = rf::tuning_range.clip(new_value);
+}
+
+volume_t headphone_volume() {
+    auto volume = volume_t::centibel(data->headphone_volume_cb);
+    volume = audio::headphone::volume_range().limit(volume);
+    return volume;
+}
+
+void set_headphone_volume(volume_t new_value) {
+    new_value = audio::headphone::volume_range().limit(new_value);
+    data->headphone_volume_cb = new_value.centibel();
+}
+
+ppb_t correction_ppb() {
+    ppb_range.reset_if_outside(data->correction_ppb, ppb_reset_value);
+    return data->correction_ppb;
+}
+
+void set_correction_ppb(const ppb_t new_value) {
+    const auto clipped_value = ppb_range.clip(new_value);
+    data->correction_ppb = clipped_value;
+    portapack::clock_manager.set_reference_ppb(clipped_value);
+}
+
+void set_touch_calibration(const touch::Calibration& new_value) {
+    data->touch_calibration = new_value;
+    data->touch_calibration_magic = TOUCH_CALIBRATION_MAGIC;
+}
+
+const touch::Calibration& touch_calibration() {
+    if (data->touch_calibration_magic != TOUCH_CALIBRATION_MAGIC) {
+        set_touch_calibration(touch::Calibration());
+    }
+    return data->touch_calibration;
+}
+
+int32_t tone_mix() {
+    tone_mix_range.reset_if_outside(data->tone_mix, tone_mix_reset_value);
+    return data->tone_mix;
+}
+
+void set_tone_mix(const int32_t new_value) {
+    data->tone_mix = tone_mix_range.clip(new_value);
+}
+
+int32_t afsk_mark_freq() {
+    afsk_freq_range.reset_if_outside(data->afsk_mark_freq, afsk_mark_reset_value);
+    return data->afsk_mark_freq;
+}
+
+void set_afsk_mark(const int32_t new_value) {
+    data->afsk_mark_freq = afsk_freq_range.clip(new_value);
+}
+
+int32_t afsk_space_freq() {
+    afsk_freq_range.reset_if_outside(data->afsk_space_freq, afsk_space_reset_value);
+    return data->afsk_space_freq;
+}
+
+void set_afsk_space(const int32_t new_value) {
+    data->afsk_space_freq = afsk_freq_range.clip(new_value);
+}
+
+int32_t modem_baudrate() {
+    modem_baudrate_range.reset_if_outside(data->modem_baudrate, modem_baudrate_reset_value);
+    return data->modem_baudrate;
+}
+
+void set_modem_baudrate(const int32_t new_value) {
+    data->modem_baudrate = modem_baudrate_range.clip(new_value);
+}
+
+/*
+int32_t modem_bw() {
+    modem_bw_range.reset_if_outside(data->modem_bw, modem_bw_reset_value);
+    return data->modem_bw;
+}
+
+void set_modem_bw(const int32_t new_value) {
+    data->modem_bw = modem_bw_range.clip(new_value);
+}
+*/
+
+uint8_t modem_repeat() {
+    modem_repeat_range.reset_if_outside(data->modem_repeat, modem_repeat_reset_value);
+    return data->modem_repeat;
+}
+
+void set_modem_repeat(const uint32_t new_value) {
+    data->modem_repeat = modem_repeat_range.clip(new_value);
+}
+
+serial_format_t serial_format() {
+    return data->serial_format;
+}
+
+void set_serial_format(const serial_format_t new_value) {
+    data->serial_format = new_value;
+}
+
+bool show_gui_return_icon() {  // add return icon in touchscreen menu
+    return data->ui_config.show_gui_return_icon != 0;
+}
+
+bool show_bigger_qr_code() {  // show bigger QR code
+    return data->ui_config.show_large_qr_code != 0;
+}
+
+bool disable_touchscreen() {  // Option to disable touch screen
+    return data->ui_config.disable_touchscreen;
+}
+
+bool hide_clock() {  // Hide clock from main menu
+    return data->ui_config.hide_clock;
+}
+
+bool clock_with_date() {  // Show clock with date, if not hidden
+    return data->ui_config.clock_show_date;
+}
+
+bool clkout_enabled() {
+    return data->ui_config.clkout_enabled;
+}
+
+bool config_audio_mute() {
+    return data->misc_config.mute_audio;
+}
+
+bool config_speaker_disable() {
+    return data->misc_config.disable_speaker;
+}
+
+bool config_disable_external_tcxo() {
+    return data->misc_config.config_disable_external_tcxo;
+}
+
+bool config_disable_config_mode() {
+    return data->misc_config.config_disable_config_mode;
+}
+
+bool config_sdcard_high_speed_io() {
+    return data->misc_config.config_sdcard_high_speed_io;
+}
+
+bool stealth_mode() {
+    return data->ui_config.stealth_mode;
+}
+
+bool config_login() {
+    return data->ui_config.config_login;
+}
+
+bool config_splash() {
+    return data->ui_config.config_splash;
+}
+
+uint8_t config_cpld() {
+    return data->hardware_config;
+}
+
+backlight_config_t config_backlight_timer() {
+    return {static_cast<backlight_timeout_t>(data->ui_config.backlight_timeout),
+            data->ui_config.enable_backlight_timeout == 1};
+}
+
+void set_gui_return_icon(bool v) {
+    data->ui_config.show_gui_return_icon = v ? 1 : 0;
+}
+
+void set_load_app_settings(bool v) {
+    data->ui_config.load_app_settings = v ? 1 : 0;
+}
+
+void set_save_app_settings(bool v) {
+    data->ui_config.save_app_settings = v ? 1 : 0;
+}
+
+void set_show_bigger_qr_code(bool v) {
+    data->ui_config.show_large_qr_code = v ? 1 : 0;
+}
+
+void set_disable_touchscreen(bool v) {
+    data->ui_config.disable_touchscreen = v;
+}
+
+void set_clock_hidden(bool v) {
+    data->ui_config.hide_clock = v;
+}
+
+void set_clock_with_date(bool v) {
+    data->ui_config.clock_show_date = v;
+}
+
+void set_clkout_enabled(bool v) {
+    data->ui_config.clkout_enabled = v;
+}
+
+void set_config_audio_mute(bool v) {
+    data->misc_config.mute_audio = v;
+}
+
+void set_config_speaker_disable(bool v) {
+    data->misc_config.disable_speaker = v;
+}
+
+void set_config_disable_external_tcxo(bool v) {
+    data->misc_config.config_disable_external_tcxo = v;
+}
+
+void set_config_disable_config_mode(bool v) {
+    data->misc_config.config_disable_config_mode = v;
+}
+
+void set_config_sdcard_high_speed_io(bool v, bool save) {
+    if (v) {
+        /* 200MHz / (2 * 2) = 50MHz */
+        /* TODO: Adjust SCU pin configurations: pull-up/down, slew, glitch filter? */
+        sdio_cclk_set(2);
+    } else {
+        /* 200MHz / (2 * 4) = 25MHz */
+        sdio_cclk_set(4);
+    }
+    if (save)
+        data->misc_config.config_sdcard_high_speed_io = v;
+}
+
+void set_stealth_mode(bool v) {
+    data->ui_config.stealth_mode = v;
+}
+
+void set_config_login(bool v) {
+    data->ui_config.config_login = v;
+}
+
+void set_config_splash(bool v) {
+    data->ui_config.config_splash = v;
+}
+
+void set_config_cpld(uint8_t i) {
+    data->hardware_config = i;
+}
+
+void set_config_backlight_timer(const backlight_config_t& new_value) {
+    data->ui_config.backlight_timeout = static_cast<uint8_t>(new_value.timeout_enum());
+    data->ui_config.enable_backlight_timeout = static_cast<uint8_t>(new_value.timeout_enabled());
+}
+
+uint32_t pocsag_last_address() {
+    return data->pocsag_last_address;
+}
+
+void set_pocsag_last_address(uint32_t address) {
+    data->pocsag_last_address = address;
+}
+
+uint32_t pocsag_ignore_address() {
+    return data->pocsag_ignore_address;
+}
+
+void set_pocsag_ignore_address(uint32_t address) {
+    data->pocsag_ignore_address = address;
+}
+
+uint16_t clkout_freq() {
+    auto freq = data->ui_config.clkout_freq;
+
+    if (freq < clkout_freq_range.minimum || freq > clkout_freq_range.maximum)
+        set_clkout_freq(clkout_freq_reset_value);
+
+    return data->ui_config.clkout_freq;
+}
+
+void set_clkout_freq(uint16_t freq) {
+    data->ui_config.clkout_freq = freq;
+}
+
+/* Recon app */
+bool recon_autosave_freqs() {
+    return (data->recon_config & 0x80000000UL) ? true : false;
+}
+bool recon_autostart_recon() {
+    return (data->recon_config & 0x40000000UL) ? true : false;
+}
+bool recon_continuous() {
+    return (data->recon_config & 0x20000000UL) ? true : false;
+}
+bool recon_clear_output() {
+    return (data->recon_config & 0x10000000UL) ? true : false;
+}
+bool recon_load_freqs() {
+    return (data->recon_config & 0x08000000UL) ? true : false;
+}
+bool recon_load_ranges() {
+    return (data->recon_config & 0x04000000UL) ? true : false;
+}
+bool recon_update_ranges_when_recon() {
+    return (data->recon_config & 0x02000000UL) ? true : false;
+}
+bool recon_load_hamradios() {
+    return (data->recon_config & 0x01000000UL) ? true : false;
+}
+bool recon_match_mode() {
+    return (data->recon_config & 0x00800000UL) ? true : false;
+}
+bool recon_auto_record_locked() {
+    return (data->recon_config & 0x00400000UL) ? true : false;
+}
+bool recon_repeat_recorded() {
+    return (data->recon_config & 0x00200000UL) ? true : false;
+}
+int8_t recon_repeat_nb() {
+    return data->recon_repeat_nb;
+}
+int8_t recon_repeat_gain() {
+    return data->recon_repeat_gain;
+}
+uint8_t recon_repeat_delay() {
+    return data->recon_repeat_delay;
+}
+bool recon_repeat_amp() {
+    return (data->recon_config & 0x00100000UL) ? true : false;
+}
+bool recon_load_repeaters() {
+    return (data->recon_config & 0x00080000UL) ? true : false;
+}
+
+void set_recon_autosave_freqs(const bool v) {
+    data->recon_config = (data->recon_config & ~0x80000000UL) | (v << 31);
+}
+void set_recon_autostart_recon(const bool v) {
+    data->recon_config = (data->recon_config & ~0x40000000UL) | (v << 30);
+}
+void set_recon_continuous(const bool v) {
+    data->recon_config = (data->recon_config & ~0x20000000UL) | (v << 29);
+}
+void set_recon_clear_output(const bool v) {
+    data->recon_config = (data->recon_config & ~0x10000000UL) | (v << 28);
+}
+void set_recon_load_freqs(const bool v) {
+    data->recon_config = (data->recon_config & ~0x08000000UL) | (v << 27);
+}
+void set_recon_load_ranges(const bool v) {
+    data->recon_config = (data->recon_config & ~0x04000000UL) | (v << 26);
+}
+void set_recon_update_ranges_when_recon(const bool v) {
+    data->recon_config = (data->recon_config & ~0x02000000UL) | (v << 25);
+}
+void set_recon_load_hamradios(const bool v) {
+    data->recon_config = (data->recon_config & ~0x01000000UL) | (v << 24);
+}
+void set_recon_match_mode(const bool v) {
+    data->recon_config = (data->recon_config & ~0x00800000UL) | (v << 23);
+}
+void set_recon_auto_record_locked(const bool v) {
+    data->recon_config = (data->recon_config & ~0x00400000UL) | (v << 22);
+}
+void set_recon_repeat_recorded(const bool v) {
+    data->recon_config = (data->recon_config & ~0x00200000UL) | (v << 21);
+}
+void set_recon_repeat_nb(const int8_t v) {
+    data->recon_repeat_nb = v;
+}
+void set_recon_repeat_gain(const int8_t v) {
+    data->recon_repeat_gain = v;
+}
+void set_recon_repeat_delay(const uint8_t v) {
+    data->recon_repeat_delay = v;
+}
+void set_recon_repeat_amp(const bool v) {
+    data->recon_config = (data->recon_config & ~0x00100000UL) | (v << 20);
+}
+void set_recon_load_repeaters(const bool v) {
+    data->recon_config = (data->recon_config & ~0x00080000UL) | (v << 19);
+}
+
+/* UI Config 2 */
+bool ui_hide_speaker() {
+    return data->ui_config2.hide_speaker;
+}
+bool ui_hide_mute() {
+    return data->ui_config2.hide_mute;
+}
+bool ui_hide_converter() {
+    return data->ui_config2.hide_converter;
+}
+bool ui_hide_stealth() {
+    return data->ui_config2.hide_stealth;
+}
+bool ui_hide_camera() {
+    return data->ui_config2.hide_camera;
+}
+bool ui_hide_sleep() {
+    return data->ui_config2.hide_sleep;
+}
+bool ui_hide_bias_tee() {
+    return data->ui_config2.hide_bias_tee;
+}
+bool ui_hide_clock() {
+    return data->ui_config2.hide_clock;
+}
+bool ui_hide_sd_card() {
+    return data->ui_config2.hide_sd_card;
+}
+
+void set_ui_hide_speaker(bool v) {
+    data->ui_config2.hide_speaker = v;
+}
+void set_ui_hide_mute(bool v) {
+    data->ui_config2.hide_mute = v;
+}
+void set_ui_hide_converter(bool v) {
+    data->ui_config2.hide_converter = v;
+    if (v)
+        data->converter = false;
+}
+void set_ui_hide_stealth(bool v) {
+    data->ui_config2.hide_stealth = v;
+}
+void set_ui_hide_camera(bool v) {
+    data->ui_config2.hide_camera = v;
+}
+void set_ui_hide_sleep(bool v) {
+    data->ui_config2.hide_sleep = v;
+}
+void set_ui_hide_bias_tee(bool v) {
+    data->ui_config2.hide_bias_tee = v;
+}
+void set_ui_hide_clock(bool v) {
+    data->ui_config2.hide_clock = v;
+}
+void set_ui_hide_sd_card(bool v) {
+    data->ui_config2.hide_sd_card = v;
+}
+
+/* Converter */
+bool config_converter() {
+    return data->converter;
+}
+bool config_updown_converter() {
+    return data->updown_converter;
+}
+int64_t config_converter_freq() {
+    return data->converter_frequency_offset;
+}
+
+void set_config_converter(bool v) {
+    data->converter = v;
+}
+void set_config_updown_converter(bool v) {
+    data->updown_converter = v;
+}
+void set_config_converter_freq(int64_t v) {
+    data->converter_frequency_offset = v;
+}
+
+// Frequency correction settings
+
+bool config_freq_tx_correction_updown() {
+    return data->updown_frequency_tx_correction;
+}
+bool config_freq_rx_correction_updown() {
+    return data->updown_frequency_rx_correction;
+}
+uint32_t config_freq_tx_correction() {
+    return data->frequency_tx_correction;
+}
+uint32_t config_freq_rx_correction() {
+    return data->frequency_rx_correction;
+}
+void set_freq_tx_correction_updown(bool v) {
+    data->updown_frequency_tx_correction = v;
+}
+void set_freq_rx_correction_updown(bool v) {
+    data->updown_frequency_rx_correction = v;
+}
+void set_config_freq_tx_correction(uint32_t v) {
+    data->frequency_tx_correction = v;
+}
+void set_config_freq_rx_correction(uint32_t v) {
+    data->frequency_rx_correction = v;
+}
+
+// Rotary encoder dial settings
+
+uint8_t config_encoder_dial_sensitivity() {
+    return data->encoder_dial_sensitivity;
+}
+void set_encoder_dial_sensitivity(uint8_t v) {
+    data->encoder_dial_sensitivity = v;
+}
+
+// Recovery mode magic value storage
+static data_t* data_direct_access = reinterpret_cast<data_t*>(memory::map::backup_ram.base());
+
+uint32_t config_mode_storage_direct() {
+    return data_direct_access->config_mode_storage;
+}
+void set_config_mode_storage_direct(uint32_t v) {
+    data_direct_access->config_mode_storage = v;
+}
+bool config_disable_config_mode_direct() {
+    // "return data_direct_access->misc_config.config_disable_config_mode"
+    // Casting as U32 as workaround for misaligned memory access
+    uint32_t misc_config_u32 = *(uint32_t*)&data_direct_access->misc_config;
+    return ((misc_config_u32 & MC_CONFIG_DISABLE_CONFIG_MODE) != 0);
+}
+
+// Daylight savings time
+bool dst_enabled() {
+    return data->dst_config.b.dst_enabled;
+}
+void set_dst_enabled(bool v) {
+    data->dst_config.b.dst_enabled = v;
+    rtc_time::dst_init();
+}
+dst_config_t config_dst() {
+    return data->dst_config;
+}
+void set_config_dst(dst_config_t v) {
+    data->dst_config = v;
+    rtc_time::dst_init();
+}
+
+// PMem to sdcard settings
+
+bool should_use_sdcard_for_pmem() {
+    return std::filesystem::file_exists(PMEM_FILEFLAG);
+}
+
+int save_persistent_settings_to_file() {
+    File outfile;
+
+    ensure_directory(SETTINGS_DIR);
+    auto error = outfile.create(PMEM_SETTING_FILE);
+    if (error)
+        return false;
+
+    outfile.write(reinterpret_cast<char*>(&cached_backup_ram), sizeof(backup_ram_t));
+    return true;
+}
+
+int load_persistent_settings_from_file() {
+    File infile;
+    auto error = infile.open(PMEM_SETTING_FILE);
+    if (error)
+        return false;
+
+    infile.read(reinterpret_cast<char*>(&cached_backup_ram), sizeof(backup_ram_t));
+    return true;
+}
+
+// Pmem size helper
+
+size_t data_size() {
+    return sizeof(data_t);
+}
+
+// Dump pmem, receiver and transmitter models internals in human readable format
+
+bool debug_dump() {
+    ui::Painter painter{};
+    std::string debug_dir = "DEBUG";
+    std::filesystem::path filename{};
+    File pmem_dump_file{};
+    // create new dump file name and DEBUG directory
+    ensure_directory(debug_dir);
+    filename = next_filename_matching_pattern(debug_dir + "/DEBUG_DUMP_????.TXT");
+    if (filename.empty()) {
+        painter.draw_string({0, 320 - 16}, ui::Styles::red, "COULD NOT GET DUMP NAME !");
+        return false;
+    }
+    // dump data fo filename
+    auto error = pmem_dump_file.create(filename);
+    if (error) {
+        painter.draw_string({0, 320 - 16}, ui::Styles::red, "ERROR DUMPING " + filename.filename().string() + " !");
+        return false;
+    }
+    pmem_dump_file.write_line("FW version: " VERSION_STRING);
+    pmem_dump_file.write_line("Ext APPS version req'd: 0x" + to_string_hex(VERSION_MD5));
+    pmem_dump_file.write_line("GCC version: " + to_string_dec_int(__GNUC__) + "." + to_string_dec_int(__GNUC_MINOR__) + "." + to_string_dec_int(__GNUC_PATCHLEVEL__));
+
+    // write persistent memory
+    pmem_dump_file.write_line("\n[Persistent Memory]");
+
+    // full variables
+    pmem_dump_file.write_line("structure_version: 0x" + to_string_hex(data->structure_version, 8));
+    pmem_dump_file.write_line("target_frequency: " + to_string_dec_int(data->target_frequency));
+    pmem_dump_file.write_line("correction_ppb: " + to_string_dec_int(data->correction_ppb));
+    pmem_dump_file.write_line("modem_def_index: " + to_string_dec_uint(data->modem_def_index));
+    pmem_dump_file.write_line("serial_format.data_bit: " + to_string_dec_uint(data->serial_format.data_bits));
+    pmem_dump_file.write_line("serial_format.parity: " + to_string_dec_uint(data->serial_format.parity));
+    pmem_dump_file.write_line("serial_format.stop_bits: " + to_string_dec_uint(data->serial_format.stop_bits));
+    pmem_dump_file.write_line("serial_format.bit_order: " + to_string_dec_uint(data->serial_format.bit_order));
+    pmem_dump_file.write_line("modem_bw: " + to_string_dec_int(data->modem_bw));
+    pmem_dump_file.write_line("afsk_mark_freq: " + to_string_dec_int(data->afsk_mark_freq));
+    pmem_dump_file.write_line("afsk_space_freq: " + to_string_dec_int(data->afsk_space_freq));
+    pmem_dump_file.write_line("modem_baudrate: " + to_string_dec_int(data->modem_baudrate));
+    pmem_dump_file.write_line("modem_repeat: " + to_string_dec_int(data->modem_repeat));
+    pmem_dump_file.write_line("playdead_magic: " + to_string_dec_uint(data->playdead_magic));
+    pmem_dump_file.write_line("playing_dead: " + to_string_dec_uint(data->playing_dead));
+    pmem_dump_file.write_line("playdead_sequence: " + to_string_dec_uint(data->playdead_sequence));
+    pmem_dump_file.write_line("pocsag_last_address: " + to_string_dec_uint(data->pocsag_last_address));
+    pmem_dump_file.write_line("pocsag_ignore_address: " + to_string_dec_uint(data->pocsag_ignore_address));
+    pmem_dump_file.write_line("tone_mix: " + to_string_dec_uint(data->tone_mix));
+    pmem_dump_file.write_line("hardware_config: " + to_string_dec_uint(data->hardware_config));
+    pmem_dump_file.write_line("recon_config: 0x" + to_string_hex(data->recon_config, 16));
+    pmem_dump_file.write_line("recon_repeat_nb: " + to_string_dec_int(data->recon_repeat_nb));
+    pmem_dump_file.write_line("recon_repeat_gain: " + to_string_dec_int(data->recon_repeat_gain));
+    pmem_dump_file.write_line("recon_repeat_delay: " + to_string_dec_int(data->recon_repeat_delay));
+    pmem_dump_file.write_line("converter: " + to_string_dec_int(data->converter));
+    pmem_dump_file.write_line("updown_converter: " + to_string_dec_int(data->updown_converter));
+    pmem_dump_file.write_line("updown_frequency_rx_correction: " + to_string_dec_int(data->updown_frequency_rx_correction));
+    pmem_dump_file.write_line("updown_frequency_tx_correction: " + to_string_dec_int(data->updown_frequency_tx_correction));
+    // pmem_dump_file.write_line("UNUSED_4: " + to_string_dec_int(data->UNUSED_4));
+    // pmem_dump_file.write_line("UNUSED_5: " + to_string_dec_int(data->UNUSED_5));
+    // pmem_dump_file.write_line("UNUSED_6: " + to_string_dec_int(data->UNUSED_6));
+    // pmem_dump_file.write_line("UNUSED_7: " + to_string_dec_int(data->UNUSED_7));
+    pmem_dump_file.write_line("converter_frequency_offset: " + to_string_dec_int(data->converter_frequency_offset));
+    pmem_dump_file.write_line("frequency_rx_correction: " + to_string_dec_uint(data->frequency_rx_correction));
+    pmem_dump_file.write_line("frequency_tx_correction: " + to_string_dec_uint(data->frequency_tx_correction));
+    pmem_dump_file.write_line("encoder_dial_sensitivity: " + to_string_dec_uint(data->encoder_dial_sensitivity));
+    // pmem_dump_file.write_line("UNUSED_8: " + to_string_dec_uint(data->UNUSED_8));
+    pmem_dump_file.write_line("headphone_volume_cb: " + to_string_dec_int(data->headphone_volume_cb));
+    pmem_dump_file.write_line("config_mode_storage: 0x" + to_string_hex(data->config_mode_storage, 8));
+    pmem_dump_file.write_line("dst_config: 0x" + to_string_hex((uint32_t)data->dst_config.v, 8));
+
+    // ui_config bits
+    const auto backlight_timer = portapack::persistent_memory::config_backlight_timer();
+    pmem_dump_file.write_line("ui_config clkout_freq: " + to_string_dec_uint(clkout_freq()));
+    pmem_dump_file.write_line("ui_config backlight_timer.timeout_enabled: " + to_string_dec_uint(backlight_timer.timeout_enabled()));
+    pmem_dump_file.write_line("ui_config backlight_timer.timeout_seconds: " + to_string_dec_uint(backlight_timer.timeout_seconds()));
+    pmem_dump_file.write_line("ui_config show_gui_return_icon: " + to_string_dec_uint(data->ui_config.show_gui_return_icon));
+    pmem_dump_file.write_line("ui_config load_app_settings: " + to_string_dec_uint(data->ui_config.load_app_settings));
+    pmem_dump_file.write_line("ui_config save_app_settings: " + to_string_dec_uint(data->ui_config.save_app_settings));
+    pmem_dump_file.write_line("ui_config show_bigger_qr_code: " + to_string_dec_uint(data->ui_config.show_large_qr_code));
+    pmem_dump_file.write_line("ui_config disable_touchscreen: " + to_string_dec_uint(data->ui_config.disable_touchscreen));
+    pmem_dump_file.write_line("ui_config hide_clock: " + to_string_dec_uint(data->ui_config.hide_clock));
+    pmem_dump_file.write_line("ui_config clock_with_date: " + to_string_dec_uint(data->ui_config.clock_show_date));
+    pmem_dump_file.write_line("ui_config clkout_enabled: " + to_string_dec_uint(data->ui_config.clkout_enabled));
+    pmem_dump_file.write_line("ui_config stealth_mode: " + to_string_dec_uint(data->ui_config.stealth_mode));
+    pmem_dump_file.write_line("ui_config config_login: " + to_string_dec_uint(data->ui_config.config_login));
+    pmem_dump_file.write_line("ui_config config_splash: " + to_string_dec_uint(data->ui_config.config_splash));
+
+    // ui_config2 bits
+    pmem_dump_file.write_line("ui_config2 hide_speaker: " + to_string_dec_uint(data->ui_config2.hide_speaker));
+    pmem_dump_file.write_line("ui_config2 hide_converter: " + to_string_dec_uint(data->ui_config2.hide_converter));
+    pmem_dump_file.write_line("ui_config2 hide_stealth: " + to_string_dec_uint(data->ui_config2.hide_stealth));
+    pmem_dump_file.write_line("ui_config2 hide_camera: " + to_string_dec_uint(data->ui_config2.hide_camera));
+    pmem_dump_file.write_line("ui_config2 hide_sleep: " + to_string_dec_uint(data->ui_config2.hide_sleep));
+    pmem_dump_file.write_line("ui_config2 hide_bias_tee: " + to_string_dec_uint(data->ui_config2.hide_bias_tee));
+    pmem_dump_file.write_line("ui_config2 hide_clock: " + to_string_dec_uint(data->ui_config2.hide_clock));
+    pmem_dump_file.write_line("ui_config2 hide_sd_card: " + to_string_dec_uint(data->ui_config2.hide_sd_card));
+    pmem_dump_file.write_line("ui_config2 hide_mute: " + to_string_dec_uint(data->ui_config2.hide_mute));
+
+    // misc_config bits
+    pmem_dump_file.write_line("misc_config config_audio_mute: " + to_string_dec_int(config_audio_mute()));
+    pmem_dump_file.write_line("misc_config config_speaker_disable: " + to_string_dec_int(config_speaker_disable()));
+    pmem_dump_file.write_line("misc_config config_disable_external_tcxo: " + to_string_dec_uint(config_disable_external_tcxo()));
+    pmem_dump_file.write_line("misc_config config_sdcard_high_speed_io: " + to_string_dec_uint(config_sdcard_high_speed_io()));
+    pmem_dump_file.write_line("misc_config config_disable_config_mode: " + to_string_dec_uint(config_disable_config_mode()));
+
+    // receiver_model
+    pmem_dump_file.write_line("\n[Receiver Model]");
+    pmem_dump_file.write_line("target_frequency: " + to_string_dec_uint(receiver_model.target_frequency()));
+    pmem_dump_file.write_line("frequency_step: " + to_string_dec_uint(receiver_model.frequency_step()));
+    pmem_dump_file.write_line("lna: " + to_string_dec_int(receiver_model.lna()));
+    pmem_dump_file.write_line("vga: " + to_string_dec_int(receiver_model.vga()));
+    pmem_dump_file.write_line("rf_amp: " + to_string_dec_int(receiver_model.rf_amp()));
+    pmem_dump_file.write_line("baseband_bandwidth: " + to_string_dec_uint(receiver_model.baseband_bandwidth()));
+    pmem_dump_file.write_line("sampling_rate: " + to_string_dec_uint(receiver_model.sampling_rate()));
+    switch (receiver_model.modulation()) {
+        case ReceiverModel::Mode::AMAudio:
+            pmem_dump_file.write_line("modulation: Mode::AMAudio");
+            break;
+        case ReceiverModel::Mode::NarrowbandFMAudio:
+            pmem_dump_file.write_line("modulation: Mode::NarrowbandFMAudio");
+            break;
+        case ReceiverModel::Mode::WidebandFMAudio:
+            pmem_dump_file.write_line("modulation: Mode::WidebandFMAudio");
+            break;
+        case ReceiverModel::Mode::SpectrumAnalysis:
+            pmem_dump_file.write_line("modulation: Mode::SpectrumAnalysis");
+            break;
+        case ReceiverModel::Mode::Capture:
+            pmem_dump_file.write_line("modulation: Mode::Capture");
+            break;
+        default:
+            pmem_dump_file.write_line("modulation: !!unknown mode!!");
+            break;
+    }
+    pmem_dump_file.write_line("headphone_volume.centibel: " + to_string_dec_int(receiver_model.headphone_volume().centibel()));
+    pmem_dump_file.write_line("normalized_headphone_volume: " + to_string_dec_uint(receiver_model.normalized_headphone_volume()));
+    pmem_dump_file.write_line("am_configuration: " + to_string_dec_uint(receiver_model.am_configuration()));
+    pmem_dump_file.write_line("nbfm_configuration: " + to_string_dec_uint(receiver_model.nbfm_configuration()));
+    pmem_dump_file.write_line("wfm_configuration: " + to_string_dec_uint(receiver_model.wfm_configuration()));
+
+    // transmitter_model
+    pmem_dump_file.write_line("\n[Transmitter Model]");
+    pmem_dump_file.write_line("target_frequency: " + to_string_dec_uint(transmitter_model.target_frequency()));
+    pmem_dump_file.write_line("rf_amp: " + to_string_dec_int(transmitter_model.rf_amp()));
+    pmem_dump_file.write_line("baseband_bandwidth: " + to_string_dec_uint(transmitter_model.baseband_bandwidth()));
+    pmem_dump_file.write_line("sampling_rate: " + to_string_dec_uint(transmitter_model.sampling_rate()));
+    pmem_dump_file.write_line("tx_gain: " + to_string_dec_int(transmitter_model.tx_gain()));
+    pmem_dump_file.write_line("channel_bandwidth: " + to_string_dec_uint(transmitter_model.channel_bandwidth()));
+    // on screen information
+    painter.draw_string({0, 320 - 16}, ui::Styles::green, filename.filename().string() + " DUMPED !");
+    return true;
+}
+
+} /* namespace persistent_memory */
+} /* namespace portapack */

--- a/common/portapack_persistent_memory.hpp
+++ b/common/portapack_persistent_memory.hpp
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __PORTAPACK_PERSISTENT_MEMORY_H__
+#define __PORTAPACK_PERSISTENT_MEMORY_H__
+
+#include <cstdint>
+
+#include "optional.hpp"
+
+#include "rf_path.hpp"
+#include "touch.hpp"
+#include "modems.hpp"
+#include "serializer.hpp"
+#include "volume.hpp"
+
+// persistent memory from/to sdcard flag file
+#define PMEM_FILEFLAG u"/SETTINGS/PMEM_FILEFLAG"
+
+// persistent memory from/to sdcard flag file
+#define PMEM_SETTING_FILE u"/SETTINGS/pmem_settings"
+
+#define PMEM_SIZE_BYTES 256  // total amount of pmem space in bytes, including checksum
+#define PMEM_SIZE_WORDS (PMEM_SIZE_BYTES / 4)
+
+using namespace modems;
+using namespace serializer;
+
+namespace portapack {
+
+namespace persistent_memory {
+
+enum backlight_timeout_t {
+    Timeout5Sec = 0,
+    Timeout15Sec = 1,
+    Timeout30Sec = 2,
+    Timeout60Sec = 3,
+    Timeout180Sec = 4,
+    Timeout300Sec = 5,
+    Timeout600Sec = 6,
+    Timeout3600Sec = 7,
+};
+
+struct backlight_config_t {
+   public:
+    backlight_config_t()
+        : _timeout_enum(backlight_timeout_t::Timeout600Sec),
+          _timeout_enabled(false) {
+    }
+
+    backlight_config_t(
+        backlight_timeout_t timeout_enum,
+        bool timeout_enabled)
+        : _timeout_enum(timeout_enum),
+          _timeout_enabled(timeout_enabled) {
+    }
+
+    bool timeout_enabled() const {
+        return _timeout_enabled;
+    }
+
+    backlight_timeout_t timeout_enum() const {
+        return _timeout_enum;
+    }
+
+    uint32_t timeout_seconds() const {
+        switch (timeout_enum()) {
+            case Timeout5Sec:
+                return 5;
+            case Timeout15Sec:
+                return 15;
+            case Timeout30Sec:
+                return 30;
+            case Timeout60Sec:
+                return 60;
+            case Timeout180Sec:
+                return 180;
+            case Timeout300Sec:
+                return 300;
+            default:
+            case Timeout600Sec:
+                return 600;
+            case Timeout3600Sec:
+                return 3600;
+        }
+    }
+
+   private:
+    backlight_timeout_t _timeout_enum;
+    bool _timeout_enabled;
+};
+
+enum encoder_dial_sensitivity {
+    DIAL_SENSITIVITY_NORMAL = 0,
+    DIAL_SENSITIVITY_LOW = 1,
+    DIAL_SENSITIVITY_HIGH = 2,
+    NUM_DIAL_SENSITIVITY
+};
+
+typedef union {
+    uint32_t v;
+    struct {
+        uint8_t start_which : 4;
+        uint8_t start_weekday : 4;
+        uint8_t start_month : 4;
+        uint8_t end_which : 4;
+        uint8_t end_weekday : 4;
+        uint8_t end_month : 4;
+        uint8_t UNUSED : 7;
+        uint8_t dst_enabled : 1;
+    } b;
+} dst_config_t;
+static_assert(sizeof(dst_config_t) == sizeof(uint32_t));
+
+namespace cache {
+
+/* Set values in cache to sensible defaults. */
+void defaults();
+
+/* Load cached settings from values in persistent RAM, replacing with defaults
+ * if persistent RAM contents appear to be invalid. */
+void init();
+
+/* Calculate a check value for cached settings, and copy the check value and
+ * settings into persistent RAM. Intended to be called periodically to update
+ * persistent settings with current settings. */
+void persist();
+
+} /* namespace cache */
+
+using ppb_t = int32_t;
+
+rf::Frequency target_frequency();
+void set_target_frequency(const rf::Frequency new_value);
+
+volume_t headphone_volume();
+void set_headphone_volume(volume_t new_value);
+
+ppb_t correction_ppb();
+void set_correction_ppb(const ppb_t new_value);
+
+void set_touch_calibration(const touch::Calibration& new_value);
+const touch::Calibration& touch_calibration();
+
+serial_format_t serial_format();
+void set_serial_format(const serial_format_t new_value);
+
+int32_t tone_mix();
+void set_tone_mix(const int32_t new_value);
+
+int32_t afsk_mark_freq();
+void set_afsk_mark(const int32_t new_value);
+
+int32_t afsk_space_freq();
+void set_afsk_space(const int32_t new_value);
+
+int32_t modem_baudrate();
+void set_modem_baudrate(const int32_t new_value);
+
+uint8_t modem_repeat();
+void set_modem_repeat(const uint32_t new_value);
+
+uint32_t playing_dead();
+void set_playing_dead(const uint32_t new_value);
+
+uint32_t playdead_sequence();
+void set_playdead_sequence(const uint32_t new_value);
+
+bool stealth_mode();
+void set_stealth_mode(const bool v);
+
+uint8_t config_cpld();
+void set_config_cpld(uint8_t i);
+
+bool config_disable_external_tcxo();
+bool config_sdcard_high_speed_io();
+bool config_disable_config_mode();
+
+bool config_splash();
+bool config_converter();
+bool config_updown_converter();
+int64_t config_converter_freq();
+bool show_gui_return_icon();
+bool show_bigger_qr_code();
+bool hide_clock();
+bool clock_with_date();
+bool config_login();
+bool config_audio_mute();
+bool config_speaker_disable();
+backlight_config_t config_backlight_timer();
+bool disable_touchscreen();
+
+void set_gui_return_icon(bool v);
+void set_load_app_settings(bool v);
+void set_save_app_settings(bool v);
+void set_show_bigger_qr_code(bool v);
+void set_config_disable_external_tcxo(bool v);
+void set_config_sdcard_high_speed_io(bool v, bool save);
+void set_config_disable_config_mode(bool v);
+
+void set_config_splash(bool v);
+bool config_converter();
+bool config_updown_converter();
+int64_t config_converter_freq();
+void set_config_converter(bool v);
+void set_config_updown_converter(bool v);
+void set_config_converter_freq(int64_t v);
+bool config_freq_tx_correction_updown();
+void set_freq_tx_correction_updown(bool v);
+bool config_freq_rx_correction_updown();
+void set_freq_rx_correction_updown(bool v);
+uint32_t config_freq_tx_correction();
+uint32_t config_freq_rx_correction();
+void set_config_freq_tx_correction(uint32_t v);
+void set_config_freq_rx_correction(uint32_t v);
+void set_clock_hidden(bool v);
+void set_clock_with_date(bool v);
+void set_config_login(bool v);
+void set_config_audio_mute(bool v);
+void set_config_speaker_disable(bool v);
+void set_config_backlight_timer(const backlight_config_t& new_value);
+void set_disable_touchscreen(bool v);
+uint8_t config_encoder_dial_sensitivity();
+void set_encoder_dial_sensitivity(uint8_t v);
+
+#define CONFIG_MODE_GUARD_VALUE 0x000007d1
+#define CONFIG_MODE_NORMAL_VALUE 0x000007cf
+uint32_t config_mode_storage_direct();
+void set_config_mode_storage_direct(uint32_t v);
+bool config_disable_config_mode_direct();
+
+uint32_t pocsag_last_address();
+void set_pocsag_last_address(uint32_t address);
+
+uint32_t pocsag_ignore_address();
+void set_pocsag_ignore_address(uint32_t address);
+
+bool clkout_enabled();
+void set_clkout_enabled(bool v);
+void set_clkout_freq(uint16_t freq);
+
+bool dst_enabled();
+void set_dst_enabled(bool v);
+uint16_t clkout_freq();
+dst_config_t config_dst();
+void set_config_dst(dst_config_t v);
+
+/* Recon app */
+bool recon_autosave_freqs();
+bool recon_autostart_recon();
+bool recon_continuous();
+bool recon_clear_output();
+bool recon_load_freqs();
+bool recon_load_repeaters();
+bool recon_load_ranges();
+bool recon_update_ranges_when_recon();
+bool recon_auto_record_locked();
+bool recon_repeat_recorded();
+int8_t recon_repeat_nb();
+int8_t recon_repeat_gain();
+bool recon_repeat_amp();
+bool recon_load_hamradios();
+bool recon_match_mode();
+uint8_t recon_repeat_delay();
+void set_recon_autosave_freqs(const bool v);
+void set_recon_autostart_recon(const bool v);
+void set_recon_continuous(const bool v);
+void set_recon_clear_output(const bool v);
+void set_recon_load_freqs(const bool v);
+void set_recon_load_ranges(const bool v);
+void set_recon_update_ranges_when_recon(const bool v);
+void set_recon_auto_record_locked(const bool v);
+void set_recon_repeat_recorded(const bool v);
+void set_recon_repeat_nb(const int8_t v);
+void set_recon_repeat_gain(const int8_t v);
+void set_recon_repeat_amp(const bool v);
+void set_recon_load_hamradios(const bool v);
+void set_recon_load_repeaters(const bool v);
+void set_recon_match_mode(const bool v);
+void set_recon_repeat_delay(const uint8_t v);
+
+/* UI Config 2 */
+bool ui_hide_speaker();
+bool ui_hide_mute();
+bool ui_hide_converter();
+bool ui_hide_stealth();
+bool ui_hide_camera();
+bool ui_hide_sleep();
+bool ui_hide_bias_tee();
+bool ui_hide_clock();
+bool ui_hide_sd_card();
+void set_ui_hide_speaker(bool v);
+void set_ui_hide_mute(bool v);
+void set_ui_hide_converter(bool v);
+void set_ui_hide_stealth(bool v);
+void set_ui_hide_camera(bool v);
+void set_ui_hide_sleep(bool v);
+void set_ui_hide_bias_tee(bool v);
+void set_ui_hide_clock(bool v);
+void set_ui_hide_sd_card(bool v);
+
+// sd persisting settings
+bool should_use_sdcard_for_pmem();
+int save_persistent_settings_to_file();
+int load_persistent_settings_from_file();
+
+uint32_t pmem_data_word(uint32_t index);
+uint32_t pmem_stored_checksum(void);
+uint32_t pmem_calculated_checksum(void);
+
+size_t data_size();
+
+bool debug_dump();
+
+} /* namespace persistent_memory */
+
+} /* namespace portapack */
+
+#endif /*__PORTAPACK_PERSISTENT_MEMORY_H__*/

--- a/common/ui_widget.cpp
+++ b/common/ui_widget.cpp
@@ -1,0 +1,2637 @@
+/*
+ * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_widget.hpp"
+#include "ui_painter.hpp"
+#include "portapack.hpp"
+
+#include <cstdint>
+#include <cstddef>
+#include <algorithm>
+
+#include "chprintf.h"
+#include "irq_controls.hpp"
+#include "string_format.hpp"
+#include "usb_serial_device_to_host.h"
+#include "rtc_time.hpp"
+
+using namespace portapack;
+using namespace rtc_time;
+
+namespace ui {
+
+static bool ui_dirty = true;
+
+void dirty_set() {
+    ui_dirty = true;
+}
+
+void dirty_clear() {
+    ui_dirty = false;
+}
+
+bool is_dirty() {
+    return ui_dirty;
+}
+
+/* Widget ****************************************************************/
+
+const std::vector<Widget*> Widget::no_children{};
+
+Point Widget::screen_pos() {
+    return screen_rect().location();
+}
+
+Size Widget::size() const {
+    return _parent_rect.size();
+}
+
+Rect Widget::screen_rect() const {
+    return parent() ? (parent_rect() + parent()->screen_pos()) : parent_rect();
+}
+
+Rect Widget::parent_rect() const {
+    return _parent_rect;
+}
+
+void Widget::set_parent_rect(const Rect new_parent_rect) {
+    _parent_rect = new_parent_rect;
+    set_dirty();
+}
+
+Widget* Widget::parent() const {
+    return parent_;
+}
+
+void Widget::set_parent(Widget* const widget) {
+    if (widget == parent_) {
+        return;
+    }
+
+    if (parent_ && !widget) {
+        // We have a parent, but are losing it. Update visible status.
+        dirty_overlapping_children_in_rect(screen_rect());
+        visible(false);
+    }
+
+    parent_ = widget;
+
+    set_dirty();
+}
+
+void Widget::set_dirty() {
+    flags.dirty = true;
+    dirty_set();
+}
+
+bool Widget::dirty() const {
+    return flags.dirty;
+}
+
+void Widget::set_clean() {
+    flags.dirty = false;
+}
+
+void Widget::hidden(bool hide) {
+    if (hide != flags.hidden) {
+        flags.hidden = hide;
+
+        // If parent is hidden, either of these is a no-op.
+        if (hide) {
+            // TODO: Instead of dirtying parent entirely, dirty only children
+            // that overlap with this widget.
+
+            // parent()->dirty_overlapping_children_in_rect(parent_rect());
+
+            /* TODO: Notify self and all non-hidden children that they're
+             * now effectively hidden?
+             */
+        } else {
+            set_dirty();
+            /* TODO: Notify self and all non-hidden children that they're
+             * now effectively shown?
+             */
+        }
+    }
+}
+
+void Widget::focus() {
+    context().focus_manager().set_focus_widget(this);
+}
+
+void Widget::on_focus() {
+}
+
+void Widget::blur() {
+    context().focus_manager().set_focus_widget(nullptr);
+}
+
+void Widget::on_blur() {
+}
+
+bool Widget::focusable() const {
+    return flags.focusable;
+}
+
+void Widget::set_focusable(const bool value) {
+    flags.focusable = value;
+}
+
+bool Widget::has_focus() {
+    return (context().focus_manager().focus_widget() == this);
+}
+
+bool Widget::on_key(const KeyEvent event) {
+    (void)event;
+    return false;
+}
+
+bool Widget::on_encoder(const EncoderEvent event) {
+    (void)event;
+    return false;
+}
+
+bool Widget::on_touch(const TouchEvent event) {
+    (void)event;
+    return false;
+}
+bool Widget::on_keyboard(const KeyboardEvent event) {
+    (void)event;
+    return false;
+}
+
+const std::vector<Widget*>& Widget::children() const {
+    return no_children;
+}
+
+Context& Widget::context() const {
+    chDbgAssert(parent_, "parent_ is null",
+                "Check that parent isn't null before deref.");
+    return parent()->context();
+}
+
+void Widget::set_style(const Style* new_style) {
+    if (new_style != style_) {
+        style_ = new_style;
+        set_dirty();
+    }
+}
+
+const Style& Widget::style() const {
+    return style_ ? *style_ : parent()->style();
+}
+
+void Widget::visible(bool v) {
+    if (v != flags.visible) {
+        flags.visible = v;
+
+        /* TODO: This on_show/on_hide implementation seems inelegant.
+         * But I need *some* way to take/configure resources when
+         * a widget becomes visible, and reverse the process when the
+         * widget becomes invisible, whether the widget (or parent) is
+         * hidden, or the widget (or parent) is removed from the tree.
+         */
+        if (v) {
+            on_show();
+        } else {
+            on_hide();
+
+            // Set all children invisible too.
+            for (const auto child : children()) {
+                child->visible(false);
+            }
+        }
+    }
+}
+
+bool Widget::highlighted() const {
+    return flags.highlighted;
+}
+
+void Widget::set_highlighted(const bool value) {
+    flags.highlighted = value;
+}
+
+void Widget::dirty_overlapping_children_in_rect(const Rect& child_rect) {
+    for (auto child : children()) {
+        if (!child_rect.intersect(child->parent_rect()).is_empty()) {
+            child->set_dirty();
+        }
+    }
+}
+
+void Widget::getAccessibilityText(std::string& result) {
+    result = "";
+}
+void Widget::getWidgetName(std::string& result) {
+    result = "";
+}
+/* View ******************************************************************/
+
+void View::paint(Painter& painter) {
+    painter.fill_rectangle(
+        screen_rect(),
+        style().background);
+}
+
+void View::add_child(Widget* const widget) {
+    if (widget) {
+        if (widget->parent() == nullptr) {
+            widget->set_parent(this);
+            children_.push_back(widget);
+        }
+    }
+}
+
+void View::add_children(const std::initializer_list<Widget*> children) {
+    children_.insert(std::end(children_), children);
+    for (auto child : children) {
+        child->set_parent(this);
+    }
+}
+
+void View::remove_child(Widget* const widget) {
+    if (widget) {
+        children_.erase(std::remove(children_.begin(), children_.end(), widget), children_.end());
+        widget->set_parent(nullptr);
+    }
+}
+
+void View::remove_children(const std::vector<Widget*>& children) {
+    for (auto child : children) {
+        remove_child(child);
+    }
+}
+
+const std::vector<Widget*>& View::children() const {
+    return children_;
+}
+
+std::string View::title() const {
+    return "";
+};
+
+/* OptionTabView *********************************************************/
+
+OptionTabView::OptionTabView(Rect parent_rect) {
+    set_parent_rect(parent_rect);
+
+    add_child(&check_enable);
+    hidden(true);
+
+    check_enable.on_select = [this](Checkbox&, bool value) {
+        enabled = value;
+    };
+}
+
+void OptionTabView::set_enabled(bool value) {
+    check_enable.set_value(value);
+}
+
+bool OptionTabView::is_enabled() {
+    return check_enable.value();
+}
+
+void OptionTabView::set_type(std::string type) {
+    check_enable.set_text("Transmit " + type);
+}
+
+void OptionTabView::focus() {
+    check_enable.focus();
+}
+
+/* Rectangle *************************************************************/
+
+Rectangle::Rectangle(
+    Color c)
+    : Widget{},
+      color{c} {
+}
+
+Rectangle::Rectangle(
+    Rect parent_rect,
+    Color c)
+    : Widget{parent_rect},
+      color{c} {
+}
+
+void Rectangle::set_color(const Color c) {
+    color = c;
+    set_dirty();
+}
+
+void Rectangle::set_outline(const bool outline) {
+    _outline = outline;
+    set_dirty();
+}
+
+void Rectangle::paint(Painter& painter) {
+    if (!_outline) {
+        painter.fill_rectangle(
+            screen_rect(),
+            color);
+    } else {
+        painter.draw_rectangle(
+            screen_rect(),
+            color);
+    }
+}
+
+/* Text ******************************************************************/
+
+Text::Text(
+    Rect parent_rect,
+    std::string text)
+    : Widget{parent_rect},
+      text{std::move(text)} {
+}
+
+Text::Text(
+    Rect parent_rect)
+    : Text{parent_rect, {}} {
+}
+
+void Text::set(std::string_view value) {
+    text = std::string{value};
+    set_dirty();
+}
+
+void Text::getAccessibilityText(std::string& result) {
+    result = text;
+}
+void Text::getWidgetName(std::string& result) {
+    result = "Text";
+}
+void Text::paint(Painter& painter) {
+    const auto rect = screen_rect();
+    auto s = has_focus() ? style().invert() : style();
+    auto max_len = (unsigned)rect.width() / s.font.char_width();
+    auto text_view = std::string_view{text};
+
+    painter.fill_rectangle(rect, s.background);
+
+    if (text_view.length() > max_len)
+        text_view = text_view.substr(0, max_len);
+
+    painter.draw_string(
+        rect.location(),
+        s,
+        text_view);
+}
+
+/* Labels ****************************************************************/
+
+Labels::Labels(
+    std::initializer_list<Label> labels)
+    : labels_{labels} {
+}
+
+void Labels::set_labels(std::initializer_list<Label> labels) {
+    labels_ = labels;
+    set_dirty();
+}
+
+void Labels::paint(Painter& painter) {
+    for (auto& label : labels_) {
+        painter.draw_string(
+            label.pos + screen_pos(),
+            style().font,
+            label.color,
+            style().background,
+            label.text);
+    }
+}
+
+void Labels::getAccessibilityText(std::string& result) {
+    result = "";
+    for (auto& label : labels_) {
+        result += label.text;
+        result += ", ";
+    }
+}
+void Labels::getWidgetName(std::string& result) {
+    result = "Labels";
+}
+
+/* LiveDateTime **********************************************************/
+
+void LiveDateTime::on_tick_second() {
+    rtc_time::now(datetime);
+    text = "";
+    if (!hide_clock) {
+        if (date_enabled) {
+            text = to_string_dec_uint(datetime.year(), 4, '0') + "-" +
+                   to_string_dec_uint(datetime.month(), 2, '0') + "-" +
+                   to_string_dec_uint(datetime.day(), 2, '0') + " ";
+        } else {
+            text = "           ";
+        }
+
+        text = text + to_string_dec_uint(datetime.hour(), 2, '0') + ":" + to_string_dec_uint(datetime.minute(), 2, '0');
+
+        if (seconds_enabled) {
+            text += ":";
+
+            if (init_delay == 0)
+                text += to_string_dec_uint(datetime.second(), 2, '0');
+            else {
+                // Placeholder while the seconds are not updated
+                text += "XX";
+                init_delay--;
+            }
+        }
+    }
+    set_dirty();
+}
+
+LiveDateTime::LiveDateTime(
+    Rect parent_rect)
+    : Widget{parent_rect} {
+    signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
+        this->on_tick_second();
+    };
+}
+
+LiveDateTime::~LiveDateTime() {
+    rtc_time::signal_tick_second -= signal_token_tick_second;
+}
+
+void LiveDateTime::paint(Painter& painter) {
+    const auto rect = screen_rect();
+    const auto s = style();
+
+    on_tick_second();
+
+    painter.fill_rectangle(rect, s.background);
+
+    painter.draw_string(
+        rect.location(),
+        s,
+        text);
+}
+void LiveDateTime::set_hide_clock(bool new_value) {
+    this->hide_clock = new_value;
+}
+
+void LiveDateTime::set_date_enabled(bool new_value) {
+    this->date_enabled = new_value;
+}
+
+void LiveDateTime::set_seconds_enabled(bool new_value) {
+    this->seconds_enabled = new_value;
+}
+
+/* BigFrequency **********************************************************/
+
+BigFrequency::BigFrequency(
+    Rect parent_rect,
+    rf::Frequency frequency)
+    : Widget{parent_rect},
+      _frequency{frequency} {
+}
+
+void BigFrequency::set(const rf::Frequency frequency) {
+    _frequency = frequency;
+    set_dirty();
+}
+
+void BigFrequency::paint(Painter& painter) {
+    uint32_t i, digit_def;
+    std::array<char, 7> digits;
+    char digit;
+    Point digit_pos;
+    ui::Color segment_color;
+
+    const auto rect = screen_rect();
+
+    // Erase
+    painter.fill_rectangle(
+        {{0, rect.location().y()}, {screen_width, 52}},
+        ui::Color::black());
+
+    // Prepare digits
+    if (!_frequency) {
+        digits.fill(10);  // ----.---
+        digit_pos = {0, rect.location().y()};
+    } else {
+        _frequency /= 1000;  // GMMM.KKK(uuu)
+
+        for (i = 0; i < 7; i++) {
+            digits[6 - i] = _frequency % 10;
+            _frequency /= 10;
+        }
+
+        // Remove leading zeros
+        for (i = 0; i < 3; i++) {
+            if (!digits[i])
+                digits[i] = 16;  // "Don't draw" code
+            else
+                break;
+        }
+
+        digit_pos = {(Coord)(240 - ((7 * digit_width) + 8) - (i * digit_width)) / 2, rect.location().y()};
+    }
+
+    segment_color = style().foreground;
+
+    // Draw
+    for (i = 0; i < 7; i++) {
+        digit = digits[i];
+
+        if (digit < 16) {
+            digit_def = segment_font[(uint8_t)digit];
+
+            for (size_t s = 0; s < 7; s++) {
+                if (digit_def & 1)
+                    painter.fill_rectangle({digit_pos + segments[s].location(), segments[s].size()}, segment_color);
+                digit_def >>= 1;
+            }
+        }
+
+        if (i == 3) {
+            // Dot
+            painter.fill_rectangle({digit_pos + Point(34, 48), {4, 4}}, segment_color);
+            digit_pos += {(digit_width + 8), 0};
+        } else {
+            digit_pos += {digit_width, 0};
+        }
+    }
+}
+
+/* ProgressBar ***********************************************************/
+
+ProgressBar::ProgressBar(
+    Rect parent_rect)
+    : Widget{parent_rect} {
+}
+
+void ProgressBar::set_max(const uint32_t max) {
+    if (max == _max) return;
+
+    if (_value > _max)
+        _value = _max;
+
+    _max = max;
+    set_dirty();
+}
+
+void ProgressBar::set_value(const uint32_t value) {
+    if (value == _value) return;
+
+    if (value > _max)
+        _value = _max;
+    else
+        _value = value;
+    set_dirty();
+}
+
+void ProgressBar::getAccessibilityText(std::string& result) {
+    result = to_string_dec_uint(_value) + " / " + to_string_dec_uint(_max);
+}
+void ProgressBar::getWidgetName(std::string& result) {
+    result = "ProgressBar";
+}
+
+void ProgressBar::paint(Painter& painter) {
+    int v_scaled;
+
+    const auto sr = screen_rect();
+    const auto s = style();
+
+    v_scaled = (sr.size().width() * (uint64_t)_value) / _max;
+
+    painter.fill_rectangle({sr.location(), {v_scaled, sr.size().height()}}, style().foreground);
+    painter.fill_rectangle({{sr.location().x() + v_scaled, sr.location().y()}, {sr.size().width() - v_scaled, sr.size().height()}}, s.background);
+
+    painter.draw_rectangle(sr, s.foreground);
+}
+
+/* ActivityDot ***********************************************************/
+
+ActivityDot::ActivityDot(
+    Rect parent_rect,
+    Color color)
+    : Widget{parent_rect},
+      _color{color} {}
+
+void ActivityDot::paint(Painter& painter) {
+    painter.fill_rectangle(screen_rect(), _on ? _color : Color::grey());
+}
+
+void ActivityDot::toggle() {
+    _on = !_on;
+    set_dirty();
+}
+
+void ActivityDot::reset() {
+    _on = false;
+    set_dirty();
+}
+
+/* Console ***************************************************************/
+
+Console::Console(
+    Rect parent_rect)
+    : Widget{parent_rect} {
+}
+
+void Console::clear(bool clear_buffer = false) {
+    if (clear_buffer)
+        buffer.clear();
+
+    if (!hidden() && visible()) {
+        display.fill_rectangle(
+            screen_rect(),
+            Color::black());
+    }
+
+    pos = {0, 0};
+}
+
+void Console::write(std::string message) {
+    bool escape = false;
+
+    if (!hidden() && visible()) {
+        const Style& s = style();
+        const Font& font = s.font;
+        auto rect = screen_rect();
+        ui::Color pen_color = s.foreground;
+
+        for (auto c : message) {
+            if (escape) {
+                if (c < std::size(term_colors))
+                    pen_color = term_colors[(uint8_t)c];
+                else
+                    pen_color = s.foreground;
+                escape = false;
+            } else {
+                if (c == '\n') {
+                    crlf();
+                } else if (c == '\r') {
+                    pos = {0, pos.y()};
+                } else if (c == '\x1B') {
+                    escape = true;
+                } else {
+                    auto glyph = font.glyph(c);
+                    auto advance = glyph.advance();
+                    // Would drawing next character be off the end? Newline.
+                    if ((pos.x() + advance.x()) > rect.width())
+                        crlf();
+
+                    Point pos_glyph{
+                        rect.left() + pos.x(),
+                        display.scroll_area_y(pos.y())};
+                    display.draw_glyph(pos_glyph, glyph, pen_color, s.background);
+                    pos += {advance.x(), 0};
+                }
+            }
+        }
+        buffer = message;
+    } else {
+        if (buffer.size() < 256) buffer += message;
+    }
+}
+
+void Console::getAccessibilityText(std::string& result) {
+    result = "{" + buffer + "}";
+}
+void Console::getWidgetName(std::string& result) {
+    result = "Console";
+}
+
+void Console::writeln(std::string message) {
+    write(message + "\n");
+}
+
+void Console::paint(Painter&) {
+    write(buffer);
+}
+
+void Console::on_show() {
+    enable_scrolling(true);
+    clear();
+}
+
+bool Console::scrolling_enabled = false;
+
+void Console::enable_scrolling(bool enable) {
+    if (enable) {
+        auto sr = screen_rect();
+        auto line_height = style().font.line_height();
+
+        // Count full lines that can fit in console's rectangle.
+        auto max_lines = sr.height() / line_height;  // NB: int division to floor.
+
+        // The scroll area must be a multiple of the line_height
+        // or some lines will end up vertically truncated.
+        scroll_height = max_lines * line_height;
+
+        display.scroll_set_area(sr.top(), sr.top() + scroll_height);
+        display.scroll_set_position(0);
+        scrolling_enabled = true;
+    } else {
+        display.scroll_disable();
+        scrolling_enabled = false;
+    }
+}
+
+void Console::on_hide() {
+    /* TODO: Clear region to eliminate brief flash of content at un-shifted
+     * position? */
+    enable_scrolling(false);
+}
+
+void Console::crlf() {
+    if (hidden() || !visible()) return;
+
+    const auto& s = style();
+    auto sr = screen_rect();
+    auto line_height = s.font.line_height();
+
+    // Advance to the next line (\n) position and "carriage return" x to 0.
+    pos = {0, pos.y() + line_height};
+
+    if (pos.y() >= scroll_height) {
+        // Line is past off the "bottom", need to scroll.
+        if (!scrolling_enabled)
+            enable_scrolling(true);
+
+        // See the notes in lcd_ili9341.hpp about how scrolling works.
+        // The gist is that VSA will be moved to scroll the "top" off the
+        // screen. The drawing code uses 'scroll_area_y' to get the actual
+        // screen coordinate based on VSA. The "bottom" line is *always*
+        // at 'VSA + ((max_lines - 1) * line_height)' and so is constant.
+        pos = {0, scroll_height - line_height};
+
+        // Scroll off the "top" line.
+        display.scroll(-line_height);
+
+        // Clear the new line at the "bottom".
+        Rect dirty{sr.left(), display.scroll_area_y(pos.y()), sr.width(), line_height};
+        display.fill_rectangle(dirty, s.background);
+    }
+}
+
+/* Checkbox **************************************************************/
+
+Checkbox::Checkbox(
+    Point parent_pos,
+    size_t length,
+    std::string text,
+    bool small)
+    : Widget{},
+      text_{text},
+      small_{small} {
+    if (!small_)
+        set_parent_rect({parent_pos, {static_cast<ui::Dim>((8 * length) + 24), 24}});
+    else
+        set_parent_rect({parent_pos, {static_cast<ui::Dim>((8 * length) + 16), 16}});
+
+    set_focusable(true);
+}
+
+void Checkbox::set_text(const std::string value) {
+    text_ = value;
+    set_dirty();
+}
+
+bool Checkbox::set_value(const bool value) {
+    value_ = value;
+    set_dirty();
+
+    if (on_select) {
+        on_select(*this, value_);
+        return true;
+    }
+
+    return false;
+}
+
+void Checkbox::getAccessibilityText(std::string& result) {
+    result = text_ + ((value_) ? " checked" : " unchecked");
+}
+void Checkbox::getWidgetName(std::string& result) {
+    result = "Checkbox";
+}
+
+bool Checkbox::value() const {
+    return value_;
+}
+
+void Checkbox::paint(Painter& painter) {
+    const auto r = screen_rect();
+
+    const auto paint_style = (has_focus() || highlighted()) ? style().invert() : style();
+
+    const auto x = r.location().x();
+    const auto y = r.location().y();
+
+    const auto label_r = paint_style.font.size_of(text_);
+
+    if (!small_) {
+        painter.draw_rectangle({{r.location()}, {24, 24}}, style().foreground);
+
+        painter.fill_rectangle({x + 1, y + 1, 24 - 2, 24 - 2}, style().background);
+
+        // Highlight
+        painter.draw_rectangle({x + 2, y + 2, 24 - 4, 24 - 4}, paint_style.background);
+
+        if (value_ == true) {
+            // Check
+            portapack::display.draw_line({x + 2, y + 14}, {x + 6, y + 18}, ui::Color::green());
+            portapack::display.draw_line({x + 6, y + 18}, {x + 20, y + 4}, ui::Color::green());
+        } else {
+            // Cross
+            portapack::display.draw_line({x + 1, y + 1}, {x + 24 - 2, y + 24 - 2}, ui::Color::red());
+            portapack::display.draw_line({x + 24 - 2, y + 1}, {x + 1, y + 24 - 2}, ui::Color::red());
+        }
+
+        painter.draw_string(
+            {static_cast<Coord>(x + 24 + 4),
+             static_cast<Coord>(y + (24 - label_r.height()) / 2)},
+            paint_style,
+            text_);
+    } else {
+        painter.draw_rectangle({{r.location()}, {16, 16}}, style().foreground);
+
+        painter.fill_rectangle({x + 1, y + 1, 16 - 2, 16 - 2}, style().background);
+
+        // Highlight
+        painter.draw_rectangle({x + 1, y + 1, 16 - 2, 16 - 2}, paint_style.background);
+
+        if (value_ == true) {
+            // Check
+            portapack::display.draw_line({x + 2, y + 8}, {x + 6, y + 12}, ui::Color::green());
+            portapack::display.draw_line({x + 6, y + 12}, {x + 13, y + 5}, ui::Color::green());
+        } else {
+            // Cross
+            portapack::display.draw_line({x + 1, y + 1}, {x + 16 - 2, y + 16 - 2}, ui::Color::red());
+            portapack::display.draw_line({x + 16 - 2, y + 1}, {x + 1, y + 16 - 2}, ui::Color::red());
+        }
+
+        painter.draw_string(
+            {static_cast<Coord>(x + 16 + 2),
+             static_cast<Coord>(y + (16 - label_r.height()) / 2)},
+            paint_style,
+            text_);
+    }
+}
+
+bool Checkbox::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Select)
+        return set_value(not value_);
+
+    return false;
+}
+
+bool Checkbox::on_keyboard(const KeyboardEvent event) {
+    if (event == 10 || event == 32) return set_value(not value_);
+    return false;
+}
+
+bool Checkbox::on_touch(const TouchEvent event) {
+    switch (event.type) {
+        case TouchEvent::Type::Start:
+            set_highlighted(true);
+            set_dirty();
+            return true;
+
+        case TouchEvent::Type::End:
+            set_highlighted(false);
+            value_ = not value_;
+            set_dirty();
+            if (on_select) {
+                on_select(*this, value_);
+            }
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+/* Button ****************************************************************/
+
+Button::Button(
+    Rect parent_rect,
+    std::string text,
+    bool instant_exec)
+    : Widget{parent_rect},
+      text_{text},
+      instant_exec_{instant_exec} {
+    set_focusable(true);
+}
+
+void Button::set_text(const std::string value) {
+    text_ = value;
+    set_dirty();
+}
+
+std::string Button::text() const {
+    return text_;
+}
+
+void Button::getAccessibilityText(std::string& result) {
+    result = text_;
+}
+void Button::getWidgetName(std::string& result) {
+    result = "Button";
+}
+
+void Button::paint(Painter& painter) {
+    Color bg, fg;
+    const auto r = screen_rect();
+
+    if (has_focus() || highlighted()) {
+        bg = style().foreground;
+        fg = Color::black();
+    } else {
+        bg = Color::grey();
+        fg = style().foreground;
+    }
+
+    const Style paint_style = {style().font, bg, fg};
+
+    painter.draw_rectangle({r.location(), {r.size().width(), 1}}, Color::light_grey());
+    painter.draw_rectangle({r.location().x(), r.location().y() + r.size().height() - 1, r.size().width(), 1}, Color::dark_grey());
+    painter.draw_rectangle({r.location().x() + r.size().width() - 1, r.location().y(), 1, r.size().height()}, Color::dark_grey());
+
+    painter.fill_rectangle(
+        {r.location().x(), r.location().y() + 1, r.size().width() - 1, r.size().height() - 2},
+        paint_style.background);
+
+    const auto label_r = paint_style.font.size_of(text_);
+    painter.draw_string(
+        {r.location().x() + (r.size().width() - label_r.width()) / 2, r.location().y() + (r.size().height() - label_r.height()) / 2},
+        paint_style,
+        text_);
+}
+
+void Button::on_focus() {
+    if (on_highlight)
+        on_highlight(*this);
+}
+
+bool Button::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Select) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    } else {
+        if (on_dir) {
+            return on_dir(*this, key);
+        }
+    }
+
+    return false;
+}
+
+bool Button::on_keyboard(const KeyboardEvent event) {
+    if (event == 10 || event == 32) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Button::on_touch(const TouchEvent event) {
+    switch (event.type) {
+        case TouchEvent::Type::Start:
+            set_highlighted(true);
+            set_dirty();
+            if (on_touch_press) {
+                on_touch_press(*this);
+            }
+            if (on_select && instant_exec_) {
+                on_select(*this);
+            }
+            return true;
+
+        case TouchEvent::Type::End:
+            set_highlighted(false);
+            set_dirty();
+            if (on_touch_release) {
+                on_touch_release(*this);
+            }
+            if (on_select && !instant_exec_) {
+                on_select(*this);
+            }
+            return true;
+
+        default:
+            return false;
+    }
+#if 0
+	switch(event.type) {
+	case TouchEvent::Type::Start:
+		flags.highlighted = true;
+		set_dirty();
+		return true;
+
+	case TouchEvent::Type::Move:
+		{
+			const bool new_highlighted = screen_rect().contains(event.point);
+			if( flags.highlighted != new_highlighted ) {
+				flags.highlighted = new_highlighted;
+				set_dirty();
+			}
+		}
+		return true;
+
+	case TouchEvent::Type::End:
+		if( flags.highlighted ) {
+			flags.highlighted = false;
+			set_dirty();
+			if( on_select ) {
+				on_select(*this);
+			}
+		}
+		return true;
+
+	default:
+		return false;
+	}
+#endif
+}
+
+/* ButtonWithEncoder ****************************************************************/
+
+ButtonWithEncoder::ButtonWithEncoder(
+    Rect parent_rect,
+    std::string text,
+    bool instant_exec)
+    : Widget{parent_rect},
+      text_{text},
+      instant_exec_{instant_exec} {
+    set_focusable(true);
+}
+
+void ButtonWithEncoder::set_text(const std::string value) {
+    text_ = value;
+    set_dirty();
+}
+int32_t ButtonWithEncoder::get_encoder_delta() {
+    return encoder_delta;
+}
+void ButtonWithEncoder::set_encoder_delta(const int32_t delta) {
+    encoder_delta = delta;
+}
+
+std::string ButtonWithEncoder::text() const {
+    return text_;
+}
+
+void ButtonWithEncoder::getAccessibilityText(std::string& result) {
+    result = text_;
+}
+void ButtonWithEncoder::getWidgetName(std::string& result) {
+    result = "ButtonWithEncoder";
+}
+
+void ButtonWithEncoder::paint(Painter& painter) {
+    Color bg, fg;
+    const auto r = screen_rect();
+
+    if (has_focus() || highlighted()) {
+        bg = style().foreground;
+        fg = Color::black();
+    } else {
+        bg = Color::grey();
+        fg = style().foreground;
+    }
+
+    const Style paint_style = {style().font, bg, fg};
+
+    painter.draw_rectangle({r.location(), {r.size().width(), 1}}, Color::light_grey());
+    painter.draw_rectangle({r.location().x(), r.location().y() + r.size().height() - 1, r.size().width(), 1}, Color::dark_grey());
+    painter.draw_rectangle({r.location().x() + r.size().width() - 1, r.location().y(), 1, r.size().height()}, Color::dark_grey());
+
+    painter.fill_rectangle(
+        {r.location().x(), r.location().y() + 1, r.size().width() - 1, r.size().height() - 2},
+        paint_style.background);
+
+    const auto label_r = paint_style.font.size_of(text_);
+    painter.draw_string(
+        {r.location().x() + (r.size().width() - label_r.width()) / 2, r.location().y() + (r.size().height() - label_r.height()) / 2},
+        paint_style,
+        text_);
+}
+
+void ButtonWithEncoder::on_focus() {
+    if (on_highlight)
+        on_highlight(*this);
+}
+
+bool ButtonWithEncoder::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Select) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    } else {
+        if (on_dir) {
+            return on_dir(*this, key);
+        }
+    }
+
+    return false;
+}
+
+bool ButtonWithEncoder::on_keyboard(const KeyboardEvent key) {
+    if (key == 32 || key == 10) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ButtonWithEncoder::on_touch(const TouchEvent event) {
+    switch (event.type) {
+        case TouchEvent::Type::Start:
+            set_highlighted(true);
+            set_dirty();
+            if (on_touch_press) {
+                on_touch_press(*this);
+            }
+            if (on_select && instant_exec_) {
+                on_select(*this);
+            }
+            return true;
+
+        case TouchEvent::Type::End:
+            set_highlighted(false);
+            set_dirty();
+            if (on_touch_release) {
+                on_touch_release(*this);
+            }
+            if (on_select && !instant_exec_) {
+                on_select(*this);
+            }
+            return true;
+
+        default:
+            return false;
+    }
+#if 0
+	switch(event.type) {
+	case TouchEvent::Type::Start:
+		flags.highlighted = true;
+		set_dirty();
+		return true;
+
+	case TouchEvent::Type::Move:
+		{
+			const bool new_highlighted = screen_rect().contains(event.point);
+			if( flags.highlighted != new_highlighted ) {
+				flags.highlighted = new_highlighted;
+				set_dirty();
+			}
+		}
+		return true;
+
+	case TouchEvent::Type::End:
+		if( flags.highlighted ) {
+			flags.highlighted = false;
+			set_dirty();
+			if( on_select ) {
+				on_select(*this);
+			}
+		}
+		return true;
+
+	default:
+		return false;
+	}
+#endif
+}
+bool ButtonWithEncoder::on_encoder(const EncoderEvent delta) {
+    if (delta != 0) {
+        encoder_delta += delta;
+        delta_change = true;
+        on_change();
+    } else
+        delta_change = 0;
+    return true;
+}
+
+/* NewButton ****************************************************************/
+
+NewButton::NewButton(
+    Rect parent_rect,
+    std::string text,
+    const Bitmap* bitmap)
+    : NewButton{parent_rect, text, bitmap, Color::dark_cyan()} {}
+
+NewButton::NewButton(
+    Rect parent_rect,
+    std::string text,
+    const Bitmap* bitmap,
+    Color color,
+    bool vertical_center)
+    : Widget{parent_rect},
+      color_{color},
+      text_{text},
+      bitmap_{bitmap},
+      vertical_center_{vertical_center} {
+    set_focusable(true);
+}
+
+void NewButton::set_text(const std::string value) {
+    text_ = value;
+    set_dirty();
+}
+
+void NewButton::getAccessibilityText(std::string& result) {
+    result = text_;
+}
+void NewButton::getWidgetName(std::string& result) {
+    result = "NewButton";
+}
+
+std::string NewButton::text() const {
+    return text_;
+}
+
+void NewButton::set_bitmap(const Bitmap* bitmap) {
+    bitmap_ = bitmap;
+    set_dirty();
+}
+
+const Bitmap* NewButton::bitmap() {
+    return bitmap_;
+}
+
+void NewButton::set_color(Color color) {
+    color_ = color;
+    set_dirty();
+}
+
+void NewButton::set_vertical_center(bool value) {
+    vertical_center_ = value;
+    set_dirty();
+}
+
+ui::Color NewButton::color() {
+    return color_;
+}
+
+void NewButton::paint(Painter& painter) {
+    if (!bitmap_ && text_.empty())
+        return;
+
+    const auto r = screen_rect();
+    const Style style = paint_style();
+
+    painter.draw_rectangle({r.location(), {r.width(), 1}}, Color::light_grey());
+    painter.draw_rectangle({r.left(), r.top() + r.height() - 1, r.width(), 1}, Color::dark_grey());
+    painter.draw_rectangle({r.left() + r.width() - 1, r.top(), 1, r.height()}, Color::dark_grey());
+
+    painter.fill_rectangle(
+        {r.left(), r.top() + 1, r.width() - 1, r.height() - 2},
+        style.background);
+
+    int y = r.top();
+    if (bitmap_) {
+        int offset_y = vertical_center_ ? (r.height() / 2) - (bitmap_->size.height() / 2) : 6;
+        Point bmp_pos = {r.left() + (r.width() / 2) - (bitmap_->size.width() / 2), r.top() + offset_y};
+        y += bitmap_->size.height() - offset_y;
+
+        painter.draw_bitmap(
+            bmp_pos,
+            *bitmap_,
+            color_,
+            style.background);
+    }
+
+    if (!text_.empty()) {
+        const auto label_r = style.font.size_of(text_);
+        painter.draw_string(
+            {r.left() + (r.width() - label_r.width()) / 2, y + (r.height() - label_r.height()) / 2},
+            style,
+            text_);
+    }
+}
+
+Style NewButton::paint_style() {
+    MutableStyle s{style()};
+
+    if (has_focus() || highlighted()) {
+        s.background = style().foreground;
+        s.foreground = Color::black();
+    } else {
+        s.background = Color::grey();
+        s.foreground = style().foreground;
+    }
+
+    return s;
+}
+
+void NewButton::on_focus() {
+    if (on_highlight)
+        on_highlight(*this);
+}
+
+bool NewButton::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Select) {
+        if (on_select) {
+            on_select();
+            return true;
+        }
+    } else {
+        if (on_dir) {
+            return on_dir(*this, key);
+        }
+    }
+
+    return false;
+}
+
+bool NewButton::on_keyboard(const KeyboardEvent key) {
+    if (key == 32 || key == 10) {
+        if (on_select) {
+            on_select();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool NewButton::on_touch(const TouchEvent event) {
+    switch (event.type) {
+        case TouchEvent::Type::Start:
+            set_highlighted(true);
+            set_dirty();
+            return true;
+
+        case TouchEvent::Type::End:
+            set_highlighted(false);
+            set_dirty();
+            if (on_select) {
+                on_select();
+            }
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+/* Image *****************************************************************/
+
+Image::Image()
+    : Image{{}, nullptr, Color::white(), Color::black()} {
+}
+
+Image::Image(
+    const Rect parent_rect,
+    const Bitmap* bitmap,
+    const Color foreground,
+    const Color background)
+    : Widget{parent_rect},
+      bitmap_{bitmap},
+      foreground_{foreground},
+      background_{background} {
+}
+
+void Image::set_bitmap(const Bitmap* bitmap) {
+    bitmap_ = bitmap;
+    set_dirty();
+}
+
+void Image::set_foreground(const Color color) {
+    foreground_ = color;
+    set_dirty();
+}
+
+void Image::set_background(const Color color) {
+    background_ = color;
+    set_dirty();
+}
+
+void Image::invert_colors() {
+    Color temp;
+
+    temp = background_;
+    background_ = foreground_;
+    foreground_ = temp;
+    set_dirty();
+}
+
+void Image::paint(Painter& painter) {
+    if (bitmap_) {
+        // Code also handles ImageButton behavior.
+        const bool selected = (has_focus() || highlighted());
+        painter.draw_bitmap(
+            screen_pos(),
+            *bitmap_,
+            selected ? background_ : foreground_,
+            selected ? foreground_ : background_);
+    }
+}
+
+/* ImageButton ***********************************************************/
+
+// TODO: Virtually all this code is duplicated from Button. Base class?
+
+ImageButton::ImageButton(
+    const Rect parent_rect,
+    const Bitmap* bitmap,
+    const Color foreground,
+    const Color background)
+    : Image{parent_rect, bitmap, foreground, background} {
+    set_focusable(true);
+}
+
+void ImageButton::getAccessibilityText(std::string& result) {
+    result = "image";
+}
+void ImageButton::getWidgetName(std::string& result) {
+    result = "ImageButton";
+}
+
+bool ImageButton::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Select) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ImageButton::on_keyboard(const KeyboardEvent key) {
+    if (key == 32 || key == 10) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ImageButton::on_touch(const TouchEvent event) {
+    switch (event.type) {
+        case TouchEvent::Type::Start:
+            set_highlighted(true);
+            set_dirty();
+            return true;
+
+        case TouchEvent::Type::End:
+            set_highlighted(false);
+            set_dirty();
+            if (on_select) {
+                on_select(*this);
+            }
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+/* ImageToggle ***********************************************************/
+ImageToggle::ImageToggle(
+    Rect parent_rect,
+    const Bitmap* bitmap_)
+    : ImageToggle{parent_rect,
+                  bitmap_,
+                  Color::green(),
+                  Color::light_grey(),
+                  Color::dark_grey()} {}
+
+ImageToggle::ImageToggle(
+    Rect parent_rect,
+    const Bitmap* bitmap_,
+    Color foreground_true,
+    Color foreground_false,
+    Color background_)
+    : ImageToggle{parent_rect,
+                  bitmap_,
+                  bitmap_,
+                  foreground_true,
+                  background_,
+                  foreground_false,
+                  background_} {}
+
+ImageToggle::ImageToggle(
+    Rect parent_rect,
+    const Bitmap* bitmap_true,
+    const Bitmap* bitmap_false,
+    Color foreground_true,
+    Color background_true,
+    Color foreground_false,
+    Color background_false)
+    : ImageButton{parent_rect, bitmap_false, foreground_false, background_false},
+      bitmap_true_{bitmap_true},
+      bitmap_false_{bitmap_false},
+      foreground_true_{foreground_true},
+      background_true_{background_true},
+      foreground_false_{foreground_false},
+      background_false_{background_false},
+      value_{false} {
+    ImageButton::on_select = [this](ImageButton&) {
+        set_value(!value());
+    };
+}
+
+bool ImageToggle::value() const {
+    return value_;
+}
+
+void ImageToggle::getAccessibilityText(std::string& result) {
+    result = value_ ? "checked" : "unchecked";
+}
+void ImageToggle::getWidgetName(std::string& result) {
+    result = "ImageToggle";
+}
+
+void ImageToggle::set_value(bool b) {
+    if (b == value_)
+        return;
+
+    value_ = b;
+    set_bitmap(b ? bitmap_true_ : bitmap_false_);
+    set_foreground(b ? foreground_true_ : foreground_false_);
+    set_background(b ? background_true_ : background_false_);
+
+    if (on_change)
+        on_change(b);
+}
+
+/* ImageOptionsField *****************************************************/
+
+ImageOptionsField::ImageOptionsField(
+    Rect parent_rect,
+    Color foreground,
+    Color background,
+    options_t options)
+    : Widget{parent_rect},
+      options{std::move(options)},
+      foreground_{foreground},
+      background_{background} {
+    set_focusable(true);
+}
+
+size_t ImageOptionsField::selected_index() const {
+    return selected_index_;
+}
+
+size_t ImageOptionsField::selected_index_value() const {
+    return options[selected_index_].second;
+}
+
+void ImageOptionsField::getAccessibilityText(std::string& result) {
+    result = "selected index: " + to_string_dec_uint(selected_index_);
+}
+void ImageOptionsField::getWidgetName(std::string& result) {
+    result = "ImageOptionsField";
+}
+
+void ImageOptionsField::set_selected_index(const size_t new_index) {
+    if (new_index < options.size()) {
+        if (new_index != selected_index()) {
+            selected_index_ = new_index;
+            if (on_change) {
+                on_change(selected_index(), options[selected_index()].second);
+            }
+            set_dirty();
+        }
+    }
+}
+
+void ImageOptionsField::set_by_value(value_t v) {
+    size_t new_index = 0;
+    for (const auto& option : options) {
+        if (option.second == v) {
+            set_selected_index(new_index);
+            return;
+        }
+
+        new_index++;
+    }
+
+    // No exact match was found, default to 0.
+    set_selected_index(0);
+}
+
+void ImageOptionsField::set_options(options_t new_options) {
+    options = std::move(new_options);
+
+    // Set an invalid index to force on_change.
+    selected_index_ = (size_t)-1;
+    set_selected_index(0);
+    set_dirty();
+}
+
+void ImageOptionsField::paint(Painter& painter) {
+    const bool selected = (has_focus() || highlighted());
+    const auto paint_style = selected ? style().invert() : style();
+
+    painter.draw_rectangle(
+        {screen_rect().location(), {screen_rect().size().width() + 4, screen_rect().size().height() + 4}},
+        paint_style.background);
+
+    painter.draw_bitmap(
+        {screen_pos().x() + 2, screen_pos().y() + 2},
+        *options[selected_index_].first,
+        foreground_,
+        background_);
+}
+
+void ImageOptionsField::on_focus() {
+    if (on_show_options) {
+        on_show_options();
+    }
+}
+
+bool ImageOptionsField::on_encoder(const EncoderEvent delta) {
+    set_selected_index(selected_index() + delta);
+    return true;
+}
+
+bool ImageOptionsField::on_keyboard(const KeyboardEvent key) {
+    if (key == '+' || key == ' ' || key == 10) return on_encoder(1);
+    if (key == '-' || key == 8) return on_encoder(-1);
+    return false;
+}
+
+bool ImageOptionsField::on_touch(const TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start) {
+        focus();
+    }
+    return true;
+}
+
+/* OptionsField **********************************************************/
+
+OptionsField::OptionsField(
+    Point parent_pos,
+    size_t length,
+    options_t options)
+    : Widget{{parent_pos, {8 * (int)length, 16}}},
+      length_{length},
+      options_{std::move(options)} {
+    set_focusable(true);
+}
+
+size_t OptionsField::selected_index() const {
+    return selected_index_;
+}
+
+const OptionsField::name_t& OptionsField::selected_index_name() const {
+    return options_[selected_index_].first;
+}
+
+const OptionsField::value_t& OptionsField::selected_index_value() const {
+    return options_[selected_index_].second;
+}
+
+void OptionsField::getAccessibilityText(std::string& result) {
+    result = "options: ";
+    bool first = true;
+    for (const auto& option : options_) {
+        if (!first) result += " ,";
+        first = false;
+        result += option.first;
+    }
+    result += "; selected: " + selected_index_name();
+}
+void OptionsField::getWidgetName(std::string& result) {
+    result = "OptionsField";
+}
+
+void OptionsField::set_selected_index(const size_t new_index, bool trigger_change) {
+    if (new_index < options_.size()) {
+        if (new_index != selected_index() || trigger_change) {
+            selected_index_ = new_index;
+            if (on_change) {
+                on_change(selected_index(), options_[selected_index()].second);
+            }
+            set_dirty();
+        }
+    }
+}
+
+void OptionsField::set_by_value(value_t v) {
+    size_t new_index = 0;
+    for (const auto& option : options_) {
+        if (option.second == v) {
+            set_selected_index(new_index);
+            return;
+        }
+        new_index++;
+    }
+
+    // No exact match was found, default to 0.
+    set_selected_index(0);
+}
+
+void OptionsField::set_by_nearest_value(value_t v) {
+    size_t new_index = 0;
+    size_t curr_index = 0;
+    int32_t min_diff = INT32_MAX;
+
+    for (const auto& option : options_) {
+        auto diff = abs(v - option.second);
+        if (diff < min_diff) {
+            min_diff = diff;
+            new_index = curr_index;
+        }
+
+        curr_index++;
+    }
+
+    set_selected_index(new_index);
+}
+
+void OptionsField::set_options(options_t new_options) {
+    options_ = std::move(new_options);
+
+    // Set an invalid index to force on_change.
+    selected_index_ = (size_t)-1;
+    set_selected_index(0);
+    set_dirty();
+}
+
+void OptionsField::paint(Painter& painter) {
+    const auto paint_style = has_focus() ? style().invert() : style();
+
+    painter.fill_rectangle({screen_rect().location(), {(int)length_ * 8, 16}}, ui::Color::black());
+
+    if (selected_index() < options_.size()) {
+        std::string_view temp = selected_index_name();
+        if (temp.length() > length_)
+            temp = temp.substr(0, length_);
+        painter.draw_string(
+            screen_pos(),
+            paint_style,
+            temp);
+    }
+}
+
+void OptionsField::on_focus() {
+    if (on_show_options) {
+        on_show_options();
+    }
+}
+
+bool OptionsField::on_encoder(const EncoderEvent delta) {
+    int32_t new_value = selected_index() + delta;
+    if (new_value < 0)
+        new_value = options_.size() - 1;
+    else if ((size_t)new_value >= options_.size())
+        new_value = 0;
+
+    set_selected_index(new_value);
+    return true;
+}
+bool OptionsField::on_keyboard(const KeyboardEvent key) {
+    if (key == '+' || key == ' ' || key == 10) return on_encoder(1);
+    if (key == '-' || key == 8) return on_encoder(-1);
+    return false;
+}
+
+bool OptionsField::on_touch(const TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start) {
+        focus();
+    }
+    return true;
+}
+
+/* TextEdit ***********************************************************/
+
+TextEdit::TextEdit(
+    std::string& str,
+    size_t max_length,
+    Point position,
+    uint32_t length)
+    : Widget{{position, {8 * static_cast<int>(length), 16}}},
+      text_{str},
+      max_length_{std::max<size_t>(max_length, str.length())},
+      char_count_{std::max<uint32_t>(length, 1)},
+      cursor_pos_{text_.length()},
+      insert_mode_{true} {
+    set_focusable(true);
+}
+
+const std::string& TextEdit::value() const {
+    return text_;
+}
+
+void TextEdit::getAccessibilityText(std::string& result) {
+    result = text_;
+}
+void TextEdit::getWidgetName(std::string& result) {
+    result = "TextEdit";
+}
+
+void TextEdit::set_cursor(uint32_t pos) {
+    cursor_pos_ = std::min<size_t>(pos, text_.length());
+    set_dirty();
+}
+
+void TextEdit::set_insert_mode() {
+    insert_mode_ = true;
+}
+
+void TextEdit::set_overwrite_mode() {
+    insert_mode_ = false;
+}
+
+void TextEdit::char_add(char c) {
+    // Don't add if inserting and at max_length and
+    // don't overwrite if past the end of the text.
+    if ((text_.length() >= max_length_ && insert_mode_) ||
+        (cursor_pos_ >= text_.length() && !insert_mode_))
+        return;
+
+    if (insert_mode_)
+        text_.insert(cursor_pos_, 1, c);
+    else
+        text_[cursor_pos_] = c;
+
+    cursor_pos_++;
+    set_dirty();
+}
+
+void TextEdit::char_delete() {
+    if (cursor_pos_ == 0)
+        return;
+
+    cursor_pos_--;
+    text_.erase(cursor_pos_, 1);
+    set_dirty();
+}
+
+void TextEdit::paint(Painter& painter) {
+    auto rect = screen_rect();
+    auto text_style = has_focus() ? style().invert() : style();
+    auto offset = 0;
+
+    // Does the string need to be shifted?
+    if (cursor_pos_ >= char_count_)
+        offset = cursor_pos_ - char_count_ + 1;
+
+    // Draw the text starting at the offset.
+    for (uint32_t i = 0; i < char_count_; i++) {
+        // Using draw_char to blank the rest of the line with spaces produces less flicker.
+        auto c = (i + offset < text_.length()) ? text_[i + offset] : ' ';
+
+        painter.draw_char(
+            {rect.location().x() + (static_cast<int>(i) * char_width), rect.location().y()},
+            text_style, c);
+    }
+
+    // Determine cursor position on screen (either the cursor position or the last char).
+    int32_t cursor_x = char_width * (offset > 0 ? char_count_ - 1 : cursor_pos_);
+    Point cursor_point{screen_pos().x() + cursor_x, screen_pos().y()};
+    auto cursor_style = text_style.invert();
+
+    // Invert the cursor character when in overwrite mode.
+    if (!insert_mode_ && (cursor_pos_) < text_.length())
+        painter.draw_char(cursor_point, cursor_style, text_[cursor_pos_]);
+
+    // Draw the cursor.
+    Rect cursor_box{cursor_point, {char_width, char_height}};
+    painter.draw_rectangle(cursor_box, cursor_style.background);
+}
+
+bool TextEdit::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Left && cursor_pos_ > 0)
+        cursor_pos_--;
+    else if (key == KeyEvent::Right && cursor_pos_ < text_.length())
+        cursor_pos_++;
+    else if (key == KeyEvent::Select) {
+        if (key_is_long_pressed(key)) {
+            // Delete text to the cursor.
+            text_ = text_.substr(cursor_pos_);
+            set_cursor(0);
+        } else {
+            insert_mode_ = !insert_mode_;
+        }
+    } else
+        return false;
+
+    set_dirty();
+    return true;
+}
+
+bool TextEdit::on_keyboard(const KeyboardEvent key) {
+    // if ascii printable
+    if (key >= 0x20 && key <= 0x7e) {
+        char_add(key);
+        return true;
+    }
+    if (key == 8) {
+        char_delete();
+        return true;
+    }
+    return false;
+}
+
+bool TextEdit::on_encoder(const EncoderEvent delta) {
+    int32_t new_pos = cursor_pos_ + delta;
+
+    // Let the encoder wrap around the ends of the text.
+    if (new_pos < 0)
+        new_pos = text_.length();
+    else if (static_cast<size_t>(new_pos) > text_.length())
+        new_pos = 0;
+
+    set_cursor(new_pos);
+    return true;
+}
+
+bool TextEdit::on_touch(const TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start)
+        focus();
+
+    set_dirty();
+    return true;
+}
+
+void TextEdit::on_focus() {
+    // Enable long press on "Select".
+    SwitchesState config;
+    config[toUType(Switch::Sel)] = true;
+    set_switches_long_press_config(config);
+}
+
+void TextEdit::on_blur() {
+    // Reset long press.
+    SwitchesState config{};
+    set_switches_long_press_config(config);
+}
+
+/* TextField *************************************************************/
+
+TextField::TextField(Rect parent_rect, std::string text)
+    : Text(parent_rect, std::move(text)) {
+    set_focusable(true);
+}
+
+const std::string& TextField::get_text() const {
+    return text;
+}
+
+void TextField::getAccessibilityText(std::string& result) {
+    result = text;
+}
+void TextField::getWidgetName(std::string& result) {
+    result = "TextField";
+}
+
+void TextField::set_text(std::string_view value) {
+    set(value);
+    if (on_change)
+        on_change(*this);
+}
+
+bool TextField::on_key(KeyEvent key) {
+    if (key == KeyEvent::Select && on_select) {
+        on_select(*this);
+        return true;
+    }
+
+    return false;
+}
+
+bool TextField::on_encoder(EncoderEvent delta) {
+    if (on_encoder_change) {
+        on_encoder_change(*this, delta);
+        return true;
+    }
+
+    return false;
+}
+
+bool TextField::on_touch(TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start) {
+        focus();
+        return true;
+    }
+
+    return false;
+}
+
+/* NumberField ***********************************************************/
+
+NumberField::NumberField(
+    Point parent_pos,
+    int length,
+    range_t range,
+    int32_t step,
+    char fill_char,
+    bool can_loop)
+    : Widget{{parent_pos, {8 * length, 16}}},
+      range{range},
+      step{step},
+      length_{length},
+      fill_char{fill_char},
+      can_loop{can_loop} {
+    set_focusable(true);
+}
+
+int32_t NumberField::value() const {
+    return value_;
+}
+
+void NumberField::getAccessibilityText(std::string& result) {
+    result = to_string_dec_int(value_);
+}
+void NumberField::getWidgetName(std::string& result) {
+    result = "NumberField";
+}
+
+void NumberField::set_value(int32_t new_value, bool trigger_change) {
+    if (can_loop) {
+        if (new_value >= range.first)
+            new_value = new_value % (range.second + 1);
+        else
+            new_value = range.second + new_value + 1;
+    }
+
+    new_value = clip(new_value, range.first, range.second);
+
+    if (new_value != value()) {
+        value_ = new_value;
+        if (on_change && trigger_change) {
+            on_change(value_);
+        }
+        set_dirty();
+    }
+}
+
+void NumberField::set_range(const int32_t min, const int32_t max) {
+    range.first = min;
+    range.second = max;
+    set_value(value(), false);
+}
+
+void NumberField::set_step(const int32_t new_step) {
+    step = new_step;
+}
+
+void NumberField::paint(Painter& painter) {
+    const auto text = to_string_dec_int(value_, length_, fill_char);
+
+    const auto paint_style = has_focus() ? style().invert() : style();
+
+    painter.draw_string(
+        screen_pos(),
+        paint_style,
+        text);
+}
+
+bool NumberField::on_key(const KeyEvent key) {
+    if (key == KeyEvent::Select) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool NumberField::on_encoder(const EncoderEvent delta) {
+    int32_t old_value = value();
+    set_value(value() + (delta * step));
+
+    if (on_wrap) {
+        if ((delta > 0) && (value() < old_value))
+            on_wrap(1);
+        else if ((delta < 0) && (value() > old_value))
+            on_wrap(-1);
+    }
+    return true;
+}
+
+bool NumberField::on_keyboard(const KeyboardEvent key) {
+    if (key == 10) {
+        if (on_select) {
+            on_select(*this);
+            return true;
+        }
+    }
+    if (key == '+' || key == ' ') {
+        return on_encoder(1);
+    }
+    if (key == '-' || key == 8) {
+        return on_encoder(-1);
+    }
+    return false;
+}
+
+bool NumberField::on_touch(const TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start) {
+        focus();
+    }
+    return true;
+}
+
+/* SymField **************************************************************/
+
+SymField::SymField(
+    Point parent_pos,
+    size_t length,
+    Type type,
+    bool explicit_edits)
+    : Widget{{parent_pos, {char_width * (int)length, 16}}},
+      type_{type},
+      explicit_edits_{explicit_edits} {
+    if (length == 0)
+        length = 1;
+
+    selected_ = length - 1;
+    value_.resize(length);
+
+    switch (type) {
+        case Type::Oct:
+            set_symbol_list("01234567");
+            break;
+
+        case Type::Dec:
+            set_symbol_list("0123456789");
+            break;
+
+        case Type::Hex:
+            set_symbol_list("0123456789ABCDEF");
+            break;
+
+        case Type::Alpha:
+            set_symbol_list(" 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            break;
+
+        default:
+            set_symbol_list("01");
+            break;
+    }
+
+    set_focusable(true);
+}
+
+SymField::SymField(
+    Point parent_pos,
+    size_t length,
+    std::string symbol_list,
+    bool explicit_edits)
+    : SymField{parent_pos, length, Type::Custom, explicit_edits} {
+    set_symbol_list(std::move(symbol_list));
+}
+
+char SymField::get_symbol(size_t index) const {
+    if (index >= value_.length())
+        return 0;
+
+    return value_[index];
+}
+
+void SymField::set_symbol(size_t index, char symbol) {
+    if (index >= value_.length())
+        return;
+
+    set_symbol_internal(index, ensure_valid(symbol));
+}
+
+size_t SymField::get_offset(size_t index) const {
+    if (index >= value_.length())
+        return 0;
+
+    // NB: Linear search - symbol lists are small.
+    return symbols_.find(value_[index]);
+}
+
+void SymField::set_offset(size_t index, size_t offset) {
+    if (index >= value_.length() || offset >= symbols_.length())
+        return;
+
+    set_symbol_internal(index, symbols_[offset]);
+}
+
+void SymField::set_symbol_list(std::string symbol_list) {
+    if (symbol_list.length() == 0)
+        return;
+
+    symbols_ = std::move(symbol_list);
+    ensure_all_symbols();
+}
+
+void SymField::set_value(uint64_t value) {
+    auto v = value;
+    uint8_t radix = get_radix();
+
+    for (int i = value_.length() - 1; i >= 0; --i) {
+        uint8_t temp = v % radix;
+        value_[i] = uint_to_char(temp, radix);
+        v /= radix;
+    }
+
+    if (on_change)
+        on_change(*this);
+}
+
+void SymField::set_value(std::string_view value) {
+    // Is new value too long?
+    // TODO: Truncate instead? Which end?
+    if (value.length() > value_.length())
+        return;
+
+    // Right-align string in field.
+    auto left_padding = value_.length() - value.length();
+    value_ = std::string(static_cast<size_t>(left_padding), '\0') + std::string{value};
+    ensure_all_symbols();
+}
+
+uint64_t SymField::to_integer() const {
+    uint64_t v = 0;
+    uint64_t mul = 1;
+    uint8_t radix = get_radix();
+
+    for (int i = value_.length() - 1; i >= 0; --i) {
+        auto temp = char_to_uint(value_[i], radix);
+        v += temp * mul;
+        mul *= radix;
+    }
+
+    return v;
+}
+
+const std::string& SymField::to_string() const {
+    return value_;
+}
+
+void SymField::getAccessibilityText(std::string& result) {
+    result = value_;
+}
+void SymField::getWidgetName(std::string& result) {
+    result = "SymField";
+}
+void SymField::paint(Painter& painter) {
+    Point p = screen_pos();
+
+    for (size_t n = 0; n < value_.length(); n++) {
+        auto c = value_[n];
+        MutableStyle paint_style{style()};
+
+        // Only highlight while focused.
+        if (has_focus()) {
+            if (explicit_edits_) {
+                // Invert the whole field on focus if explicit edits is enabled.
+                paint_style.invert();
+            } else if (n == selected_) {
+                // Otherwise only highlight the selected symbol.
+                paint_style.invert();
+            }
+
+            if (editing_ && n == selected_) {
+                // Use 'bg_blue' style to indicate in editing mode.
+                paint_style.foreground = Color::white();
+                paint_style.background = Color::blue();
+            }
+        }
+
+        painter.draw_char(p, paint_style, c);
+        p += {8, 0};
+    }
+}
+
+bool SymField::on_key(KeyEvent key) {
+    // If explicit edits are enabled, only Select is handled when not in edit mode.
+    if (explicit_edits_ && !editing_) {
+        switch (key) {
+            case KeyEvent::Select:
+                editing_ = true;
+                set_dirty();
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    switch (key) {
+        case KeyEvent::Select:
+            editing_ = !editing_;
+            set_dirty();
+            return true;
+
+        case KeyEvent::Left:
+            if (selected_ > 0) {
+                selected_--;
+                set_dirty();
+                return true;
+            }
+            break;
+
+        case KeyEvent::Right:
+            if (selected_ < (value_.length() - 1)) {
+                selected_++;
+                set_dirty();
+                return true;
+            }
+            break;
+
+        case KeyEvent::Up:
+            if (editing_) {
+                on_encoder(1);
+                return true;
+            }
+            break;
+
+        case KeyEvent::Down:
+            if (editing_) {
+                on_encoder(-1);
+                return true;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    return false;
+}
+
+bool SymField::on_encoder(EncoderEvent delta) {
+    if (explicit_edits_ && !editing_)
+        return false;
+
+    // TODO: Wrapping or carrying might be nice.
+    int offset = get_offset(selected_) + delta;
+
+    offset = clip<int>(offset, 0, symbols_.length() - 1);
+    set_offset(selected_, offset);
+
+    return true;
+}
+
+bool SymField::on_touch(TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start)
+        focus();
+
+    return true;
+}
+
+char SymField::ensure_valid(char symbol) const {
+    // NB: Linear search - symbol lists are small.
+    auto pos = symbols_.find(symbol);
+    return pos != std::string::npos ? symbol : symbols_[0];
+}
+
+void SymField::ensure_all_symbols() {
+    auto temp = value_;
+
+    for (auto& c : value_)
+        c = ensure_valid(c);
+
+    if (temp != value_) {
+        if (on_change)
+            on_change(*this);
+        set_dirty();
+    }
+}
+
+void SymField::set_symbol_internal(size_t index, char symbol) {
+    if (value_[index] == symbol)
+        return;
+
+    value_[index] = symbol;
+    if (on_change)
+        on_change(*this);
+    set_dirty();
+}
+
+uint8_t SymField::get_radix() const {
+    switch (type_) {
+        case Type::Oct:
+            return 8;
+        case Type::Dec:
+            return 10;
+        case Type::Hex:
+            return 16;
+        default:
+            return 0;
+    }
+}
+
+/* Waveform **************************************************************/
+
+Waveform::Waveform(
+    Rect parent_rect,
+    int16_t* data,
+    uint32_t length,
+    uint32_t offset,
+    bool digital,
+    Color color)
+    : Widget{parent_rect},
+      data_{data},
+      length_{length},
+      offset_{offset},
+      digital_{digital},
+      color_{color} {
+    // set_focusable(false);
+    // previous_data.resize(length_, 0);
+}
+
+void Waveform::set_cursor(const uint32_t i, const int16_t position) {
+    if (i < 2) {
+        if (position != cursors[i]) {
+            cursors[i] = position;
+            set_dirty();
+        }
+        show_cursors = true;
+    }
+}
+
+void Waveform::set_offset(const uint32_t new_offset) {
+    if (new_offset != offset_) {
+        offset_ = new_offset;
+        set_dirty();
+    }
+}
+
+void Waveform::set_length(const uint32_t new_length) {
+    if (new_length != length_) {
+        length_ = new_length;
+        set_dirty();
+    }
+}
+
+void Waveform::paint(Painter& painter) {
+    size_t n;
+    Coord y, y_offset = screen_rect().location().y();
+    Coord prev_x = screen_rect().location().x(), prev_y;
+    float x, x_inc;
+    Dim h = screen_rect().size().height();
+    const float y_scale = (float)(h - 1) / 65536.0;
+    int16_t* data_start = data_ + offset_;
+
+    if (!length_) return;
+
+    x_inc = (float)screen_rect().size().width() / length_;
+
+    // Clear
+    painter.fill_rectangle_unrolled8(screen_rect(), Color::black());
+
+    if (digital_) {
+        // Digital waveform: each value is an horizontal line
+        x = 0;
+        h--;
+        for (n = 0; n < length_; n++) {
+            y = *(data_start++) ? h : 0;
+
+            if (n) {
+                if (y != prev_y)
+                    painter.draw_vline({(Coord)x, y_offset}, h, color_);
+            }
+
+            painter.draw_hline({(Coord)x, y_offset + y}, ceil(x_inc), color_);
+
+            prev_y = y;
+            x += x_inc;
+        }
+    } else {
+        // Analog waveform: each value is a point's Y coordinate
+        x = prev_x + x_inc;
+        h /= 2;
+        prev_y = y_offset + h - (*(data_start++) * y_scale);
+        for (n = 1; n < length_; n++) {
+            y = y_offset + h - (*(data_start++) * y_scale);
+            display.draw_line({prev_x, prev_y}, {(Coord)x, y}, color_);
+
+            prev_x = x;
+            prev_y = y;
+            x += x_inc;
+        }
+    }
+
+    // Cursors
+    if (show_cursors) {
+        for (n = 0; n < 2; n++) {
+            painter.draw_vline(
+                Point(std::min(screen_rect().size().width(), (int)cursors[n]), y_offset),
+                screen_rect().size().height(),
+                cursor_colors[n]);
+        }
+    }
+}
+
+/* VuMeter **************************************************************/
+
+VuMeter::VuMeter(
+    Rect parent_rect,
+    uint32_t LEDs,
+    bool show_max)
+    : Widget{parent_rect},
+      LEDs_{LEDs},
+      show_max_{show_max} {
+    // set_focusable(false);
+    LED_height = std::max(1UL, parent_rect.size().height() / LEDs);
+    split = 256 / LEDs;
+}
+
+void VuMeter::set_value(const uint32_t new_value) {
+    if ((new_value != value_) && (new_value < 256)) {
+        value_ = new_value;
+        set_dirty();
+    }
+}
+
+void VuMeter::set_mark(const uint32_t new_mark) {
+    if ((new_mark != mark) && (new_mark < 256)) {
+        mark = new_mark;
+        set_dirty();
+    }
+}
+
+void VuMeter::paint(Painter& painter) {
+    uint32_t bar;
+    Color color;
+    bool lit = false;
+    uint32_t bar_level;
+    Point pos = screen_rect().location();
+    Dim width = screen_rect().size().width() - 4;
+    Dim height = screen_rect().size().height();
+    Dim bottom = pos.y() + height;
+    Coord marks_x = pos.x() + width;
+
+    if (value_ != prev_value) {
+        bar_level = LEDs_ - ((value_ + 1) / split);
+
+        // Draw LEDs
+        for (bar = 0; bar < LEDs_; bar++) {
+            if (bar >= bar_level)
+                lit = true;
+
+            if (bar == 0)
+                color = lit ? Color::red() : Color::dark_grey();
+            else if (bar == 1)
+                color = lit ? Color::orange() : Color::dark_grey();
+            else if ((bar == 2) || (bar == 3))
+                color = lit ? Color::yellow() : Color::dark_grey();
+            else
+                color = lit ? Color::green() : Color::dark_grey();
+
+            painter.fill_rectangle({pos.x(), pos.y() + (Coord)(bar * (LED_height + 1)), width, (Coord)LED_height}, color);
+        }
+        prev_value = value_;
+    }
+
+    // Update max level
+    if (show_max_) {
+        if (value_ > max) {
+            max = value_;
+            hold_timer = 30;  // 0.5s @ 60Hz
+        } else {
+            if (hold_timer) {
+                hold_timer--;
+            } else {
+                if (max) max--;  // Let it drop
+            }
+        }
+
+        // Draw max level
+        if (max != prev_max) {
+            painter.draw_hline({marks_x, bottom - (height * prev_max) / 256}, 8, Color::black());
+            painter.draw_hline({marks_x, bottom - (height * max) / 256}, 8, Color::white());
+            if (prev_max == mark)
+                prev_mark = 0;  // Force mark refresh
+            prev_max = max;
+        }
+    }
+
+    // Draw mark (forced refresh)
+    if (mark) {
+        painter.draw_hline({marks_x, bottom - (height * prev_mark) / 256}, 8, Color::black());
+        painter.draw_hline({marks_x, bottom - (height * mark) / 256}, 8, Color::grey());
+        prev_mark = mark;
+    }
+}
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -407,7 +407,7 @@ void ADSBRxView::on_frame(const ADSBFrameMessage* message) {
     status_good_frame.toggle();
 
     rtc::RTC datetime;
-    rtcGetTime(&RTCD1, &datetime);
+    rtc_time::now(datetime);
     frame.set_rx_timestamp(datetime.minute() * 60 + datetime.second());
 
     // NB: Reference to update entry in-place.

--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -258,7 +258,7 @@ void APRSTableView::on_pkt(const APRSPacketMessage* message) {
     std::string source_formatted = packet.get_source_formatted();
     std::string info_string = packet.get_stream_text();
 
-    rtcGetTime(&RTCD1, &datetime);
+    rtc_time::now(datetime);
     auto& entry = ::on_packet(recent, packet.get_source());
     entry.reset_age();
     entry.inc_hit();

--- a/firmware/application/apps/ui_numbers.cpp
+++ b/firmware/application/apps/ui_numbers.cpp
@@ -277,18 +277,9 @@ NumbersStationView::NumbersStationView(
     symfield_code.set_offset(10, 12);  // End
 
     /*
-        rtc::RTC datetime;
-        rtcGetTime(&RTCD1, &datetime);
-
-        // Thanks, Sakamoto-sama !
-        y = datetime.year();
-        m = datetime.month();
-        d = datetime.day();
-        y -= m < 3;
-        dayofweek = (y + y/4 - y/100 + y/400 + month_table[m-1] + d) % 7;
-
+        dayofweek = rtc_time::current_day_of_week();
         text_title.set(day_of_week[dayofweek]);
-*/
+    */
 
     button_exit.on_select = [&nav](Button&) {
         nav.pop();

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -113,7 +113,7 @@ SetDateTimeView::SetDateTimeView(
     field_day.on_change = date_changed_fn;
 
     rtc::RTC datetime;
-    rtc_time::now(datetime);  // NB: Time here may already include DST adjustment
+    rtc_time::now(datetime);
     SetDateTimeModel model{
         datetime.year(),
         datetime.month(),

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -61,10 +61,9 @@ SetDateTimeView::SetDateTimeView(
     NavigationView& nav) {
     button_save.on_select = [&nav, this](Button&) {
         const auto model = this->form_collect();
-        const rtc::RTC new_datetime{
-            model.year, model.month, model.day,
-            model.hour, model.minute, model.second};
-        rtcSetTime(&RTCD1, &new_datetime);
+        rtc::RTC new_datetime{model.year, model.month, model.day, model.hour, model.minute, model.second};
+        pmem::set_config_dst(model.dst);
+        rtc_time::set(new_datetime);  // NB: 1 hour will be subtracted if value is stored in RTC during DST
         nav.pop();
     },
 
@@ -80,20 +79,49 @@ SetDateTimeView::SetDateTimeView(
         &field_hour,
         &field_minute,
         &field_second,
+        &text_weekday,
+        &text_day_of_year,
+        &checkbox_dst_enable,
+        &options_dst_start_which,
+        &options_dst_start_weekday,
+        &options_dst_start_month,
+        &options_dst_end_which,
+        &options_dst_end_weekday,
+        &options_dst_end_month,
         &button_save,
         &button_cancel,
     });
 
+    // Populate DST options (same string text for start & end)
+    options_dst_start_which.set_options(which_options);
+    options_dst_end_which.set_options(which_options);
+    options_dst_start_weekday.set_options(weekday_options);
+    options_dst_end_weekday.set_options(weekday_options);
+    options_dst_start_month.set_options(month_options);
+    options_dst_end_month.set_options(month_options);
+
+    const auto date_changed_fn = [this](int32_t) {
+        auto weekday = rtc_time::day_of_week(field_year.value(), field_month.value(), field_day.value());
+        auto doy = rtc_time::day_of_year(field_year.value(), field_month.value(), field_day.value());
+        bool valid_date = (field_day.value() <= rtc_time::days_per_month(field_year.value(), field_month.value()));
+        text_weekday.set(valid_date ? weekday_options[weekday].first : "-");
+        text_day_of_year.set(valid_date ? to_string_dec_uint(doy, 3) : "-");
+    };
+
+    field_year.on_change = date_changed_fn;
+    field_month.on_change = date_changed_fn;
+    field_day.on_change = date_changed_fn;
+
     rtc::RTC datetime;
-    rtcGetTime(&RTCD1, &datetime);
+    rtc_time::now(datetime);  // NB: Time here may already include DST adjustment
     SetDateTimeModel model{
         datetime.year(),
         datetime.month(),
         datetime.day(),
         datetime.hour(),
         datetime.minute(),
-        datetime.second()};
-
+        datetime.second(),
+        pmem::config_dst()};
     form_init(model);
 }
 
@@ -108,16 +136,32 @@ void SetDateTimeView::form_init(const SetDateTimeModel& model) {
     field_hour.set_value(model.hour);
     field_minute.set_value(model.minute);
     field_second.set_value(model.second);
+    checkbox_dst_enable.set_value(model.dst.b.dst_enabled);
+    options_dst_start_which.set_by_value(model.dst.b.start_which);
+    options_dst_start_weekday.set_by_value(model.dst.b.start_weekday);
+    options_dst_start_month.set_by_value(model.dst.b.start_month);
+    options_dst_end_which.set_by_value(model.dst.b.end_which);
+    options_dst_end_weekday.set_by_value(model.dst.b.end_weekday);
+    options_dst_end_month.set_by_value(model.dst.b.end_month);
 }
 
 SetDateTimeModel SetDateTimeView::form_collect() {
+    pmem::dst_config_t dst;
+    dst.b.dst_enabled = static_cast<uint8_t>(checkbox_dst_enable.value());
+    dst.b.start_which = static_cast<uint8_t>(options_dst_start_which.selected_index_value());
+    dst.b.start_weekday = static_cast<uint8_t>(options_dst_start_weekday.selected_index_value());
+    dst.b.start_month = static_cast<uint8_t>(options_dst_start_month.selected_index_value());
+    dst.b.end_which = static_cast<uint8_t>(options_dst_end_which.selected_index_value());
+    dst.b.end_weekday = static_cast<uint8_t>(options_dst_end_weekday.selected_index_value());
+    dst.b.end_month = static_cast<uint8_t>(options_dst_end_month.selected_index_value());
     return {
         .year = static_cast<uint16_t>(field_year.value()),
         .month = static_cast<uint8_t>(field_month.value()),
         .day = static_cast<uint8_t>(field_day.value()),
         .hour = static_cast<uint8_t>(field_hour.value()),
         .minute = static_cast<uint8_t>(field_minute.value()),
-        .second = static_cast<uint8_t>(field_second.value())};
+        .second = static_cast<uint8_t>(field_second.value()),
+        .dst = dst};
 }
 
 /* SetRadioView ******************************************/

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -44,6 +44,7 @@ struct SetDateTimeModel {
     uint8_t hour;
     uint8_t minute;
     uint8_t second;
+    portapack::persistent_memory::dst_config_t dst;
 };
 
 class SetDateTimeView : public View {
@@ -55,56 +56,111 @@ class SetDateTimeView : public View {
     std::string title() const override { return "Date/Time"; };
 
    private:
+    using option_t = std::pair<std::string, int32_t>;
+    std::vector<option_t> which_options = {{"1st", 0}, {"2nd", 1}, {"3rd", 2}, {"4th", 3}, {"Last", 4}};
+    std::vector<option_t> weekday_options = {{"Sun", 0}, {"Mon", 1}, {"Tue", 2}, {"Wed", 3}, {"Thu", 4}, {"Fri", 5}, {"Sat", 6}};
+    std::vector<option_t> month_options = {{"Jan", 1}, {"Feb", 2}, {"Mar", 3}, {"Apr", 4}, {"May", 5}, {"Jun", 6}, {"Jul", 7}, {"Aug", 8}, {"Sep", 9}, {"Oct", 10}, {"Nov", 11}, {"Dec", 12}};
+
     Labels labels{
         {{1 * 8, 1 * 16}, "Adjust the RTC clock date &", Color::light_grey()},
         {{1 * 8, 2 * 16}, "time. If clock resets after", Color::light_grey()},
         {{1 * 8, 3 * 16}, "reboot, coin batt. is dead. ", Color::light_grey()},
-        {{5 * 8, 8 * 16 - 2}, "YYYY-MM-DD HH:MM:SS", Color::grey()},
-        {{9 * 8, 9 * 16}, "-  -     :  :", Color::light_grey()}};
+        {{1 * 8, 5 * 16 - 2}, "YYYY-MM-DD HH:MM:SS  DoW DoY", Color::grey()},
+        {{5 * 8, 6 * 16}, "-  -     :  :", Color::light_grey()},
+        {{1 * 8, 11 * 16}, "DST adds 1 hour to RTC time.", Color::light_grey()},
+        {{0 * 8, 12 * 16}, "Start: 0:00 on Nth  DDD in", Color::light_grey()},
+        {{0 * 8, 13 * 16}, "End:   1:00 on Nth  DDD in", Color::light_grey()}};
 
     NumberField field_year{
-        {5 * 8, 9 * 16},
+        {1 * 8, 6 * 16},
         4,
         {2015, 2099},
         1,
         '0',
+        true,
     };
     NumberField field_month{
-        {10 * 8, 9 * 16},
+        {6 * 8, 6 * 16},
         2,
         {1, 12},
         1,
         '0',
+        true,
     };
     NumberField field_day{
-        {13 * 8, 9 * 16},
+        {9 * 8, 6 * 16},
         2,
         {1, 31},
         1,
         '0',
+        true,
     };
 
     NumberField field_hour{
-        {16 * 8, 9 * 16},
+        {12 * 8, 6 * 16},
         2,
         {0, 23},
         1,
         '0',
+        true,
     };
     NumberField field_minute{
-        {19 * 8, 9 * 16},
+        {15 * 8, 6 * 16},
         2,
         {0, 59},
         1,
         '0',
+        true,
     };
     NumberField field_second{
-        {22 * 8, 9 * 16},
+        {18 * 8, 6 * 16},
         2,
         {0, 59},
         1,
         '0',
+        true,
     };
+    Text text_weekday{
+        {22 * 8, 6 * 16, 3 * 8, 16},
+        ""};
+    Text text_day_of_year{
+        {26 * 8, 6 * 16, 3 * 8, 16},
+        ""};
+
+    Checkbox checkbox_dst_enable{
+        {2 * 8, 9 * 16},
+        23,
+        "Enable Daylight Savings"};
+
+    OptionsField options_dst_start_which{
+        {15 * 8, 12 * 16},
+        4,
+        {}};
+
+    OptionsField options_dst_start_weekday{
+        {20 * 8, 12 * 16},
+        3,
+        {}};
+
+    OptionsField options_dst_start_month{
+        {27 * 8, 12 * 16},
+        3,
+        {}};
+
+    OptionsField options_dst_end_which{
+        {15 * 8, 13 * 16},
+        4,
+        {}};
+
+    OptionsField options_dst_end_weekday{
+        {20 * 8, 13 * 16},
+        3,
+        {}};
+
+    OptionsField options_dst_end_month{
+        {27 * 8, 13 * 16},
+        3,
+        {}};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -411,6 +411,7 @@ bool init() {
 
     /* Cache some configuration data from persistent memory. */
     persistent_memory::cache::init();
+    rtc_time::dst_init();
     chThdSleepMilliseconds(10);
 
     clock_manager.init_clock_generator();

--- a/firmware/application/rtc_time.cpp
+++ b/firmware/application/rtc_time.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2023 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -20,24 +21,253 @@
  */
 
 #include "rtc_time.hpp"
+#include "portapack_persistent_memory.hpp"
+
+using namespace portapack;
+namespace pmem = portapack::persistent_memory;
 
 namespace rtc_time {
 
 Signal<> signal_tick_second;
 
+bool dst_enabled{false};
+bool dst_dates_reversed;
+bool dst_in_range{false};
+uint16_t dst_start_doy;
+uint16_t dst_end_doy;
+uint16_t dst_current_doy{0xFFFF};
+uint16_t dst_current_year{0xFFFF};
+
+static const uint16_t months_with_31 = 0x0AD5;  // Bits represents months with 31 days (bit 0 for January, etc)
+
 void on_tick_second() {
     signal_tick_second.emit();
 }
 
+// Check if DST is configured and active (called at power-up)
+void dst_init() {
+    rtc::RTC datetime;
+    rtcGetTime(&RTCD1, &datetime);
+    dst_update_date_range(datetime.year(), LPC_RTC->DOY);
+}
+
+// Return current time & date (adjusted for DST if enabled)
 rtc::RTC now() {
     rtc::RTC datetime;
     rtcGetTime(&RTCD1, &datetime);
+    if (dst_enabled) {
+        datetime = dst_adjust_returned_time(datetime);
+    }
     return datetime;
 }
 
 rtc::RTC now(rtc::RTC& out_datetime) {
     rtcGetTime(&RTCD1, &out_datetime);
+    if (dst_enabled) {
+        out_datetime = dst_adjust_returned_time(out_datetime);
+    }
     return out_datetime;
+}
+
+// Add 1 hour (spring forward) if needed for DST (called whenever RTC is read if DST is enabled)
+rtc::RTC dst_adjust_returned_time(rtc::RTC& datetime) {
+    // Read day of year from RTC and check for change
+    uint32_t doy = LPC_RTC->DOY;
+
+    // Update DST start/end day-of-year only when year changes, otherwise just check if in range when day changes
+    if (doy != dst_current_doy) {
+        if (datetime.year() != dst_current_year)
+            dst_update_date_range(datetime.year(), doy);
+        else
+            dst_check_date_range(doy);
+    }
+
+    // Not in DST date range
+    if (!dst_in_range)
+        return datetime;
+
+    // Add 1 hour to RTC time
+    uint16_t year = datetime.year();
+    uint8_t month = datetime.month();
+    uint8_t day = datetime.day();
+    uint8_t hour = datetime.hour();
+
+    if (++hour > 23) {
+        hour = 0;
+        if (++day > days_per_month(year, month)) {
+            day = 1;
+            if (++month > 12) {
+                year++;
+            }
+        }
+    }
+    rtc::RTC dst_datetime{year, month, day, hour, datetime.minute(), datetime.second()};
+    return dst_datetime;
+}
+
+// Check if current date is within the DST range (called when date changes)
+void dst_check_date_range(uint16_t doy) {
+    bool in_range = true;
+    dst_current_doy = doy;
+
+    // Check if date is within DST range
+    if (!dst_dates_reversed) {
+        if ((doy < dst_start_doy) || (doy >= dst_end_doy))
+            in_range = false;
+    } else {
+        if ((doy < dst_start_doy) && (doy >= dst_end_doy))
+            in_range = false;
+    }
+    dst_in_range = in_range;
+}
+
+// Update DST parameters (called at power-up, when year changes, or DST settings are changed)
+void dst_update_date_range(uint16_t year, uint16_t doy) {
+    dst_enabled = pmem::dst_enabled();
+    if (dst_enabled) {
+        const pmem::dst_config_t dst = pmem::config_dst();
+        dst_current_year = year;
+        dst_start_doy = day_of_year_of_nth_weekday(dst_current_year, dst.b.start_month, dst.b.start_which, dst.b.start_weekday);
+        dst_end_doy = day_of_year_of_nth_weekday(dst_current_year, dst.b.end_month, dst.b.end_which, dst.b.end_weekday);
+        dst_dates_reversed = (dst_start_doy > dst_end_doy);  // Summer starts in December in Southern hemisphere
+
+        dst_check_date_range(doy);
+    } else {
+        dst_in_range = false;
+    }
+}
+
+// Set RTC clock.
+// If the user has enabled DST, the time entered and passed to this function is interpreted as having been adjusted for DST.
+// When DST functionality is enabled in pmem, the value stored in the RTC hardware is non-DST time, and we only fudge the time when read.
+// Thus, it's necessary to subtract an hour before storing it in the RTC if we're in the DST date range.
+// (If RTC is desired to represent UTC, then DST should obviously be disabled in settings.)
+// NB: Firmware should not change RTC without going through this function.
+void set(rtc::RTC& new_datetime) {
+    uint16_t year = new_datetime.year();
+    uint8_t month = new_datetime.month();
+    uint8_t day = new_datetime.day();
+    uint8_t hour = new_datetime.hour();
+
+    // NB: DST code relies on the Day of Year (DOY) value to be initialized in the RTC by firmware (RTC hardware only does increment and wrap)
+    uint16_t doy = day_of_year(year, month, day);
+    dst_update_date_range(year, doy);
+
+    // NB: Currently we only support the DST transition at midnight RTC time (not configurable to hour granularity).
+    // Note on handling the the hour before/after DST time change:
+    // 
+    //   If entered hour==0 on dst_start_day:
+    //      Time entered is INVALID due to spring-forward; code below rolls back RTC to last hour of previous day.
+    //
+    //   If entered hour==0 on dst_end_doy:
+    //      This hour occurs twice due to fall-back; code below treats as if DST has ended (the second occurrence) and doesn't roll back RTC
+    //
+    if (!dst_in_range) {
+        LPC_RTC->DOY = doy;
+        // NB: Writing RTC twice takes a second, but ensures that new value can be read back immediately
+        // (if not written twice, the old value will be returned if read back in the following 1-2 seconds)
+        // (you will notice with older Mayhem versions that running the Date/Time Settings app again quickly will show the old time)
+        rtcSetTime(&RTCD1, &new_datetime);
+        rtcSetTime(&RTCD1, &new_datetime);
+        return;
+    }
+
+    // If within the DST date range, subtract 1 hour from requested time before storing in RTC.
+    if (hour-- == 0) {
+        hour = 23;
+        if (day-- == 0) {
+            if (month-- == 0) {
+                month = 12;
+                year--;
+            }
+            day = days_per_month(year, month);
+        }
+    }
+
+    // Update day-of-year if date was changed above
+    if (day != new_datetime.day()) {
+        doy = day_of_year(year, month, day);
+        dst_update_date_range(year, doy);
+    }
+
+    // NB: Writing RTC twice takes a second, but ensures that new value can be read back immediately
+    // (if not written twice, the old value will be returned if read back in the following 1-2 seconds)
+    // (you will notice with older Mayhem versions that running the Date/Time Settings app again quickly will show the old time)
+    LPC_RTC->DOY = doy;
+    rtc::RTC adjusted_datetime{year, month, day, hour, new_datetime.minute(), new_datetime.second()};
+    rtcSetTime(&RTCD1, &adjusted_datetime);
+    rtcSetTime(&RTCD1, &adjusted_datetime);
+}
+
+// Calculates 1-based day of year for Nth weekday in month (weekday and n are 0-based, month is 1-based)
+uint16_t day_of_year_of_nth_weekday(uint16_t year, uint8_t month, uint8_t n, uint8_t weekday) {
+    uint8_t w = day_of_week(year, month, 1);
+    uint8_t nn = n;
+
+    // special handling for "last" weekday - are there 4 or 5 in the month?
+    if (n == 4) {
+        if (month == 2) {
+            // February
+            // only weekday w occurs 5 times on the 29th on leap years only
+            if ((weekday != w) || !leap_year(year))
+                nn = 3;
+        } else {
+            // Other months have either 30 or 31 days;
+            // weekdays w and w+1 occur 5 times (on the 29th & 30th); weekday w+2 occurs 5 times only if month has 31 days
+            if ((weekday != w) && (weekday != (w + 1) % 7) &&
+                ((weekday != (w + 2) % 7) || ((months_with_31 & (1 << (month - 1))) == 0)))
+                nn = 3;
+        }
+    }
+    return day_of_year(year, month, 1) + (nn * 7) + weekday + ((weekday < w) ? 7 : 0) - w;
+}
+
+// Calculates 1-based day of year (input month & day are 1-based)
+uint16_t day_of_year(uint16_t year, uint8_t month, uint8_t day) {
+    // 1-based day of year for 1st day or month (index is 1-based month)
+    static uint16_t month_to_day_in_year[13] = {
+        0,  // placeholder for 1-based indexing
+        1,
+        1 + 31,
+        1 + 31 + 28,
+        1 + 31 + 28 + 31,
+        1 + 31 + 28 + 31 + 30,
+        1 + 31 + 28 + 31 + 30 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
+        1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
+    };
+    return month_to_day_in_year[month] + day - (((month > 2) && leap_year(year)) ? 0 : 1);
+}
+
+bool leap_year(uint16_t year) {
+    // Technically should be: ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)
+    // but year 2100 is a long way off and the LPC43xx RTC doesn't bother handling it either
+    return ((year & 3) == 0);
+}
+
+uint8_t days_per_month(uint16_t year, uint8_t month) {
+    if (month == 2)
+        return leap_year(year)? 29 : 28;
+    else
+        return ((months_with_31 & (1 << (month - 1))) != 0)? 31 : 30;
+}
+
+uint8_t current_day_of_week() {
+    rtc::RTC datetime;
+    now(datetime);
+    return day_of_week(datetime.year(), datetime.month(), datetime.day());
+}
+
+// Returns 0-based weekday for date (0=Sunday, 1=Monday, etc) - using Zeller's Congruence formula
+// (month and day are 1-based)
+uint8_t day_of_week(uint16_t year, uint8_t month, uint8_t day) {
+    int m = (month < 3) ? month + 13 : month + 1;
+    int y = (month < 3) ? year - 1 : year;
+    return (day - 1 + (13 * m / 5) + y + (y / 4) - (y / 100) + (y / 400)) % 7;
 }
 
 } /* namespace rtc_time */

--- a/firmware/application/rtc_time.hpp
+++ b/firmware/application/rtc_time.hpp
@@ -33,11 +33,26 @@ extern Signal<> signal_tick_second;
 
 void on_tick_second();
 
+/* Sets the current RTCTime in the RTC. */
+void set(rtc::RTC& new_datetime);
+
 /* Returns the current RTCTime from the RTC. */
 rtc::RTC now();
 
 /* Returns the current RTCTime from the RTC. */
 rtc::RTC now(rtc::RTC& out_datetime);
+
+/* Daylight Savings Time functions */
+void dst_init();
+rtc::RTC dst_adjust_returned_time(rtc::RTC& datetime);
+void dst_check_date_range(uint16_t doy);
+void dst_update_date_range(uint16_t year, uint16_t doy);
+uint8_t days_per_month(uint16_t year, uint8_t month);
+uint8_t current_day_of_week();
+uint8_t day_of_week(uint16_t year, uint8_t month, uint8_t day);
+bool leap_year(uint16_t year);
+uint16_t day_of_year(uint16_t year, uint8_t month, uint8_t day);
+uint16_t day_of_year_of_nth_weekday(uint16_t year, uint8_t month, uint8_t n, uint8_t weekday);
 
 } /* namespace rtc_time */
 

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -181,7 +181,7 @@ void RecordView::start() {
 
     std::filesystem::path base_path;
     if (filename_date_frequency) {
-        rtcGetTime(&RTCD1, &datetime);
+        rtc_time::now(datetime);
 
         // ISO 8601
         std::string date_time =

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -711,6 +711,30 @@ static void printAppInfo(BaseSequentialStream* chp, ui::AppInfoConsole& element)
     }
 }
 
+static void printAppInfo(BaseSequentialStream* chp, const ui::AppInfo& element) {
+    if (strlen(element.id) == 0) return;
+    chprintf(chp, element.id);
+    chprintf(chp, " ");
+    chprintf(chp, element.displayName);
+    chprintf(chp, " ");
+    switch (element.menuLocation) {
+        case RX:
+            chprintf(chp, "[RX]\r\n");
+            break;
+        case TX:
+            chprintf(chp, "[TX]\r\n");
+            break;
+        case UTILITIES:
+            chprintf(chp, "[UTIL]\r\n");
+            break;
+        case DEBUG:
+            chprintf(chp, "[DEBUG]\r\n");
+            break;
+        default:
+            break;
+    }
+}
+
 // returns the installed apps, those can be called by appstart APPNAME
 static void cmd_applist(BaseSequentialStream* chp, int argc, char* argv[]) {
     (void)argc;
@@ -721,8 +745,9 @@ static void cmd_applist(BaseSequentialStream* chp, int argc, char* argv[]) {
     if (!top_widget) return;
     auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
     if (!nav) return;
-    for (auto element : ui::NavigationView::fixedAppListFC) {
-        printAppInfo(chp, element);
+    // TODO(u-foka): Somehow order static and dynamic app lists together
+    for (auto& element : ui::NavigationView::appMap) {  // Use the map as its ordered by id
+        printAppInfo(chp, element.second);
     }
     ui::ExternalItemsMenuLoader::load_all_external_items_callback([chp](ui::AppInfoConsole& info) {
         printAppInfo(chp, info);

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -116,6 +116,21 @@ enum encoder_dial_sensitivity {
     NUM_DIAL_SENSITIVITY
 };
 
+typedef union {
+    uint32_t v;
+    struct {
+        uint8_t start_which : 4;
+        uint8_t start_weekday : 4;
+        uint8_t start_month : 4;
+        uint8_t end_which : 4;
+        uint8_t end_weekday : 4;
+        uint8_t end_month : 4;
+        uint8_t UNUSED : 7;
+        uint8_t dst_enabled : 1;
+    } b;
+} dst_config_t;
+static_assert(sizeof(dst_config_t) == sizeof(uint32_t));
+
 namespace cache {
 
 /* Set values in cache to sensible defaults. */
@@ -241,8 +256,12 @@ void set_pocsag_ignore_address(uint32_t address);
 
 bool clkout_enabled();
 void set_clkout_enabled(bool v);
-uint16_t clkout_freq();
 void set_clkout_freq(uint16_t freq);
+
+bool dst_enabled();
+void set_dst_enabled(bool v);uint16_t clkout_freq();
+dst_config_t config_dst();
+void set_config_dst(dst_config_t v);
 
 /* Recon app */
 bool recon_autosave_freqs();

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -259,7 +259,8 @@ void set_clkout_enabled(bool v);
 void set_clkout_freq(uint16_t freq);
 
 bool dst_enabled();
-void set_dst_enabled(bool v);uint16_t clkout_freq();
+void set_dst_enabled(bool v);
+uint16_t clkout_freq();
 dst_config_t config_dst();
 void set_config_dst(dst_config_t v);
 

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -32,8 +32,10 @@
 #include "irq_controls.hpp"
 #include "string_format.hpp"
 #include "usb_serial_device_to_host.h"
+#include "rtc_time.hpp"
 
 using namespace portapack;
+using namespace rtc_time;
 
 namespace ui {
 
@@ -433,7 +435,7 @@ void Labels::getWidgetName(std::string& result) {
 /* LiveDateTime **********************************************************/
 
 void LiveDateTime::on_tick_second() {
-    rtcGetTime(&RTCD1, &datetime);
+    rtc_time::now(datetime);
     text = "";
     if (!hide_clock) {
         if (date_enabled) {


### PR DESCRIPTION
The more clocks and PortaPacks you have, the less fun it is updating the time whenever Daylight Savings Time starts & ends.  Resolves #1756.

* Added Daylight Savings Time options to the Settings -> Time/Date app.  Time will be changed automatically based on the starting & ending date criteria expressed as the Nth Weekday of Month.  If you don't know what the DST rules are in your country, see https://en.wikipedia.org/wiki/Daylight_saving_time_by_country
* When setting the date, the screen now shows the day of week and day of year as well, and the values wrap for convenience (if minutes is 55 and you want it to be 2 then you no longer have to turn the encoder so many times).
* Added DST configuration field to pmem.
* Updated RTC functions including the "rtc_time::now" function to add 1 hour during DST date range.
* Modified functions that were accessing the RTC directly to use the "now" and "set" functions (most apps were already using the "now" function).
*  When setting the time in RTC, note that the time is now written twice to guarantee that the next read-back will match what you just set (this take a second, but note in existing code that if you run the Time/Date app twice in quick succession that the old time will be seen on the 2nd run).

Notes on implementation are in the comments.