### PR TITLE
Allow 3 boot failures before Config Mode starts

### DIFF
--- a/firmware/application/config_mode.cpp
+++ b/firmware/application/config_mode.cpp
@@ -28,7 +28,7 @@ void config_mode_blink_until_dfu();
 
 void config_mode_set() {
     uint32_t cms = portapack::persistent_memory::config_mode_storage_direct();
-    if ((cms >= CONFIG_MODE_GUARD_VALUE) && (cms <= CONFIG_MODE_LIMIT_VALUE))
+    if ((cms >= CONFIG_MODE_GUARD_VALUE) && (cms < CONFIG_MODE_LIMIT_VALUE))
         cms += 1;
     else
         cms = CONFIG_MODE_GUARD_VALUE;

--- a/firmware/application/config_mode.cpp
+++ b/firmware/application/config_mode.cpp
@@ -27,14 +27,19 @@
 void config_mode_blink_until_dfu();
 
 void config_mode_set() {
-    portapack::persistent_memory::set_config_mode_storage_direct(CONFIG_MODE_GUARD_VALUE);
+    uint32_t cms = portapack::persistent_memory::config_mode_storage_direct();
+    if ((cms >= CONFIG_MODE_GUARD_VALUE) && (cms <= CONFIG_MODE_LIMIT_VALUE))
+        cms += 1;
+    else
+        cms = CONFIG_MODE_GUARD_VALUE;
+    portapack::persistent_memory::set_config_mode_storage_direct(cms);
 }
 
 bool config_mode_should_enter() {
     if (portapack::persistent_memory::config_disable_config_mode_direct())
         return false;
     else
-        return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_GUARD_VALUE;
+        return portapack::persistent_memory::config_mode_storage_direct() == CONFIG_MODE_LIMIT_VALUE;
 }
 
 void config_mode_clear() {

--- a/firmware/application/config_mode.hpp
+++ b/firmware/application/config_mode.hpp
@@ -28,6 +28,13 @@
 #include "portapack_shared_memory.hpp"
 #include "portapack_persistent_memory.hpp"
 
+// number of boot failures before entering config menu mode
+#define BOOT_FAILURES_BEFORE_CONFIG_MODE 3
+
+#define CONFIG_MODE_GUARD_VALUE 0xbadb0000
+#define CONFIG_MODE_LIMIT_VALUE (CONFIG_MODE_GUARD_VALUE + BOOT_FAILURES_BEFORE_CONFIG_MODE - 1)
+#define CONFIG_MODE_NORMAL_VALUE 0x000007cf
+
 void config_mode_set();
 bool config_mode_should_enter();
 void config_mode_clear();

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -32,6 +32,7 @@
 #include "modems.hpp"
 #include "serializer.hpp"
 #include "volume.hpp"
+#include "config_mode.hpp"
 
 // persistent memory from/to sdcard flag file
 #define PMEM_FILEFLAG u"/SETTINGS/PMEM_FILEFLAG"
@@ -242,8 +243,6 @@ void set_disable_touchscreen(bool v);
 uint8_t config_encoder_dial_sensitivity();
 void set_encoder_dial_sensitivity(uint8_t v);
 
-#define CONFIG_MODE_GUARD_VALUE 0x000007d1
-#define CONFIG_MODE_NORMAL_VALUE 0x000007cf
 uint32_t config_mode_storage_direct();
 void set_config_mode_storage_direct(uint32_t v);
 bool config_disable_config_mode_direct();


### PR DESCRIPTION
Resolves Config Mode issue mentioned in #1693, #1718, and in PR 1781

Instead of entering Config Menu Mode after a single boot failure, wait until 3 consecutive boot failures have occurred.

With this change, I don't know if we still need the Settings -> Config Mode app to disable the Config Menu entirely, but I have not removed that app, just in case.  (Perhaps I should change it to allow the user to configure exactly how many failed boot attempts before entering Config Mode?  Opinions?)