### PR TITLE
Adding_TX_IQ_phase_Calibration_to_Mic_App

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -31,6 +31,7 @@
 #include "tonesets.hpp"
 #include "ui_tone_key.hpp"
 #include "wm8731.hpp"
+#include "radio.hpp"
 
 #include <cstring>
 
@@ -336,6 +337,7 @@ MicTXView::MicTXView(
                   &field_rxlna,
                   &field_rxvga,
                   &field_rxamp,
+                  hackrf_r9 ? &field_tx_iq_phase_cal_2839 : &field_tx_iq_phase_cal_2837,
                   &tx_button,
                   &tx_icon});
 
@@ -367,6 +369,20 @@ MicTXView::MicTXView(
     field_rxamp.on_change = [this](int32_t v) {
         receiver_model.set_rf_amp(v);
     };
+
+    if (hackrf_r9) {  // MAX2839 has 6 bits IQ CAL phasse adjustment.
+        field_tx_iq_phase_cal_2839.set_value(iq_phase_calibration_value);
+        field_tx_iq_phase_cal_2839.on_change = [this](int32_t v) {
+            iq_phase_calibration_value = v;
+            radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
+        };
+    } else {  // MAX2837 has 5 bits IQ CAL phase adjustment.
+        field_tx_iq_phase_cal_2837.set_value(iq_phase_calibration_value);
+        field_tx_iq_phase_cal_2837.on_change = [this](int32_t v) {
+            iq_phase_calibration_value = v;
+            radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
+        };
+    }
 
     options_gain.on_change = [this](size_t, int32_t v) {
         mic_gain_x10 = v;

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -370,6 +370,7 @@ MicTXView::MicTXView(
         receiver_model.set_rf_amp(v);
     };
 
+    radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
     if (hackrf_r9) {  // MAX2839 has 6 bits IQ CAL phasse adjustment.
         field_tx_iq_phase_cal_2839.set_value(iq_phase_calibration_value);
         field_tx_iq_phase_cal_2839.on_change = [this](int32_t v) {

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -113,7 +113,7 @@ class MicTXView : public View {
     uint32_t va_level{40};
     uint32_t attack_ms{500};
     uint32_t decay_ms{1000};
-    size_t iq_phase_calibration_value{15};
+    uint8_t iq_phase_calibration_value{15};
     app_settings::SettingsManager settings_{
         "tx_mic",
         app_settings::Mode::RX_TX,
@@ -133,6 +133,7 @@ class MicTXView : public View {
             {"vox"sv, &va_enabled},
             {"rogerbeep"sv, &rogerbeep_enabled},
             {"tone_key_index"sv, &tone_key_index},
+            {"iq_phase_calibration"sv, &iq_phase_calibration_value},
         }};
 
     rf::Frequency tx_frequency{0};

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -113,6 +113,7 @@ class MicTXView : public View {
     uint32_t va_level{40};
     uint32_t attack_ms{500};
     uint32_t decay_ms{1000};
+    size_t iq_phase_calibration_value{15};
     app_settings::SettingsManager settings_{
         "tx_mic",
         app_settings::Mode::RX_TX,
@@ -160,7 +161,8 @@ class MicTXView : public View {
         {{5 * 8, (25 * 8) + 2}, "F_RX:", Color::light_grey()},
         {{5 * 8, (27 * 8) + 2}, "LNA:", Color::light_grey()},
         {{12 * 8, (27 * 8) + 2}, "VGA:", Color::light_grey()},
-        {{19 * 8, (27 * 8) + 2}, "AMP:", Color::light_grey()}};
+        {{19 * 8, (27 * 8) + 2}, "AMP:", Color::light_grey()},
+        {{21 * 8, (31 * 8)}, "TX-IQ-CAL:", Color::light_grey()}};
     Labels labels_WM8731{
         {{17 * 8, 1 * 8}, "Boost", Color::light_grey()}};
     Labels labels_AK4951{
@@ -334,6 +336,22 @@ class MicTXView : public View {
         {24 * 8, (27 * 8) + 2},
         1,
         {0, 1},
+        1,
+        ' ',
+    };
+
+    NumberField field_tx_iq_phase_cal_2837{
+        {24 * 8, (33 * 8)},
+        2,
+        {0, 31},  // 5 bits IQ CAL phase adjustment.
+        1,
+        ' ',
+    };
+
+    NumberField field_tx_iq_phase_cal_2839{
+        {24 * 8, (33 * 8)},
+        2,
+        {0, 63},  // 6 bits IQ CAL phasse adjustment.
         1,
         ' ',
     };

--- a/firmware/application/hw/max2837.hpp
+++ b/firmware/application/hw/max2837.hpp
@@ -829,6 +829,7 @@ class MAX2837 : public MAX283x {
     bool set_frequency(const rf::Frequency lo_frequency) override;
 
     void set_rx_lo_iq_calibration(const size_t v) override;
+    void set_tx_LO_iq_phase_calibration(const size_t v) override;
     void set_rx_bias_trim(const size_t v);
     void set_vco_bias(const size_t v);
     void set_rx_buff_vcm(const size_t v) override;

--- a/firmware/application/hw/max2839.hpp
+++ b/firmware/application/hw/max2839.hpp
@@ -690,6 +690,7 @@ class MAX2839 : public MAX283x {
     void set_lpf_rf_bandwidth_tx(const uint32_t bandwidth_minimum) override;
     bool set_frequency(const rf::Frequency lo_frequency) override;
     void set_rx_lo_iq_calibration(const size_t v) override;
+    void set_tx_LO_iq_phase_calibration(const size_t v) override;
     void set_rx_buff_vcm(const size_t v) override;
 
     int8_t temp_sense() override;

--- a/firmware/application/hw/max283x.hpp
+++ b/firmware/application/hw/max283x.hpp
@@ -98,11 +98,13 @@ constexpr auto bandwidth_maximum = bandwidths[bandwidths.size() - 1];
 
 /*************************************************************************/
 
-enum Mode {
+enum Mode {  // MAX283x Operating modes.
     Shutdown,
     Standby,
     Receive,
     Transmit,
+    Rx_Calibration,  // just add the sequential enum of those two CAL operating modes .
+    Tx_Calibration,
 };
 
 using reg_t = uint16_t;
@@ -124,6 +126,8 @@ class MAX283x {
     virtual bool set_frequency(const rf::Frequency lo_frequency);
 
     virtual void set_rx_lo_iq_calibration(const size_t v);
+    virtual void set_tx_LO_iq_phase_calibration(const size_t v);
+
     virtual void set_rx_buff_vcm(const size_t v);
 
     virtual int8_t temp_sense();

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -248,6 +248,10 @@ void set_antenna_bias(const bool on) {
     }
 }
 
+void set_tx_max283x_iq_phase_calibration(const size_t v) {
+    second_if->set_tx_LO_iq_phase_calibration(v);
+}
+
 /*void enable(Configuration configuration) {
     configure(configuration);
 }

--- a/firmware/application/radio.hpp
+++ b/firmware/application/radio.hpp
@@ -54,6 +54,7 @@ void set_baseband_filter_bandwidth_rx(const uint32_t bandwidth_minimum);
 void set_baseband_filter_bandwidth_tx(const uint32_t bandwidth_minimum);
 void set_baseband_rate(const uint32_t rate);
 void set_antenna_bias(const bool on);
+void set_tx_max283x_iq_phase_calibration(const size_t v);
 
 /* Use ReceiverModel or TransmitterModel instead. */
 // void enable(Configuration configuration);


### PR DESCRIPTION
Hi , this PR is adding  a possible TX IQ phase calibration adjustment from (+4º to -4º) .
We added that GUI in the Mic App , bottom right part 
![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/86470699/d72e747f-deb3-4776-97a9-30cf8d03e5ee)

This feature will have no impact to TX  AM , FM , ...but it helps to attenuated several dB's more the suppressed carrier in the SSB (USB , LSB ) transmissions. 
As example , pls find attachment of several measurements under H2R4 ,max2837 .about that SSB "suppressed carrier"
![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/86470699/642e06da-60a7-4d3b-8bfe-0bc6d455cb72)


At the moment we do not have any automatic calibration process. 
You will need some other SDR receiver , and check the suppressed carrier level when you push PTT _TX in SSB (USB or LSB) without any modulation, and then go to the right modify the "TX-IQ-CAL" value , and press again PTT_TX till getting the lower attenuated "suppressed carrier". 

Note 1: In max2837 , I could see big improvement from current Mayhem fw settings (around -8 dB's in my set )  ,  regarding reference AM level (0 dB's) . Then  we can get  from -27 to  -34 dB's attenuation from reference AM (just playing with CAL value). 

But so far , porting the same code to max2839 that has different TQFN package and diff. reg. settings, , at the moment , in my r9 ,  I can not see any improvement effect modifying that CAL value  , (always getting -35 dB's attenuation from ref. AM 0dB's level) . 
Pending to recheck that code part, (maybe there is some error there ...) , but so far , no critical , because in my r9 ,  the attenuation level is already  better than max2837 .  (If someone can see any difference in max2839 , pls. share it with us ) .

Note 2 : if you do not modify  that adjustment field , we are not rewriting that CAL part, then   you are using the original default  fw settings (as now ) . (So if you do not go that edit that CAL field , you should not see any improv. or change difference ) .