### PR TITLE
When setting Time & Date indicate if in DST range

### DIFF
--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -126,6 +126,9 @@ class SetDateTimeView : public View {
     Text text_day_of_year{
         {26 * 8, 6 * 16, 3 * 8, 16},
         ""};
+    Text text_in_dst_range{
+        {17 * 8, 7 * 16, 3 * 8, 16},
+        ""};
 
     Checkbox checkbox_dst_enable{
         {2 * 8, 9 * 16},
@@ -171,6 +174,8 @@ class SetDateTimeView : public View {
 
     void form_init(const SetDateTimeModel& model);
     SetDateTimeModel form_collect();
+    portapack::persistent_memory::dst_config_t dst_collect();
+    void handle_date_field_update();
 };
 
 struct SetFrequencyCorrectionModel {

--- a/firmware/application/rtc_time.hpp
+++ b/firmware/application/rtc_time.hpp
@@ -25,7 +25,7 @@
 #include "signal.hpp"
 
 #include "lpc43xx_cpp.hpp"
-using namespace lpc43xx;
+#include "portapack_persistent_memory.hpp"
 
 namespace rtc_time {
 
@@ -45,8 +45,9 @@ rtc::RTC now(rtc::RTC& out_datetime);
 /* Daylight Savings Time functions */
 void dst_init();
 rtc::RTC dst_adjust_returned_time(rtc::RTC& datetime);
-void dst_check_date_range(uint16_t doy);
+bool dst_check_date_range(uint16_t doy, uint16_t start_doy, uint16_t end_doy);
 void dst_update_date_range(uint16_t year, uint16_t doy);
+bool dst_test_date_range(uint16_t year, uint16_t doy, portapack::persistent_memory::dst_config_t dst);
 uint8_t days_per_month(uint16_t year, uint8_t month);
 uint8_t current_day_of_week();
 uint8_t day_of_week(uint16_t year, uint8_t month, uint8_t day);


### PR DESCRIPTION
This PR displays the 3-character string "DST" under the time on the Settings->Date&Time screen when the DST checkbox is enabled _and_ the date is within the shown DST date range, thereby indicating to the user more clearly that the time they are entering is _after_ DST correction.

I'm not sure if this change is worth 350 more bytes of ROM space, but some clarification was recommended and perhaps it will save the user the trouble of reading the WIKI page.

Please note that this code is just adding the 3-letter "DST" clarification to the screen.  It is _not_ incrementing/decrementing the time & date displayed on the Settings screen dynamically when DST is checked/unchecked or the DST date range is altered [as was also suggested].  Frankly I would find that very annoying if I had just entered the time I wanted to set based on other clocks around me, and then I enter the DST date range only to have the firmware then change the time field (and possibly the date too if it wraps to next day) to some _other_ value from what I just entered.

Test version attached if needed:
[portapack-mayhem_dev.bin.zip](https://github.com/portapack-mayhem/mayhem-firmware/files/14183743/portapack-mayhem_dev.bin.zip)
