### PR TITLE
Screen backlight brightness

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -329,7 +329,8 @@ void EventDispatcher::handle_lcd_frame_sync() {
     static_cast<ui::SystemView*>(top_widget)->paint_overlay();
     painter.paint_widget_tree(top_widget);
 
-    portapack::backlight()->on();
+    // portapack::backlight()->on();
+    portapack::backlight()->set_level(28);
 
     if (waiting_for_frame)
         this->waiting_for_frame = false;

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -280,10 +280,14 @@ static const portapack::cpld::Config& portapack_cpld_config() {
                : portapack::cpld::rev_20150901::config;
 }
 
+// Backlight* backlight() {
+//     return (portapack_model() == PortaPackModel::R2_20170522)
+//                ? static_cast<portapack::Backlight*>(&backlight_cat4004)  // R2_20170522
+//                : static_cast<portapack::Backlight*>(&backlight_on_off);  // R1_20150901
+// }
+
 Backlight* backlight() {
-    return (portapack_model() == PortaPackModel::R2_20170522)
-               ? static_cast<portapack::Backlight*>(&backlight_cat4004)  // R2_20170522
-               : static_cast<portapack::Backlight*>(&backlight_on_off);  // R1_20150901
+    return static_cast<portapack::Backlight*>(&backlight_cat4004);  // R1_20150901
 }
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/firmware/common/backlight.cpp
+++ b/firmware/common/backlight.cpp
@@ -29,6 +29,7 @@ void BacklightOnOff::on() {
     if (!is_on()) {
         io.lcd_backlight(true);
         on_ = true;
+        
     }
 }
 
@@ -40,6 +41,7 @@ void BacklightOnOff::off() {
 }
 
 void BacklightCAT4004::set_level(const value_t value) {
+    on_ = true;
     auto target = value;
 
     // Clip target value to valid range.


### PR DESCRIPTION
There is a transistor connected to the cathode for the screen controlled by the CPLD. 
I see we have some code in backlight.cpp to control it, but I cant for the life of me get it to change, if I set it to 1 or 31(max brightness), its the same brightness