### PR TITLE
Fixed ms_duration function to show actual ms

### DIFF
--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -111,7 +111,7 @@ inline uint32_t ms_duration(
     if (sample_rate == 0 || bytes_per_sample == 0)
         return 0;
 
-    return buffer_size / bytes_per_sample / sample_rate * 1000;
+    return buffer_size * 1000 / (bytes_per_sample * sample_rate);
 }
 
 int fast_int_magnitude(int y, int x);


### PR DESCRIPTION
The ms_duration function was always returning an integer number of seconds, discarding the milliseconds.

For example, for 2999 milliseconds it would return 2000.  This resulted in a displayed time value of 2.000s instead of 2.999s.