### PR TITLE
Brightness settings fixes

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -763,12 +763,10 @@ SetFakeBrightnessView::SetFakeBrightnessView(NavigationView& nav) {
     field_fake_brightness.set_by_value(pmem::fake_brightness_level());
     checkbox_brightness_switch.set_value(pmem::apply_fake_brightness());
 
-    checkbox_brightness_switch.on_select = [this](Checkbox&, bool v) {
-        pmem::set_apply_fake_brightness(v);
-    };
-
     button_save.on_select = [&nav, this](Button&) {
+        pmem::set_apply_fake_brightness(checkbox_brightness_switch.value());
         pmem::set_fake_brightness_level(field_fake_brightness.selected_index_value());
+        send_system_refresh();
         nav.pop();
     };
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -331,7 +331,7 @@ SystemStatusView::SystemStatusView(
         set_dirty();
         pmem::set_apply_fake_brightness(v);
         refresh();
-        parent()->set_dirty(); // The parent of NavigationView shal be the SystemView
+        parent()->set_dirty();  // The parent of NavigationView shal be the SystemView
     };
 
     button_bias_tee.on_select = [this](ImageButton&) {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -330,21 +330,8 @@ SystemStatusView::SystemStatusView(
     toggle_fake_brightness.on_change = [this, &nav](bool v) {
         set_dirty();
         pmem::set_apply_fake_brightness(v);
-        if (nav.is_valid() && v) {
-            nav.display_modal(
-                "Brightness",
-                "You have enabled brightness\n"
-                "adjustment. Performance\n"
-                "will be impacted slightly.");
-
-            // TODO: refresh interface to prevent reboot requirement
-            // TODO: increase performance
-        } else if (!v) {
-            nav.display_modal(
-                "Brightness",
-                "Brightness adjust disabled.");
-        }
         refresh();
+        parent()->set_dirty(); // The parent of NavigationView shal be the SystemView
     };
 
     button_bias_tee.on_select = [this](ImageButton&) {
@@ -412,6 +399,9 @@ void SystemStatusView::refresh() {
     // Converter
     button_converter.set_bitmap(pmem::config_updown_converter() ? &bitmap_icon_downconvert : &bitmap_icon_upconvert);
     button_converter.set_foreground(pmem::config_converter() ? Color::red() : Color::light_grey());
+
+    // Brightness
+    toggle_fake_brightness.set_value(pmem::apply_fake_brightness());
 
     set_dirty();
 }


### PR DESCRIPTION
- Statusbar toggle now updated when changing in settings page
- Annoying message boxes removed
- SystemView (aka whole screen) is now refreshed after toggling from status

One remaining edge-case remains, when you toggle the on the status bar while on the brightness settings page, the checkbox wont update.. But in this case, just use the damn checkbox :D (Also the same issue is true for the freq converter icon, so we remain consistent 🙈)