### PR TITLE
Fix rounding bug when displaying frequencies

### DIFF
--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -210,7 +210,7 @@ std::string to_string_rounded_freq(const uint64_t f, int8_t precision) {
 
         uint32_t divisor = pow10[6 - precision];
 
-        final_str = to_string_dec_uint(f / 1000000) + "." + to_string_dec_int(((f + (divisor / 2)) / divisor) % pow10[precision], precision, '0');
+        final_str = to_string_dec_uint((f + (divisor / 2)) / 1000000) + "." + to_string_dec_int(((f + (divisor / 2)) / divisor) % pow10[precision], precision, '0');
     }
     return final_str;
 }

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -185,7 +185,7 @@ std::string to_string_freq(const uint64_t f) {
 
 // right-justified frequency in MHz, rounded to 4 decimal places, always 9 characters
 std::string to_string_short_freq(const uint64_t f) {
-    auto final_str = to_string_dec_int(f / 1000000, 4) + "." + to_string_dec_int(((f + 50) / 100) % 10000, 4, '0');
+    auto final_str = to_string_dec_int((f + 50) / 1000000, 4) + "." + to_string_dec_int(((f + 50) / 100) % 10000, 4, '0');
     return final_str;
 }
 

--- a/firmware/application/tone_key.cpp
+++ b/firmware/application/tone_key.cpp
@@ -85,7 +85,7 @@ const tone_key_t tone_keys = {
     {"Senn. 32.768k", F2Ix100(32768.0)}};
 
 std::string fx100_string(uint32_t f) {
-    return to_string_dec_uint(f / 100) + "." + to_string_dec_uint(((f + 5) / 10) % 10);
+    return to_string_dec_uint((f + 5) / 100) + "." + to_string_dec_uint(((f + 5) / 10) % 10);
 }
 
 float tone_key_frequency(tone_index index) {

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -495,6 +495,7 @@ void GeoMap::draw_scale(Painter& painter) {
         m /= 2;
     }
     scale_width /= 1000;
+    m += 50;  // (add rounding factor for div by 100 below)
     if (m < 1000) {
         km_string = to_string_dec_uint(m) + "m";
     } else {
@@ -503,7 +504,7 @@ void GeoMap::draw_scale(Painter& painter) {
         if (m == 0) {
             km_string = to_string_dec_uint(km) + " km";
         } else {
-            km_string = to_string_dec_uint(km) + "." + to_string_dec_uint((m + 50) / 100, 1) + "km";
+            km_string = to_string_dec_uint(km) + "." + to_string_dec_uint(m / 100, 1) + "km";
         }
     }
 

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -495,10 +495,10 @@ void GeoMap::draw_scale(Painter& painter) {
         m /= 2;
     }
     scale_width /= 1000;
-    m += 50;  // (add rounding factor for div by 100 below)
     if (m < 1000) {
         km_string = to_string_dec_uint(m) + "m";
     } else {
+        m += 50;  // (add rounding factor for div by 100 below)
         uint32_t km = m / 1000;
         m -= km * 1000;
         if (m == 0) {


### PR DESCRIPTION
Fixes a rounding bug when displaying frequencies ending in .999950 Mhz to .999990 MHz.  Resolves #1797.

A rounding factor was being added to the digits to the right of the decimal point before dividing by 100, but it was not being applied to the digits to the left of the decimal point.

This resulted in the incorrect MHz value to the left of the decimal point being displayed on the screen in this specific case when the user was stepping through frequencies in 10Hz or 50Hz increments.

Examples:

Actual frequency:  9.99995 MHz
Was incorrectly displayed as: 9.0000 MHz
Now displays 10.0000 MHz

Actual frequency:  9.99994 MHz
Was displayed as: 9.9999 MHz (rounded down)
Still displays 9.9999 MHz - no change

(Note that the +50 rounding factor should not simply be removed; it was just misapplied.  Without adding the rounding factor 50 before dividing by 100 in integer math, the displayed value would be truncated instead of rounded to the limited number of display digits.  For example, a frequency of 9.999999 Mhz would get displayed as 9.9999 instead of getting rounded up to the closer value 10.0000.)

+Added fixes for the same rounding issue in 3 other places as well.