### PR TITLE
Check app checksums during untar

### DIFF
--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -33,13 +33,13 @@ static constexpr size_t max_filename_length = 26;
 bool valid_firmware_file(std::filesystem::path::string_type path) {
     File firmware_file;
     uint32_t read_buffer[128];
-    uint32_t checksum{1};
+    uint32_t checksum{(uint32_t)~FLASH_EXPECTED_CHECKSUM};  // initializing to invalid checksum in case file can't be read
 
     // test read of the whole file just to validate checksum (baseband flash code will re-read when flashing)
     auto result = firmware_file.open(path.c_str());
     if (!result.is_valid()) {
         checksum = 0;
-        for (uint32_t i = FLASH_STARTING_ADDRESS; i < FLASH_ROM_SIZE / sizeof(read_buffer); i++) {
+        for (uint32_t i = 0; i < FLASH_ROM_SIZE / sizeof(read_buffer); i++) {
             auto readResult = firmware_file.read(&read_buffer, sizeof(read_buffer));
 
             // if file is smaller than 1MB, assume it's a downgrade to an old FW version and ignore the checksum

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ui_flash_utility.hpp"
+#include "ui_styles.hpp"
 #include "portapack_shared_memory.hpp"
 
 namespace ui {
@@ -122,12 +123,6 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
         painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
         painter.draw_string({0, 60}, this->nav_.style(), fileName);
     });
-    if (res.string().empty()) {
-        ui::Painter painter;
-        painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
-        painter.draw_string({0, 60}, this->nav_.style(), "BAD TAR FILE");
-        chThdSleepMilliseconds(5000);
-    }
     return res;
 }
 
@@ -137,8 +132,13 @@ void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
         path = extract_tar(u'/' + path).native();
     }
 
-    if (path.empty() || !valid_firmware_file(path.c_str()))
-        return;  // bad firmware image - just returning back to the file list
+    if (path.empty() || !valid_firmware_file(path.c_str())) {
+        ui::Painter painter;
+        painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
+        painter.draw_string({0, 60}, Styles::red, "BAD FIRMWARE FILE");
+        chThdSleepMilliseconds(5000);
+        return;
+    }
 
     ui::Painter painter;
     painter.fill_rectangle(

--- a/firmware/common/external_app.hpp
+++ b/firmware/common/external_app.hpp
@@ -26,7 +26,8 @@
 #include "ui_navigation.hpp"
 #include "spi_image.hpp"
 
-#define CURRENT_HEADER_VERSION 0x00000001
+#define CURRENT_HEADER_VERSION 0x00000002
+#define MIN_HEADER_VERSION_FOR_CHECKSUM 0x00000002
 
 typedef void (*externalAppEntry_t)(ui::NavigationView& nav);
 

--- a/firmware/common/untar.hpp
+++ b/firmware/common/untar.hpp
@@ -90,6 +90,7 @@ class UnTar {
         int filesize;
         uint32_t app_checksum;
         bool app_file;
+        bool first_read;
         for (;;) {
             auto readres = a->read(buff, 512);
             if (!readres.is_ok()) return "";
@@ -137,9 +138,9 @@ class UnTar {
                 auto fres = f.open(fn, false, true);
                 if (!fres.value().ok()) return "";
                 app_file = (fn.substr(fn.size() - 5) == ".ppma");
+                first_read = true;
                 app_checksum = 0;
             }
-            bool first_read{true};
             while (filesize > 0) {
                 readres = a->read(buff, 512);
                 if (!readres.is_ok()) return "";


### PR DESCRIPTION
Added checking of app checksums during untar, resolves #1813.

* If a checksum error is detected when extracting any app, the untar process will now delete the bad file, bail out, and return a null string, thereby preventing future execution of the bad app, stopping extraction of additional files, and preventing the firmware flash operation.
* Note that code specifically looks for app files (with .ppma extension) and checks the external app header to make sure that the app is a new version that includes a checksum, thereby allowing newer firmware to still un-tar older ppfw files that do not have a checksum, and to ignore any other types of files that we may add to the tar file in the future.

Additionally, if a firmware checksum error is detected in the Flash App, a "BAD FIRMWARE FILE" message is now displayed in red for 5 seconds before returning to the file selection list.