### PR TITLE
Gh workflow changelog formatting fix

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -71,8 +71,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CHANGELOG=$(python3 .github/workflows/changelog.py)
-          echo "content=$CHANGELOG" >> $GITHUB_OUTPUT
+          {
+            echo 'content<<EOF'
+            python3 .github/workflows/changelog.py
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         id: changelog
       - name: Create Release
         id: create_release

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -72,9 +72,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CHANGELOG=$(python3 .github/workflows/changelog.py)
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           echo "content=$CHANGELOG" >> $GITHUB_OUTPUT
         id: changelog
       - name: Create Release

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -55,11 +55,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CHANGELOG=$(python3 .github/workflows/changelog.py ${{ steps.past_version.outputs.past_version }})
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-          echo "content=$CHANGELOG" >> $GITHUB_OUTPUT
+          {
+            echo 'content<<EOF'
+            python3 .github/workflows/changelog.py ${{ steps.past_version.outputs.past_version }}
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         id: changelog
       - name: Create Release
         id: create_release


### PR DESCRIPTION
The new output command handles newlines differently, and when I updated the workflow I didnt noticed it messed up the changelog :/

Now I adapted the new method, and it works.

Test workflow runs and releases are available in my fork.

Related GH docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings