### PR TITLE
Functionally revert Encoder debounce PR (from 1837)

### DIFF
--- a/firmware/application/hw/debounce.cpp
+++ b/firmware/application/hw/debounce.cpp
@@ -158,8 +158,13 @@ uint8_t EncoderDebounce::state() {
 bool EncoderDebounce::feed(const uint8_t phase_bits) {
     history_ = (history_ << 2) | phase_bits;
 
-    // Has input been constant for 4 ticks? (phase_bits * 01010101b should be 0x00, 0x55, 0xAA, or 0xFF)
-    if (history_ == (phase_bits * 0x55)) {
+    // If both inputs have been stable for the last 4 ticks, history_ should equal 0x00, 0x55, 0xAA, or 0xFF.
+    uint8_t expected_stable_history = phase_bits * 0b01010101;
+
+    // But, checking for equal seems to cause issues with at least 1 user's encoder, so we're treating the input
+    // as "stable" if at least ONE input bit is consistent for 4 ticks...
+    uint8_t diff = (history_ ^ expected_stable_history);
+    if ((diff == 0) || ((diff & 0b01010101) == 0) || ((diff & 0b10101010) == 0)) {
         // Has the debounced input value changed?
         if (state_ != phase_bits) {
             state_ = phase_bits;


### PR DESCRIPTION
This PR effectively reverts the encoder dial debounce functionality in PR #1837, while leaving the rest of the optimized single-object encoder handling code (from PR #1837), and the 2nd-level encoder debouncing code (from PR #1838) in place.

I've tested it on both of my working units, but the attached test firmware needs to be tested by @jLynx and @thomasgi1 who seem to have encoders that behave a bit differently (I can still add encoder configuration settings if necessary)

Test firmware attached:
[portapack-h1_h2-mayhem.bin.zip](https://github.com/portapack-mayhem/mayhem-firmware/files/14196135/portapack-h1_h2-mayhem.bin.zip)

Test version is also available on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1204822397165903953
