### PR TITLE
Add Checksums to Firmware & External App images

### DIFF
--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -30,6 +30,30 @@ static const char16_t* firmware_folder = u"/FIRMWARE";
 Thread* FlashUtilityView::thread{nullptr};
 static constexpr size_t max_filename_length = 26;
 
+bool valid_firmware_file(std::filesystem::path::string_type path) {
+    File firmware_file;
+    uint32_t read_buffer[128];
+    uint32_t checksum{1};
+
+    // test read of the whole file just to validate checksum (baseband flash code will re-read when flashing)
+    auto result = firmware_file.open(path.c_str());
+    if (!result.is_valid()) {
+        checksum = 0;
+        for (uint32_t i = FLASH_STARTING_ADDRESS; i < FLASH_ROM_SIZE / sizeof(read_buffer); i++) {
+            auto readResult = firmware_file.read(&read_buffer, sizeof(read_buffer));
+
+            // if file is smaller than 1MB, assume it's a downgrade to an old FW version and ignore the checksum
+            if ((!readResult) || (readResult.value() == 0)) {
+                checksum = FLASH_EXPECTED_CHECKSUM;
+                break;
+            }
+
+            checksum += simple_checksum((uint32_t)read_buffer, sizeof(read_buffer));
+        }
+    }
+    return (checksum == FLASH_EXPECTED_CHECKSUM);
+}
+
 FlashUtilityView::FlashUtilityView(NavigationView& nav)
     : nav_(nav) {
     add_children({&labels,
@@ -105,30 +129,6 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
         chThdSleepMilliseconds(5000);
     }
     return res;
-}
-
-bool FlashUtilityView::valid_firmware_file(std::filesystem::path::string_type path) {
-    File firmware_file;
-    uint32_t read_buffer[128];
-    uint32_t checksum{1};
-
-    // test read of the whole file just to validate checksum (baseband flash code will re-read when flashing)
-    auto result = firmware_file.open(path.c_str());
-    if (!result.is_valid()) {
-        checksum = 0;
-        for (uint32_t i = FLASH_STARTING_ADDRESS; i < FLASH_ROM_SIZE / sizeof(read_buffer); i++) {
-            auto readResult = firmware_file.read(&read_buffer, sizeof(read_buffer));
-
-            // if file is smaller than 1MB, assume it's a downgrade to an old FW version and ignore the checksum
-            if ((!readResult) || (readResult.value() == 0)) {
-                checksum = FLASH_EXPECTED_CHECKSUM;
-                break;
-            }
-
-            checksum += simple_checksum((uint32_t)read_buffer, sizeof(read_buffer));
-        }
-    }
-    return (checksum == FLASH_EXPECTED_CHECKSUM);
 }
 
 void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -43,7 +43,7 @@ bool valid_firmware_file(std::filesystem::path::string_type path) {
             auto readResult = firmware_file.read(&read_buffer, sizeof(read_buffer));
 
             // if file is smaller than 1MB, assume it's a downgrade to an old FW version and ignore the checksum
-            if ((!readResult) || (readResult.value() == 0)) {
+            if ((!readResult) || (readResult.value() != sizeof(read_buffer))) {
                 checksum = FLASH_EXPECTED_CHECKSUM;
                 break;
             }

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -32,7 +32,9 @@
 #include "untar.hpp"
 #include <cstdint>
 
-#define FLASH_ROM_SIZE (1048576)
+#define FLASH_ROM_SIZE 1048576
+#define FLASH_STARTING_ADDRESS 0x00000000
+#define FLASH_EXPECTED_CHECKSUM 0x00000000
 
 namespace ui {
 

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -38,6 +38,8 @@
 
 namespace ui {
 
+bool valid_firmware_file(std::filesystem::path::string_type path);
+
 class FlashUtilityView : public View {
    public:
     FlashUtilityView(NavigationView& nav);
@@ -63,7 +65,6 @@ class FlashUtilityView : public View {
     void firmware_selected(std::filesystem::path::string_type path);
     void flash_firmware(std::filesystem::path::string_type path);
     bool endsWith(const std::u16string& str, const std::u16string& suffix);
-    bool valid_firmware_file(std::filesystem::path::string_type path);
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -32,6 +32,8 @@
 #include "untar.hpp"
 #include <cstdint>
 
+#define FLASH_ROM_SIZE (1048576)
+
 namespace ui {
 
 class FlashUtilityView : public View {
@@ -59,6 +61,7 @@ class FlashUtilityView : public View {
     void firmware_selected(std::filesystem::path::string_type path);
     void flash_firmware(std::filesystem::path::string_type path);
     bool endsWith(const std::u16string& str, const std::u16string& suffix);
+    bool valid_firmware_file(std::filesystem::path::string_type path);
 };
 
 } /* namespace ui */

--- a/firmware/application/ui_external_items_menu_loader.cpp
+++ b/firmware/application/ui_external_items_menu_loader.cpp
@@ -179,7 +179,7 @@ namespace ui {
         }
     }
 
-    if (checksum != 0)
+    if (checksum != EXT_APP_EXPECTED_CHECKSUM)
         return false;
 
     application_information.externalAppEntry(nav);

--- a/firmware/application/ui_external_items_menu_loader.cpp
+++ b/firmware/application/ui_external_items_menu_loader.cpp
@@ -107,6 +107,7 @@ namespace ui {
 
 /* static */ bool ExternalItemsMenuLoader::run_external_app(ui::NavigationView& nav, std::filesystem::path filePath) {
     File app;
+    uint32_t checksum{0};
 
     auto openError = app.open(filePath);
     if (openError)
@@ -115,7 +116,6 @@ namespace ui {
     application_information_t application_information = {};
 
     auto readResult = app.read(&application_information, sizeof(application_information_t));
-
     if (!readResult)
         return false;
 
@@ -134,6 +134,8 @@ namespace ui {
             readResult = app.read(&application_information.memory_location[file_read_index], bytes_to_read);
             if (!readResult)
                 return false;
+
+            checksum += simple_checksum((uint32_t)&application_information.memory_location[file_read_index], readResult.value());
 
             if (readResult.value() < std::filesystem::max_file_block_size)
                 break;
@@ -156,6 +158,8 @@ namespace ui {
             if (!readResult)
                 return false;
 
+            checksum += simple_checksum((uint32_t)target_memory, readResult.value());
+
             if (readResult.value() != bytes_to_read)
                 break;
         }
@@ -168,10 +172,15 @@ namespace ui {
             if (!readResult)
                 return false;
 
+            checksum += simple_checksum((uint32_t)&application_information.memory_location[file_read_index], readResult.value());
+
             if (readResult.value() < std::filesystem::max_file_block_size)
                 break;
         }
     }
+
+    if (checksum != 0)
+        return false;
 
     application_information.externalAppEntry(nav);
     return true;

--- a/firmware/application/ui_external_items_menu_loader.hpp
+++ b/firmware/application/ui_external_items_menu_loader.hpp
@@ -29,6 +29,8 @@
 
 #include "file.hpp"
 
+#define EXT_APP_EXPECTED_CHECKSUM 0x00000000
+
 namespace ui {
 
 template <size_t Width, size_t Height>

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -579,7 +579,6 @@ bool InformationView::firmware_checksum_error() {
     return fw_checksum_error;
 }
 
-
 /* Navigation ************************************************************/
 
 bool NavigationView::is_top() const {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -574,7 +574,7 @@ bool InformationView::firmware_checksum_error() {
 
     // only checking firmware checksum once per boot
     if (!fw_checksum_checked) {
-        fw_checksum_error = (simple_checksum(0, FLASH_ROM_SIZE) != 0);
+        fw_checksum_error = (simple_checksum(FLASH_STARTING_ADDRESS, FLASH_ROM_SIZE) != FLASH_EXPECTED_CHECKSUM);
     }
     return fw_checksum_error;
 }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -503,8 +503,8 @@ void SystemStatusView::rtc_battery_workaround() {
             month = (timestamp.FAT_date >> 5) & 0xF;
             day = timestamp.FAT_date & 0x1F;
 
-            // bump to next month at 28 days for simplicity
-            if (++day > 28) {
+            // bump to next month
+            if (++day > rtc_time::days_per_month(year, month)) {
                 day = 1;
                 if (++month > 12) {
                     month = 1;
@@ -547,15 +547,15 @@ InformationView::InformationView(
                   &ltime});
 
 #if GCC_VERSION_MISMATCH
-    static constexpr Style style_gcc_warning{
-        .font = font::fixed_8x16,
-        .background = {33, 33, 33},
-        .foreground = Color::yellow(),
-    };
-    version.set_style(&style_gcc_warning);
+    version.set_style(&Styles::yellow);
 #else
     version.set_style(&style_infobar);
 #endif
+
+    if (firmware_checksum_error()) {
+        version.set("FLASH ERROR");
+        version.set_style(&Styles::red);
+    }
 
     ltime.set_style(&style_infobar);
     refresh();
@@ -567,6 +567,18 @@ void InformationView::refresh() {
     ltime.set_seconds_enabled(true);
     ltime.set_date_enabled(pmem::clock_with_date());
 }
+
+bool InformationView::firmware_checksum_error() {
+    static bool fw_checksum_checked{false};
+    static bool fw_checksum_error{false};
+
+    // only checking firmware checksum once per boot
+    if (!fw_checksum_checked) {
+        fw_checksum_error = (simple_checksum(0, FLASH_ROM_SIZE) != 0);
+    }
+    return fw_checksum_error;
+}
+
 
 /* Navigation ************************************************************/
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -286,6 +286,7 @@ class InformationView : public View {
    public:
     InformationView(NavigationView& nav);
     void refresh();
+    bool firmware_checksum_error();
 
    private:
     // static constexpr auto version_string = "v1.4.4"; // This is commented out as we are now setting the version via ENV (VERSION_STRING=v1.0.0)

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -41,6 +41,7 @@
 #include "chprintf.h"
 #include "chqueues.h"
 #include "ui_external_items_menu_loader.hpp"
+#include "ui_flash_utility.hpp"
 #include "untar.hpp"
 #include "ui_widget.hpp"
 
@@ -170,7 +171,13 @@ static void cmd_flash(BaseSequentialStream* chp, int argc, char* argv[]) {
     } else if (strEndsWith(path.native(), u".bin")) {
         // nothing to do for this case yet.
     } else {
-        chprintf(chp, "error only .bin or .ppfw.tar files canbe flashed.\r\n");
+        chprintf(chp, "error only .bin or .ppfw.tar files can be flashed.\r\n");
+        nav->pop();
+        return;
+    }
+
+    if (!ui::valid_firmware_file(path.native().c_str())) {
+        chprintf(chp, "error corrupt firmware file.\r\n");
         nav->pop();
         return;
     }

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -32,6 +32,7 @@
 #include "string_format.hpp"
 #include "ui_styles.hpp"
 #include "ui_painter.hpp"
+#include "ui_flash_utility.hpp"
 #include "utility.hpp"
 #include "rtc_time.hpp"
 
@@ -1052,7 +1053,7 @@ bool debug_dump() {
     pmem_dump_file.write_line("GCC version: " + to_string_dec_int(__GNUC__) + "." + to_string_dec_int(__GNUC_MINOR__) + "." + to_string_dec_int(__GNUC_PATCHLEVEL__));
 
     // firmware checksum
-    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(simple_checksum(0, 1048576), 8));
+    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(simple_checksum(0, FLASH_ROM_SIZE), 8));
 
     // write persistent memory
     pmem_dump_file.write_line("\n[Persistent Memory]");

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -1051,6 +1051,14 @@ bool debug_dump() {
     pmem_dump_file.write_line("Ext APPS version req'd: 0x" + to_string_hex(VERSION_MD5));
     pmem_dump_file.write_line("GCC version: " + to_string_dec_int(__GNUC__) + "." + to_string_dec_int(__GNUC_MINOR__) + "." + to_string_dec_int(__GNUC_PATCHLEVEL__));
 
+    // simple firmware checksum test
+    uint32_t checksum = 0;
+    for (uint32_t rom_addr = 0; rom_addr < 1048576 - 4; rom_addr += 4)
+        checksum += *(uint32_t*)rom_addr;
+
+    pmem_dump_file.write_line("Firmware stored checksum: 0x" + to_string_hex(*(uint32_t*)(1048576 - 4), 8));
+    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(checksum, 8));
+
     // write persistent memory
     pmem_dump_file.write_line("\n[Persistent Memory]");
 

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -1053,7 +1053,7 @@ bool debug_dump() {
     pmem_dump_file.write_line("GCC version: " + to_string_dec_int(__GNUC__) + "." + to_string_dec_int(__GNUC_MINOR__) + "." + to_string_dec_int(__GNUC_PATCHLEVEL__));
 
     // firmware checksum
-    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(simple_checksum(0, FLASH_ROM_SIZE), 8));
+    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(simple_checksum(FLASH_STARTING_ADDRESS, FLASH_ROM_SIZE), 8));
 
     // write persistent memory
     pmem_dump_file.write_line("\n[Persistent Memory]");

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -1051,13 +1051,8 @@ bool debug_dump() {
     pmem_dump_file.write_line("Ext APPS version req'd: 0x" + to_string_hex(VERSION_MD5));
     pmem_dump_file.write_line("GCC version: " + to_string_dec_int(__GNUC__) + "." + to_string_dec_int(__GNUC_MINOR__) + "." + to_string_dec_int(__GNUC_PATCHLEVEL__));
 
-    // simple firmware checksum test
-    uint32_t checksum = 0;
-    for (uint32_t rom_addr = 0; rom_addr < 1048576 - 4; rom_addr += 4)
-        checksum += *(uint32_t*)rom_addr;
-
-    pmem_dump_file.write_line("Firmware stored checksum: 0x" + to_string_hex(*(uint32_t*)(1048576 - 4), 8));
-    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(checksum, 8));
+    // firmware checksum
+    pmem_dump_file.write_line("Firmware calculated checksum: 0x" + to_string_hex(simple_checksum(0, 1048576), 8));
 
     // write persistent memory
     pmem_dump_file.write_line("\n[Persistent Memory]");

--- a/firmware/common/utility.cpp
+++ b/firmware/common/utility.cpp
@@ -235,3 +235,10 @@ std::string join(char c, std::initializer_list<std::string_view> strings) {
 
     return result;
 }
+
+uint32_t simple_checksum(uint32_t buffer_address, uint32_t length) {
+    uint32_t checksum = 0;
+    for (uint32_t i = 0; i < length; i += 4)
+        checksum += *(uint32_t*)(buffer_address + i);
+    return checksum;
+}

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -217,4 +217,6 @@ struct range_t {
 
 std::string join(char c, std::initializer_list<std::string_view> strings);
 
+uint32_t simple_checksum(uint32_t buffer_address, uint32_t length);
+
 #endif /*__UTILITY_H__*/

--- a/firmware/tools/export_external_apps.py
+++ b/firmware/tools/export_external_apps.py
@@ -104,6 +104,13 @@ for external_image_prefix in sys.argv[4:]:
 		external_application_image = patch_image(external_application_image, search_address, replace_address)
 		external_application_image[memory_location_header_position:memory_location_header_position+4] = replace_address.to_bytes(4, byteorder='little')
 
+		checksum = 0
+		for i in range(0, len(external_application_image) - 4, 4):
+			checksum += external_application_image[i] + (external_application_image[i + 1] << 8) + (external_application_image[i + 2] << 16) + (external_application_image[i + 3] << 24)
+
+		checksum &= 0xFFFFFFFF
+		external_application_image += checksum.to_bytes(4, 'little')
+
 		write_image(external_application_image, "{}/{}.ppma".format(binary_dir, external_image_prefix))
 		continue
 
@@ -126,6 +133,13 @@ for external_image_prefix in sys.argv[4:]:
 	if (len(external_application_image) > maximum_application_size) != 0:
 		print("application {} can not exceed 32kb: {} bytes used".format(external_image_prefix, len(external_application_image)))
 		sys.exit(-1)
+
+	checksum = 0
+	for i in range(0, len(external_application_image) - 4, 4):
+		checksum += external_application_image[i] + (external_application_image[i + 1] << 8) + (external_application_image[i + 2] << 16) + (external_application_image[i + 3] << 24)
+
+	checksum &= 0xFFFFFFFF
+	external_application_image += checksum.to_bytes(4, 'little')
 
 	# write .ppma (portapack mayhem application)
 	write_image(external_application_image, "{}/{}.ppma".format(binary_dir, external_image_prefix))

--- a/firmware/tools/export_external_apps.py
+++ b/firmware/tools/export_external_apps.py
@@ -108,7 +108,8 @@ for external_image_prefix in sys.argv[4:]:
 		for i in range(0, len(external_application_image), 4):
 			checksum += external_application_image[i] + (external_application_image[i + 1] << 8) + (external_application_image[i + 2] << 16) + (external_application_image[i + 3] << 24)
 
-		checksum = (0 - checksum) & 0xFFFFFFFF
+		final_checksum = 0
+		checksum = (final_checksum - checksum) & 0xFFFFFFFF
 		external_application_image += checksum.to_bytes(4, 'little')
 
 		write_image(external_application_image, "{}/{}.ppma".format(binary_dir, external_image_prefix))
@@ -138,7 +139,8 @@ for external_image_prefix in sys.argv[4:]:
 	for i in range(0, len(external_application_image), 4):
 		checksum += external_application_image[i] + (external_application_image[i + 1] << 8) + (external_application_image[i + 2] << 16) + (external_application_image[i + 3] << 24)
 
-	checksum = (0 - checksum) & 0xFFFFFFFF
+	final_checksum = 0
+	checksum = (final_checksum - checksum) & 0xFFFFFFFF
 	external_application_image += checksum.to_bytes(4, 'little')
 
 	# write .ppma (portapack mayhem application)

--- a/firmware/tools/export_external_apps.py
+++ b/firmware/tools/export_external_apps.py
@@ -105,10 +105,10 @@ for external_image_prefix in sys.argv[4:]:
 		external_application_image[memory_location_header_position:memory_location_header_position+4] = replace_address.to_bytes(4, byteorder='little')
 
 		checksum = 0
-		for i in range(0, len(external_application_image) - 4, 4):
+		for i in range(0, len(external_application_image), 4):
 			checksum += external_application_image[i] + (external_application_image[i + 1] << 8) + (external_application_image[i + 2] << 16) + (external_application_image[i + 3] << 24)
 
-		checksum &= 0xFFFFFFFF
+		checksum = (0 - checksum) & 0xFFFFFFFF
 		external_application_image += checksum.to_bytes(4, 'little')
 
 		write_image(external_application_image, "{}/{}.ppma".format(binary_dir, external_image_prefix))
@@ -135,10 +135,10 @@ for external_image_prefix in sys.argv[4:]:
 		sys.exit(-1)
 
 	checksum = 0
-	for i in range(0, len(external_application_image) - 4, 4):
+	for i in range(0, len(external_application_image), 4):
 		checksum += external_application_image[i] + (external_application_image[i + 1] << 8) + (external_application_image[i + 2] << 16) + (external_application_image[i + 3] << 24)
 
-	checksum &= 0xFFFFFFFF
+	checksum = (0 - checksum) & 0xFFFFFFFF
 	external_application_image += checksum.to_bytes(4, 'little')
 
 	# write .ppma (portapack mayhem application)

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -22,7 +22,6 @@
 #
 
 import sys
-# import zlib
 
 usage_message = """
 PortaPack SPI flash image generator
@@ -82,15 +81,13 @@ pad_size = spi_size - 4 - len(spi_image)
 for i in range(pad_size):
 	spi_image += spi_image_default_byte
 
-# crc32 works but it's slow to check in firmware
-# checksum = zlib.crc32(spi_image)
-
-# quicker "add up the words" checksum:
+# quick "add up the words" checksum:
 checksum = 0
 for i in range(0, len(spi_image), 4):
 	checksum += (spi_image[i] + (spi_image[i + 1] << 8) + (spi_image[i + 2] << 16) + (spi_image[i + 3] << 24))
 
-checksum = (0 - checksum) & 0xFFFFFFFF
+final_checksum = 0
+checksum = (final_checksum - checksum) & 0xFFFFFFFF
 
 spi_image += checksum.to_bytes(4, 'little')
 

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -87,10 +87,10 @@ for i in range(pad_size):
 
 # quicker "add up the words" checksum:
 checksum = 0
-for i in range(0, len(spi_image) - 4, 4):
-	checksum += spi_image[i] + (spi_image[i + 1] << 8) + (spi_image[i + 2] << 16) + (spi_image[i + 3] << 24)
+for i in range(0, len(spi_image), 4):
+	checksum += (spi_image[i] + (spi_image[i + 1] << 8) + (spi_image[i + 2] << 16) + (spi_image[i + 3] << 24))
 
-checksum &= 0xFFFFFFFF
+checksum = (0 - checksum) & 0xFFFFFFFF
 
 spi_image += checksum.to_bytes(4, 'little')
 

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -88,10 +88,13 @@ for i in range(pad_size):
 # quicker "add up the words" checksum:
 checksum = 0
 for i in range(0, len(spi_image) - 4, 4):
-	checksum += spi_image[i] + (spi_image[i+1] << 8) + (spi_image[i+2] << 16) + (spi_image[i+3] << 24)
+	checksum += spi_image[i] + (spi_image[i + 1] << 8) + (spi_image[i + 2] << 16) + (spi_image[i + 3] << 24)
 
 checksum &= 0xFFFFFFFF
 
 spi_image += checksum.to_bytes(4, 'little')
 
 write_image(spi_image, output_path)
+
+percent_remaining = round(1000 * pad_size / spi_size) / 10;
+print ("Space remaining in flash ROM:", pad_size, "bytes (", percent_remaining, "%)")

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -76,7 +76,7 @@ for image in images:
 	spi_image += padded_data
 
 if len(spi_image) > spi_size - 4:
-	raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image), spi_size))
+	raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
 
 pad_size = spi_size - 4 - len(spi_image)
 for i in range(pad_size):
@@ -87,7 +87,7 @@ for i in range(pad_size):
 
 # quicker "add up the words" checksum:
 checksum = 0
-for i in range(0, len(spi_image) - 1, 4):
+for i in range(0, len(spi_image) - 4, 4):
 	checksum += spi_image[i] + (spi_image[i+1] << 8) + (spi_image[i+2] << 16) + (spi_image[i+3] << 24)
 
 checksum &= 0xFFFFFFFF

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -22,7 +22,7 @@
 #
 
 import sys
-import zlib
+# import zlib
 
 usage_message = """
 PortaPack SPI flash image generator

--- a/firmware/tools/simple_checksum.py
+++ b/firmware/tools/simple_checksum.py
@@ -53,6 +53,5 @@ checksum = 0
 for i in range(0, len(image), 4):
 	checksum += (image[i] + (image[i + 1] << 8) + (image[i + 2] << 16) + (image[i + 3] << 24))
 
-checksum = (0 - checksum) & 0xFFFFFFFF
-
+checksum &= 0xFFFFFFFF
 print ("Simple checksum =", checksum)

--- a/firmware/tools/simple_checksum.py
+++ b/firmware/tools/simple_checksum.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Mark Thompson
+# Copyright (C) 2024 Mark Thompson
 #
 # This file is part of PortaPack.
 #

--- a/firmware/tools/simple_checksum.py
+++ b/firmware/tools/simple_checksum.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Mark Thompson
+#
+# This file is part of PortaPack.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+import sys
+import struct
+
+usage_message = """
+PortaPack ROM image checksum checker
+
+Usage: <command> <input-file>
+"""
+
+def read_image(path):
+	f = open(path, 'rb')
+	data = f.read()
+	f.close()
+	return data
+
+def write_image(data, path):
+	f = open(path, 'wb')
+	f.write(data)
+	f.close()
+
+if len(sys.argv) != 2:
+	print(usage_message)
+	sys.exit(-1)
+
+image = read_image(sys.argv[1])
+image = bytearray(image)
+
+# simple "add up the words" checksum:
+checksum = 0
+for i in range(0, len(image), 4):
+	checksum += (image[i] + (image[i + 1] << 8) + (image[i + 2] << 16) + (image[i + 3] << 24))
+
+checksum = (0 - checksum) & 0xFFFFFFFF
+
+print ("Simple checksum =", checksum)


### PR DESCRIPTION
This PR resolves #1760:

firmware/tools changes:
* Modified the "make_spi_image.py" python script to pad firmware images to 1MB and to include a simple 4-byte checksum.  I also added a print to show the remaining ROM space.
* Modified "export_external_apps.py" to append simple checksum (no padding needed).
* Added a "simple_checksum.py" python tool to verify that an image file has the correct checksum (should be 0).

firmware changes:
* When flashing a new firmware image via either the Flash Utility or USB Serial Flash, the checksum is verified before flashing.  The checksum is only compared for firmware files that are exactly 1MB to retain compatibility with (allow downgrades to) older firmware versions.
* When loading an external app into memory, the checksum is now tested to verify that the app file is not corrupted, avoiding "guru meditation faults" as seen in #1805.  (This check requires the python script change above.)
* Modified the "Debug Dump" app to output the firmware checksum to the file as well (should be 0), in case it might catch a flaky bit in the ROM.
* Modified the Information area of the nav screen to show "FLASH ERROR" in red if the flash ROM checksum is bad (only checked once per boot).  (IMO this check doesn't have to be in early power-up because if a fault occurs early in power-up it's a safe bet that a DFU flash will be performed anyway.  I'm more concerned about the case where there is a partial flash corruption that might cause erratic behavior or faults in only some apps as I experienced after interrupting a flash operation.  Hence, I think it's OK to wait until the Nav screen pops up before checking.   Note this check requires the python script change above.)

This is a simple "add up all the words" type of checksum.  I tried it with the fancy CRC32 but it was taking about a second to calculate in firmware and I thought that was too long (I didn't want to slow down the boot process).

Note that adding extra checksum bytes to the end of firmware & external app images have no affect on their functionality, and the firmware image remains compatible with existing flash applications.