### PR TITLE
Embedded friendly usb

### DIFF
--- a/firmware/application/usb_serial_descriptor.c
+++ b/firmware/application/usb_serial_descriptor.c
@@ -118,7 +118,7 @@ uint8_t usb_descriptor_configuration_full_speed[] = {
     USB_INT_IN_EP_ADDR,            // bEndpointAddress
     0x03,                          // bmAttributes: BULK
     USB_WORD(16),                  // wMaxPacketSize
-    0xFF,                          // bInterval: no NAK
+    0x20,                          // bInterval: no NAK
 
     9,                              // bLength
     USB_DESCRIPTOR_TYPE_INTERFACE,  // bDescriptorType
@@ -203,7 +203,7 @@ uint8_t usb_descriptor_configuration_high_speed[] = {
     USB_INT_IN_EP_ADDR,            // bEndpointAddress
     0x03,                          // bmAttributes: BULK
     USB_WORD(16),                  // wMaxPacketSize
-    0xFF,                          // bInterval: no NAK
+    0x20,                          // bInterval: no NAK
 
     9,                              // bLength
     USB_DESCRIPTOR_TYPE_INTERFACE,  // bDescriptorType


### PR DESCRIPTION
Some embedded devices (eg esp32) support usb otg, but has problems with high bInterval, so set to 32. Under Windows it doesn't change much, the speed as it was before, but no errors on esp.

BEFORE merge should try with linux (doesn't have a box to test), and Mac too.
