### PR TITLE
debounced rotary encoder

### DIFF
--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -64,13 +64,13 @@ int_fast8_t Encoder::update(
     int8_t direction = transition_map[state & 0xf];
 
     // store only valid transitions
-    if  (direction) {
+    if (direction) {
         store <<= 4;
         store |= state & 0x0f;
 
         // dial sensitivity setting is stored in pmem
         switch (portapack::persistent_memory::config_encoder_dial_sensitivity()) {
-            case 0: // Normal (Medium) Sensitivity -- default
+            case 0:  // Normal (Medium) Sensitivity -- default
                 switch (store & 0xff) {
                     case 0x2b:
                     case 0xd4:
@@ -85,7 +85,7 @@ int_fast8_t Encoder::update(
                         break;
                 }
                 break;
-            case 1: // Low Sensitivity
+            case 1:  // Low Sensitivity
                 switch (store & 0xff) {
                     case 0x2b:
                         direction = 1;
@@ -98,7 +98,7 @@ int_fast8_t Encoder::update(
                         break;
                 }
                 break;
-            case 2: // High Sensitivity
+            case 2:  // High Sensitivity
                 switch (store & 0xff) {
                     case 0x2b:
                     case 0xd4:

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -62,13 +62,12 @@ int_fast8_t Encoder::update(
 
     // store only valid transitions
     if (direction) {
-        store <<= 4;
-        store |= state & 0x0f;
+        store = ((store << 4) | (state & 0x0F)) & 0xFF;
 
         // dial sensitivity setting is stored in pmem
         switch (portapack::persistent_memory::config_encoder_dial_sensitivity()) {
             case 0:  // Normal (Medium) Sensitivity -- default
-                switch (store & 0xff) {
+                switch (store) {
                     case 0x2b:
                     case 0xd4:
                     case 0x17:
@@ -80,7 +79,7 @@ int_fast8_t Encoder::update(
                 }
                 break;
             case 1:  // Low Sensitivity
-                switch (store & 0xff) {
+                switch (store) {
                     case 0x2b:
                     case 0x17:
                         break;
@@ -90,7 +89,7 @@ int_fast8_t Encoder::update(
                 }
                 break;
             case 2:  // High Sensitivity
-                switch (store & 0xff) {
+                switch (store) {
                     case 0x2b:
                     case 0xd4:
                     case 0xbd:

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -56,10 +56,7 @@ static const int8_t transition_map[] = {
 int_fast8_t Encoder::update(
     const uint_fast8_t phase_0,
     const uint_fast8_t phase_1) {
-    state <<= 1;
-    state |= phase_0 & 0x01;
-    state <<= 1;
-    state |= phase_1 & 0x01;
+    state = (state << 2) | (phase_0 << 1) | phase_1;
 
     int8_t direction = transition_map[state & 0xf];
 

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -71,11 +71,8 @@ int_fast8_t Encoder::update(
                 switch (store & 0xff) {
                     case 0x2b:
                     case 0xd4:
-                        direction = 1;
-                        break;
                     case 0x17:
                     case 0xe8:
-                        direction = -1;
                         break;
                     default:
                         direction = 0;
@@ -85,10 +82,7 @@ int_fast8_t Encoder::update(
             case 1:  // Low Sensitivity
                 switch (store & 0xff) {
                     case 0x2b:
-                        direction = 1;
-                        break;
                     case 0x17:
-                        direction = -1;
                         break;
                     default:
                         direction = 0;
@@ -101,13 +95,10 @@ int_fast8_t Encoder::update(
                     case 0xd4:
                     case 0xbd:
                     case 0x42:
-                        direction = 1;
-                        break;
                     case 0x17:
                     case 0xe8:
                     case 0x7e:
                     case 0x81:
-                        direction = -1;
                         break;
                     default:
                         direction = 0;

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -32,6 +32,7 @@ class Encoder {
 
    private:
     uint_fast8_t state{0};
+    uint_fast16_t store{0};
 };
 
 #endif /*__ENCODER_H__*/

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -32,7 +32,7 @@ class Encoder {
 
    private:
     uint_fast8_t state{0};
-    uint_fast16_t store{0};
+    uint_fast8_t store{0};
 };
 
 #endif /*__ENCODER_H__*/


### PR DESCRIPTION
The rotary encoder of my PortaPack suddenly became extremely noisy. When rotating in one direction the values jumped back and forth. Sometimes they even froze until I changed the direction. An oscilloscope showed very bouncing contacts. However, I found a quite robust algorithm for reading mechanical encoders on [www.best-microcontroller-projects.com](https://www.best-microcontroller-projects.com/rotary-encoder.html). This PR implements that algorithm for PortaPack. Now, my rotary encoder behaves nearly like a new one. The sudden direction changes are completely gone.