### PR TITLE
WAV Viewer & Soundboard enhancements (8 or 16-bit WAV files)

### DIFF
--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -89,6 +89,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
 
     uint32_t tone_key_index = options_tone_key.selected_index();
     uint32_t sample_rate;
+    uint8_t bits_per_sample;
 
     stop();
 
@@ -104,6 +105,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
     // button_play.set_bitmap(&bitmap_stop);
 
     sample_rate = reader->sample_rate();
+    bits_per_sample = reader->bits_per_sample();
 
     replay_thread = std::make_unique<ReplayThread>(
         std::move(reader),
@@ -120,7 +122,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
         transmitter_model.channel_bandwidth(),
         0,  // Gain is unused
         8,  // shift_bits_s16, default 8 bits, but also unused
-        8,  // bits per sample
+        bits_per_sample,
         TONES_F2D(tone_key_frequency(tone_key_index), TONES_SAMPLERATE),
         false,  // AM
         false,  // DSB
@@ -172,7 +174,7 @@ void SoundBoardView::refresh_list() {
 
                 if (entry_extension == ".WAV") {
                     if (reader->open(u"/WAV/" + entry.path().native())) {
-                        if ((reader->channels() == 1) && (reader->bits_per_sample() == 8)) {
+                        if ((reader->channels() == 1) && ((reader->bits_per_sample() == 8) || (reader->bits_per_sample() == 16))) {
                             // sounds[c].ms_duration = reader->ms_duration();
                             // sounds[c].path = u"WAV/" + entry.path().native();
                             if (count >= (page - 1) * 100 && count < page * 100) {

--- a/firmware/application/apps/ui_view_wav.hpp
+++ b/firmware/application/apps/ui_view_wav.hpp
@@ -93,7 +93,7 @@ class ViewWavView : public View {
         {5 * 8, 0 * 16, 18 * 8, 16},
         ""};
     Text text_samplerate{
-        {12 * 8, 1 * 16, 12 * 8, 16},
+        {12 * 8, 1 * 16, 10 * 8, 16},
         ""};
     Text text_title{
         {6 * 8, 2 * 16, 17 * 8, 16},

--- a/firmware/application/io_wave.cpp
+++ b/firmware/application/io_wave.cpp
@@ -27,7 +27,7 @@ bool WAVFileReader::open(const std::filesystem::path& path) {
     size_t i = 0;
     char ch;
     const uint8_t tag_INAM[4] = {'I', 'N', 'A', 'M'};
-    char title_buffer[32];
+    char title_buffer[32]{0};
     uint32_t riff_size, data_end, title_size;
     size_t search_limit = 0;
 
@@ -37,11 +37,17 @@ bool WAVFileReader::open(const std::filesystem::path& path) {
         return true;
     }
 
+    // Reinitialize to avoid old data when switching files
+    title_string = "";
+    sample_rate_ = 0;
+    bytes_per_sample = 0;
+
     auto error = file_.open(path);
 
     if (!error.is_valid()) {
         file_.read((void*)&header, sizeof(header));  // Read header (RIFF and WAVE)
 
+        // TODO: Work needed here to process RIFF file format correctly, i.e. properly skip over LIST & INFO chunks
         riff_size = header.cksize + 8;
         data_start = header.fmt.cksize + 28;
         data_size_ = header.data.cksize;

--- a/firmware/baseband/proc_audiotx.hpp
+++ b/firmware/baseband/proc_audiotx.hpp
@@ -51,11 +51,10 @@ class AudioTXProcessor : public BasebandProcessor {
     uint32_t audio_sample{};
     int32_t sample{0}, delta{};
     int8_t re{0}, im{0};
-    int8_t bytes_per_sample{1};
-    int16_t audio_sample_s16{};
+    uint8_t bytes_per_sample{1};
+    uint32_t sampling_rate{48000};
 
     int16_t audio_data[AUDIO_OUTPUT_BUFFER_SIZE];
-    buffer_s16_t audio_buffer{audio_data, AUDIO_OUTPUT_BUFFER_SIZE, 48000};
     AudioOutput audio_output{};
 
     size_t progress_interval_samples = 0, progress_samples = 0;


### PR DESCRIPTION
Enhancements to WAV Viewer & Soundboard apps

WAV viewer enhancements:
*  Added support for displaying & playing 8-bit WAV audio files (see caveat below).  (Previously only supported 16-bit)
*  Added support for viewing larger WAV files (increased time & sample field sizes, and allowable "scale" value).
*  Position in WAV files can now be navigated with milliseconds resolution (versus only seconds + sample #), and updating either the time or sample number field will automatically update the other field.
*  Limit range of time & sample position fields to the file size (was previously allowing view past end of file).
*  Wrapping is now enabled on time & sample number fields, allowing quick access to the end of the file.
*  Increased character width of file name.
*  When another file is loaded that doesn't have a Title chunk, the title from the _previous_ file is no longer displayed (bug fix).
*  Added "bits per sample" to display.

Soundboard enhancements:
* Added support for transmitting & playing 16-bit WAV audio files.  (Previously only supported 8-bit)

**Caveat**:
The existing WAV reader code does not handle RIFF WAV files containing an INFO chunk (this include sample files in the WAV folder).  Result is it'll think those files only contain 25 samples, i.e. the size of the INFO chunk.  I will fix this too, but figured it could be in a follow-on PR.

Test firmware is available on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1204298077251567626