### PR TITLE
Adsb rx airline display fix

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -64,9 +64,9 @@ static std::string mmsi(
 
 static std::string mid(
     const ais::MMSI& mmsi) {
-    std::database db;
+    database db;
     std::string mid_code = "";
-    std::database::MidDBRecord mid_record = {};
+    database::MidDBRecord mid_record = {};
     int return_code = 0;
 
     // Try getting the country name from mids.db using MID code for given MMSI

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -246,6 +246,10 @@ ADSBRxDetailsView::ADSBRxDetailsView(
             text_airline.set(airline_record.airline);
             text_country.set(airline_record.country);
             break;
+        case DATABASE_RECORD_NOT_FOUND:
+            //text_airline.set("-"); // It's what it is constructed with
+            //text_country.set("-"); // It's what it is constructed with
+            break;
         case DATABASE_NOT_FOUND:
             text_airline.set("No airlines.db file");
             break;

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -233,30 +233,6 @@ ADSBRxDetailsView::ADSBRxDetailsView(
          &button_aircraft_details,
          &button_see_map});
 
-    // The following won't change for a given airborne aircraft.
-    // Try getting the airline's name from airlines.db.
-    // NB: Only works once callsign has been read and won't be updated.
-    if (!entry_.callsign.empty()) {
-        database db;
-        database::AirlinesDBRecord airline_record;
-        std::string airline_code = entry_.callsign.substr(0, 3);
-        auto return_code = db.retrieve_airline_record(&airline_record, airline_code);
-
-        switch (return_code) {
-            case DATABASE_RECORD_FOUND:
-                text_airline.set(airline_record.airline);
-                text_country.set(airline_record.country);
-                break;
-            case DATABASE_RECORD_NOT_FOUND:
-                // text_airline.set("-"); // It's what it is constructed with
-                // text_country.set("-"); // It's what it is constructed with
-                break;
-            case DATABASE_NOT_FOUND:
-                text_airline.set("No airlines.db file");
-                break;
-        }
-    }
-
     text_icao_address.set(entry_.icao_str);
 
     button_aircraft_details.on_select = [this, &nav](Button&) {
@@ -336,6 +312,31 @@ void ADSBRxDetailsView::on_orientation(const OrientationDataMessage* msg) {
 }
 
 void ADSBRxDetailsView::refresh_ui() {
+    // The following won't change for a given airborne aircraft.
+    // Try getting the airline's name from airlines.db.
+    if (!airline_checked && !entry_.callsign.empty()) {
+        airline_checked = true;
+
+        database db;
+        database::AirlinesDBRecord airline_record;
+        std::string airline_code = entry_.callsign.substr(0, 3);
+        auto return_code = db.retrieve_airline_record(&airline_record, airline_code);
+
+        switch (return_code) {
+            case DATABASE_RECORD_FOUND:
+                text_airline.set(airline_record.airline);
+                text_country.set(airline_record.country);
+                break;
+            case DATABASE_RECORD_NOT_FOUND:
+                // text_airline.set("-"); // It's what it is constructed with
+                // text_country.set("-"); // It's what it is constructed with
+                break;
+            case DATABASE_NOT_FOUND:
+                text_airline.set("No airlines.db file");
+                break;
+        }
+    }
+
     auto age = entry_.age;
     if (age < 60)
         text_last_seen.set(to_string_dec_uint(age) + " seconds ago");

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -127,8 +127,8 @@ ADSBRxAircraftDetailsView::ADSBRxAircraftDetailsView(
     text_icao_address.set(entry.icao_str);
 
     // Try getting the aircraft information from icao24.db
-    std::database db{};
-    std::database::AircraftDBRecord aircraft_record;
+    database db{};
+    database::AircraftDBRecord aircraft_record;
     auto return_code = db.retrieve_aircraft_record(&aircraft_record, entry.icao_str);
     switch (return_code) {
         case DATABASE_RECORD_FOUND:
@@ -236,8 +236,8 @@ ADSBRxDetailsView::ADSBRxDetailsView(
     // The following won't change for a given airborne aircraft.
     // Try getting the airline's name from airlines.db.
     // NB: Only works once callsign has been read and won't be updated.
-    std::database db;
-    std::database::AirlinesDBRecord airline_record;
+    database db;
+    database::AirlinesDBRecord airline_record;
     std::string airline_code = entry_.callsign.substr(0, 3);
     auto return_code = db.retrieve_airline_record(&airline_record, airline_code);
 

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -236,8 +236,7 @@ ADSBRxDetailsView::ADSBRxDetailsView(
     // The following won't change for a given airborne aircraft.
     // Try getting the airline's name from airlines.db.
     // NB: Only works once callsign has been read and won't be updated.
-    if (! entry_.callsign.empty())
-    {
+    if (!entry_.callsign.empty()) {
         database db;
         database::AirlinesDBRecord airline_record;
         std::string airline_code = entry_.callsign.substr(0, 3);
@@ -249,8 +248,8 @@ ADSBRxDetailsView::ADSBRxDetailsView(
                 text_country.set(airline_record.country);
                 break;
             case DATABASE_RECORD_NOT_FOUND:
-                //text_airline.set("-"); // It's what it is constructed with
-                //text_country.set("-"); // It's what it is constructed with
+                // text_airline.set("-"); // It's what it is constructed with
+                // text_country.set("-"); // It's what it is constructed with
                 break;
             case DATABASE_NOT_FOUND:
                 text_airline.set("No airlines.db file");

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -236,23 +236,26 @@ ADSBRxDetailsView::ADSBRxDetailsView(
     // The following won't change for a given airborne aircraft.
     // Try getting the airline's name from airlines.db.
     // NB: Only works once callsign has been read and won't be updated.
-    database db;
-    database::AirlinesDBRecord airline_record;
-    std::string airline_code = entry_.callsign.substr(0, 3);
-    auto return_code = db.retrieve_airline_record(&airline_record, airline_code);
+    if (! entry_.callsign.empty())
+    {
+        database db;
+        database::AirlinesDBRecord airline_record;
+        std::string airline_code = entry_.callsign.substr(0, 3);
+        auto return_code = db.retrieve_airline_record(&airline_record, airline_code);
 
-    switch (return_code) {
-        case DATABASE_RECORD_FOUND:
-            text_airline.set(airline_record.airline);
-            text_country.set(airline_record.country);
-            break;
-        case DATABASE_RECORD_NOT_FOUND:
-            //text_airline.set("-"); // It's what it is constructed with
-            //text_country.set("-"); // It's what it is constructed with
-            break;
-        case DATABASE_NOT_FOUND:
-            text_airline.set("No airlines.db file");
-            break;
+        switch (return_code) {
+            case DATABASE_RECORD_FOUND:
+                text_airline.set(airline_record.airline);
+                text_country.set(airline_record.country);
+                break;
+            case DATABASE_RECORD_NOT_FOUND:
+                //text_airline.set("-"); // It's what it is constructed with
+                //text_country.set("-"); // It's what it is constructed with
+                break;
+            case DATABASE_NOT_FOUND:
+                text_airline.set("No airlines.db file");
+                break;
+        }
     }
 
     text_icao_address.set(entry_.icao_str);

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -280,6 +280,7 @@ class ADSBRxDetailsView : public View {
     // NB: Keeping a copy so that it doesn't end up dangling
     // if removed from the recent entries list.
     AircraftRecentEntry entry_{AircraftRecentEntry::invalid_key};
+    bool airline_checked{false};
 
     Labels labels{
         {{0 * 8, 1 * 16}, "ICAO:", Color::light_grey()},

--- a/firmware/application/database.cpp
+++ b/firmware/application/database.cpp
@@ -25,14 +25,12 @@
 #include "file.hpp"
 #include <cstring>
 
-namespace std {
-
 int database::retrieve_mid_record(MidDBRecord* record, std::string search_term) {
     file_path = "AIS/mids.db";
     index_item_length = 4;
     record_length = 32;
 
-    result = std::database::retrieve_record(file_path, index_item_length, record_length, record, search_term);
+    result = retrieve_record(file_path, index_item_length, record_length, record, search_term);
 
     return (result);
 }
@@ -42,7 +40,7 @@ int database::retrieve_airline_record(AirlinesDBRecord* record, std::string sear
     index_item_length = 4;
     record_length = 64;
 
-    result = std::database::retrieve_record(file_path, index_item_length, record_length, record, search_term);
+    result = retrieve_record(file_path, index_item_length, record_length, record, search_term);
 
     return (result);
 }
@@ -52,7 +50,7 @@ int database::retrieve_aircraft_record(AircraftDBRecord* record, std::string sea
     index_item_length = 7;
     record_length = 146;
 
-    result = std::database::retrieve_record(file_path, index_item_length, record_length, record, search_term);
+    result = retrieve_record(file_path, index_item_length, record_length, record, search_term);
 
     return (result);
 }
@@ -91,5 +89,3 @@ int database::retrieve_record(std::string file_path, int index_item_length, int 
     } else
         return (DATABASE_NOT_FOUND);
 }
-
-} /* namespace std */

--- a/firmware/application/database.hpp
+++ b/firmware/application/database.hpp
@@ -61,9 +61,9 @@ class database {
     int retrieve_aircraft_record(AircraftDBRecord* record, std::string search_term);
 
    private:
-    std::string file_path = "";      // path inclusing filename
-    int index_item_length = 0;  // length of index item
-    int record_length = 0;      // length of record
+    std::string file_path = "";  // path inclusing filename
+    int index_item_length = 0;   // length of index item
+    int record_length = 0;       // length of record
 
     File db_file{};
     int number_of_records = 0;

--- a/firmware/application/database.hpp
+++ b/firmware/application/database.hpp
@@ -30,7 +30,6 @@
 
 #include "file.hpp"
 
-namespace std {
 class database {
    public:
 #define DATABASE_RECORD_FOUND 0       // record found in database
@@ -62,7 +61,7 @@ class database {
     int retrieve_aircraft_record(AircraftDBRecord* record, std::string search_term);
 
    private:
-    string file_path = "";      // path inclusing filename
+    std::string file_path = "";      // path inclusing filename
     int index_item_length = 0;  // length of index item
     int record_length = 0;      // length of record
 
@@ -77,6 +76,5 @@ class database {
 
     int retrieve_record(std::string file_path, int index_item_length, int record_length, void* record, std::string search_term);
 };
-}  // namespace std
 
 #endif /*__DATABASE_H__*/


### PR DESCRIPTION
Do not display the first airline in the db before the callsign is received.
Update airline infor when the callsign becomes available.