### PR TITLE
2nd-Level Encoder Debouncing for scrappy encoder dials

### DIFF
--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -54,7 +54,7 @@ static const uint16_t sensitivity_map[] = {
     0x0990,  // DIAL_SENSITIVITY_NORMAL
     0x0110,  // DIAL_SENSITIVITY_LOW
     0x6996,  // DIAL_SENSITIVITY_HIGH
- };
+};
 
 int_fast8_t Encoder::update(const uint_fast8_t phase_bits) {
     state = ((state << 2) | phase_bits) & 0x0F;

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -26,77 +26,51 @@
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
 
-// Now supporting multiple levels of rotary encoder dial sensitivity
-//
-// Portapack H2 normally has a 30-step encoder, meaning one step (pulse) every
-// 12 degrees of rotation.
-//
-// For each encoder "pulse" there are 4 state transitions, and we can choose
-// between looking at all of them (high sensitivity), half of them (medium/default),
-// or one quarter of them (low sensitivity).
-static const int8_t transition_map[][16] = {
-    // Normal (Medium) Sensitivity -- default
-    {
-        0,   // 0000: noop
-        0,   // 0001: ccw start
-        0,   // 0010: cw start
-        0,   // 0011: rate
-        1,   // 0100: cw end
-        0,   // 0101: noop
-        0,   // 0110: rate
-        -1,  // 0111: ccw end
-        -1,  // 1000: ccw end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        1,   // 1011: cw end
-        0,   // 1100: rate
-        0,   // 1101: cw start
-        0,   // 1110: ccw start
-        0,   // 1111: noop
-    },
-    // Low Sensitivity
-    {
-        0,   // 0000: noop
-        0,   // 0001: ccw start
-        0,   // 0010: cw start
-        0,   // 0011: rate
-        1,   // 0100: cw end
-        0,   // 0101: noop
-        0,   // 0110: rate
-        0,   // 0111: ccw end
-        -1,  // 1000: ccw end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        0,   // 1011: cw end
-        0,   // 1100: rate
-        0,   // 1101: cw start
-        0,   // 1110: ccw start
-        0,   // 1111: noop
-    },
-    // High Sensitivity
-    {
-        0,   // 0000: noop
-        -1,  // 0001: ccw start
-        1,   // 0010: cw start
-        0,   // 0011: rate
-        1,   // 0100: cw end
-        0,   // 0101: noop
-        0,   // 0110: rate
-        -1,  // 0111: ccw end
-        -1,  // 1000: ccw end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        1,   // 1011: cw end
-        0,   // 1100: rate
-        1,   // 1101: cw start
-        -1,  // 1110: ccw start
-        0,   // 1111: noop
-    },
+// Transition map for rotary encoder phase bits
+//  00 -> 01 -> 11 -> 10 cw
+//  00 -> 10 -> 11 -> 01 ccw
+// NB: Bits are swapped versus older FW versions
+static const int8_t transition_map[16] = {
+    0,   // 00->00: noop
+    1,   // 00->01: cw start
+    -1,  // 00->10: ccw start
+    0,   // 00->11: rate
+    -1,  // 01->00: ccw end
+    0,   // 01->01: noop
+    0,   // 01->10: rate
+    1,   // 01->11: cw end
+    1,   // 10->00: cw end
+    0,   // 10->01: rate
+    0,   // 10->10: noop
+    -1,  // 10->11: ccw end
+    0,   // 11->00: rate
+    -1,  // 11->01: ccw start
+    1,   // 11->10: cw start
+    0,   // 11->11: noop
 };
 
-int_fast8_t Encoder::update(const uint_fast8_t phase_bits) {
-    state = (state << 2) | phase_bits;
+// Rotary encoder dial sensitivity (transition ignored if bit is 0)
+static const uint16_t sensitivity_map[] = {
+    0x0990,  // DIAL_SENSITIVITY_NORMAL
+    0x0110,  // DIAL_SENSITIVITY_LOW
+    0x6996,  // DIAL_SENSITIVITY_HIGH
+ };
 
-    // dial sensitivity setting is stored in pmem
-    return transition_map[portapack::persistent_memory::config_encoder_dial_sensitivity()][state & 0xf];
+int_fast8_t Encoder::update(const uint_fast8_t phase_bits) {
+    state = ((state << 2) | phase_bits) & 0x0F;
+
+    int_fast8_t direction = transition_map[state];
+
+    // Require 2 clicks in same direction to register movement -- for additional level of contact switch debouncing
+    if (direction == prev_direction) {
+        if ((sensitivity_map[portapack::persistent_memory::config_encoder_dial_sensitivity()] & (1 << state)) == 0)
+            return 0;
+        return direction;
+    }
+
+    // It's normal for transition map to return 0 between every +1/-1, so discarding those
+    if (direction != 0)
+        prev_direction = direction;
+
+    return 0;
 }

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -61,7 +61,7 @@ int_fast8_t Encoder::update(const uint_fast8_t phase_bits) {
 
     int_fast8_t direction = transition_map[state];
 
-    // Require 2 clicks in same direction to register movement -- for additional level of contact switch debouncing
+    // Require 2 state changes in same direction to register movement -- for additional level of contact switch debouncing
     if (direction == prev_direction) {
         if ((sensitivity_map[portapack::persistent_memory::config_encoder_dial_sensitivity()] & (1 << state)) == 0)
             return 0;

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -30,6 +30,7 @@ class Encoder {
 
    private:
     uint_fast8_t state{0};
+    int_fast8_t prev_direction{0};
 };
 
 #endif /*__ENCODER_H__*/

--- a/firmware/application/irq_controls.cpp
+++ b/firmware/application/irq_controls.cpp
@@ -162,8 +162,7 @@ static bool switches_update(const uint8_t raw) {
 }
 
 static bool encoder_update(const uint8_t raw) {
-    // TODO: swap +1/-1 directions in encoder.update() to avoid needless swizzing of phase bits here
-    return encoder_debounce.feed(((raw >> 7) & 0x01) | ((raw >> 5) & 0x02));
+    return encoder_debounce.feed(raw >> 6);
 }
 
 static bool encoder_read() {


### PR DESCRIPTION
Experimental 2nd-level encoder debouncing code based on PR #1834 by @thomasgi1

This version of 2nd-level debouncing seems to work well on my encoders (I didn't notice any delays when changing rotation direction), but TBD whether it helps on encoders with more noisy contacts.

Effectively, in "Normal" sensitivity mode this code is requiring an extra 0.5 clicks of dial rotation when (and only when) changing directions, before reporting that the rotation occurred.  This is meant to prevent random jumping back in the opposite direction when encoder switch contacts are noisy.  This might help even more in "High" sensitivity mode where this jumping back is even more likely to happen.

Please try the test version attached below (compare to previous firmware versions) and let me know:
[portapack-h1_h2-mayhem.bin.zip](https://github.com/portapack-mayhem/mayhem-firmware/files/14127880/portapack-h1_h2-mayhem.bin.zip)

Also posted on Discord #test-drive channel:  https://discord.com/channels/719669764804444213/722101917135798312/1202657336540528721

NOTE:  This code also eliminates the bit swizzling in encoder_update(), which required CW/CCW directions to be swapped in the transition_table.