### PR TITLE
Call the flasher app when flashing from serial

### DIFF
--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -125,7 +125,7 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
     return res;
 }
 
-void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
+bool FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
     ui::Painter painter;
     if (endsWith(path, u".tar")) {
         // extract, then update
@@ -136,7 +136,7 @@ void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
         painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
         painter.draw_string({0, 60}, Styles::red, "BAD FIRMWARE FILE");
         chThdSleepMilliseconds(5000);
-        return;
+        return false;
     }
     painter.fill_rectangle(
         {0, 0, portapack::display.width(), portapack::display.height()},

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -110,9 +110,8 @@ bool FlashUtilityView::endsWith(const std::u16string& str, const std::u16string&
     }
 }
 
-std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::string_type path) {
+std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::string_type path, ui::Painter& painter) {
     //
-    ui::Painter painter;
     painter.fill_rectangle(
         {0, 0, portapack::display.width(), portapack::display.height()},
         ui::Color::black());
@@ -127,20 +126,18 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
 }
 
 void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
+    ui::Painter painter;
     if (endsWith(path, u".tar")) {
         // extract, then update
-        path = extract_tar(u'/' + path).native();
+        path = extract_tar(u'/' + path, painter).native();
     }
 
     if (path.empty() || !valid_firmware_file(path.c_str())) {
-        ui::Painter painter;
         painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
         painter.draw_string({0, 60}, Styles::red, "BAD FIRMWARE FILE");
         chThdSleepMilliseconds(5000);
         return;
     }
-
-    ui::Painter painter;
     painter.fill_rectangle(
         {0, 0, portapack::display.width(), portapack::display.height()},
         ui::Color::black());

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -47,7 +47,7 @@ class FlashUtilityView : public View {
     void focus() override;
 
     std::string title() const override { return "Flash Utility"; };
-    void flash_firmware(std::filesystem::path::string_type path);
+    bool flash_firmware(std::filesystem::path::string_type path);
 
    private:
     NavigationView& nav_;

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -47,6 +47,7 @@ class FlashUtilityView : public View {
     void focus() override;
 
     std::string title() const override { return "Flash Utility"; };
+    void flash_firmware(std::filesystem::path::string_type path);
 
    private:
     NavigationView& nav_;
@@ -61,9 +62,9 @@ class FlashUtilityView : public View {
         {0, 2 * 8, 240, 26 * 8},
         true};
 
-    std::filesystem::path extract_tar(std::filesystem::path::string_type path);  // extracts the tar file, and returns the firmware.bin path from it. empty string if no fw
+    std::filesystem::path extract_tar(std::filesystem::path::string_type path, ui::Painter& painter);  // extracts the tar file, and returns the firmware.bin path from it. empty string if no fw
     void firmware_selected(std::filesystem::path::string_type path);
-    void flash_firmware(std::filesystem::path::string_type path);
+
     bool endsWith(const std::u16string& str, const std::u16string& suffix);
 };
 

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -157,7 +157,7 @@ static void cmd_flash(BaseSequentialStream* chp, int argc, char* argv[]) {
     // call nav with flash
     auto open_view = nav->push<ui::FlashUtilityView>();
     chprintf(chp, "Flashing started\r\n");
-    chThdSleepMilliseconds(150);  // to givew display some time to paint the screen
+    chThdSleepMilliseconds(150);  // to give display some time to paint the screen
     if (!open_view->flash_firmware(path.native())) {
         chprintf(chp, "error\r\n");
     }

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -152,45 +152,12 @@ static void cmd_flash(BaseSequentialStream* chp, int argc, char* argv[]) {
     if (!top_widget) return;
     auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
     if (!nav) return;
-    nav->display_modal("Flashing", "Flashing from serial.\r\nPlease wait!\r\nDevice will restart.");
-    // check file extensions
-    if (strEndsWith(path.native(), u".ppfw.tar")) {
-        // extract tar
-        chprintf(chp, "Extracting TAR file.\r\n");
-        auto res = UnTar::untar(
-            path.native(), [chp](const std::string fileName) {
-                chprintf(chp, fileName.c_str());
-                chprintf(chp, "\r\n");
-            });
-        if (res.empty()) {
-            chprintf(chp, "error bad TAR file.\r\n");
-            nav->pop();
-            return;
-        }
-        path = res;  // it will contain the last bin file in tar
-    } else if (strEndsWith(path.native(), u".bin")) {
-        // nothing to do for this case yet.
-    } else {
-        chprintf(chp, "error only .bin or .ppfw.tar files can be flashed.\r\n");
-        nav->pop();
-        return;
-    }
+    nav->home(false);
 
-    if (!ui::valid_firmware_file(path.native().c_str())) {
-        chprintf(chp, "error corrupt firmware file.\r\n");
-        nav->pop();
-        return;
-    }
-
-    chprintf(chp, "Flashing: ");
-    chprintf(chp, path.string().c_str());
-    chprintf(chp, "\r\n");
-    chThdSleepMilliseconds(50);
-    std::memcpy(&shared_memory.bb_data.data[0], path.native().c_str(), (path.native().length() + 1) * 2);
-    m4_request_shutdown();
-    chThdSleepMilliseconds(50);
-    m4_init(portapack::spi_flash::image_tag_flash_utility, portapack::memory::map::m4_code, false);
-    m0_halt();
+    // call nav with flash
+    auto open_view = nav->push<ui::FlashUtilityView>();
+    chThdSleepMilliseconds(150);  // to givew display some time to paint the screen
+    open_view->flash_firmware(path.native());
 }
 
 static void cmd_screenshot(BaseSequentialStream* chp, int argc, char* argv[]) {

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -156,9 +156,11 @@ static void cmd_flash(BaseSequentialStream* chp, int argc, char* argv[]) {
 
     // call nav with flash
     auto open_view = nav->push<ui::FlashUtilityView>();
-    chprintf(chp, "ok\r\n");
+    chprintf(chp, "Flashing started\r\n");
     chThdSleepMilliseconds(150);  // to givew display some time to paint the screen
-    open_view->flash_firmware(path.native());
+    if (!open_view->flash_firmware(path.native())) {
+        chprintf(chp, "error\r\n");
+    }
 }
 
 static void cmd_screenshot(BaseSequentialStream* chp, int argc, char* argv[]) {

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -156,6 +156,7 @@ static void cmd_flash(BaseSequentialStream* chp, int argc, char* argv[]) {
 
     // call nav with flash
     auto open_view = nav->push<ui::FlashUtilityView>();
+    chprintf(chp, "ok\r\n");
     chThdSleepMilliseconds(150);  // to givew display some time to paint the screen
     open_view->flash_firmware(path.native());
 }


### PR DESCRIPTION
Call the flasher app when flashing from serial, so the 2 type of flashing would be handled in one place, to reduce maintainable code, and give the same experience to user.