### PR TITLE
Fix tuning of freq ranges 2170-2300 and 2700-2740 MHz

### DIFF
--- a/firmware/application/hw/max283x.hpp
+++ b/firmware/application/hw/max283x.hpp
@@ -33,10 +33,10 @@ namespace max283x {
 namespace lo {
 
 constexpr std::array<rf::FrequencyRange, 4> band{{
-    {2300000000, 2400000000},
+    {2170000000, 2400000000},
     {2400000000, 2500000000},
     {2500000000, 2600000000},
-    {2600000000, 2700000000},
+    {2600000000, 2740000000},
 }};
 
 } /* namespace lo */
@@ -47,11 +47,6 @@ namespace lna {
 
 constexpr range_t<int8_t> gain_db_range{0, 40};
 constexpr int8_t gain_db_step = 8;
-
-constexpr std::array<rf::FrequencyRange, 2> band{{
-    {2300000000, 2500000000},
-    {2500000000, 2700000000},
-}};
 
 } /* namespace lna */
 


### PR DESCRIPTION
As configured in rf_path.hpp, "mid" band frequency ranges between 2170-2740 MHz bypass the RFFC5072 and are passed to the MAX283x code.  BUT, the MAX283x code was using the spec'd range 2300-2700 MHz and was just bailing out (without updating the tuner frequency) for frequencies outside the 2300-2700 MHz range.

Result was the frequency was never programmed if it was between 2170-2300 MHz or 2700-2740 MHz.

This resolves some of the dead bands in issue #1772.  Note that the remaining dead bands at 2740-2936 and 4201-4560 MHz appear to be a different issue.

BTW, the couple lines I commented out were unused.