### PR TITLE
Use std:rand() in Touchscreen Test

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -552,6 +552,7 @@ void DebugPmemView::update() {
 DebugScreenTest::DebugScreenTest(NavigationView& nav)
     : nav_{nav} {
     set_focusable(true);
+    std::srand(LPC_RTC->CTIME0);
 }
 
 bool DebugScreenTest::on_key(const KeyEvent key) {
@@ -561,10 +562,10 @@ bool DebugScreenTest::on_key(const KeyEvent key) {
             nav_.pop();
             break;
         case KeyEvent::Down:
-            painter.fill_rectangle({0, 0, screen_width, screen_height}, semirand());
+            painter.fill_rectangle({0, 0, screen_width, screen_height}, std::rand());
             break;
         case KeyEvent::Left:
-            pen_color = semirand();
+            pen_color = std::rand();
             break;
         default:
             break;
@@ -584,17 +585,10 @@ bool DebugScreenTest::on_touch(const TouchEvent event) {
     return true;
 }
 
-uint16_t DebugScreenTest::semirand() {
-    static uint64_t seed{0x0102030405060708};
-    seed = seed * 137;
-    seed = (seed >> 1) | ((seed & 0x01) << 63);
-    return (uint16_t)seed;
-}
-
 void DebugScreenTest::paint(Painter& painter) {
     painter.fill_rectangle({0, 16, screen_width, screen_height - 16}, Color::white());
     painter.draw_string({10 * 8, screen_height / 2}, Styles::white, "Use Stylus");
-    pen_color = semirand();
+    pen_color = std::rand();
 }
 
 /* DebugLCRView *******************************************************/

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -385,7 +385,6 @@ class DebugScreenTest : public View {
     bool on_key(KeyEvent key) override;
     bool on_encoder(EncoderEvent delta) override;
     bool on_touch(TouchEvent event) override;
-    uint16_t semirand();
     void paint(Painter& painter) override;
 
    private:


### PR DESCRIPTION
When randomizing colors in the Debug Touch Test application, use the standard C library random number generator (seeding from the RTC) versus the "semirand" function that always returned the same color sequence.

Seems like every app has a different way of generating random numbers, but at least now _this_ app is using standard library functions.