### PR TITLE
Renamed Replay app settings file, and get default freq from .ini file

### DIFF
--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -389,7 +389,7 @@ PlaylistView::PlaylistView(
     ensure_directory(u"PLAYLIST");
     waterfall.show_audio_spectrum_view(false);
 
-    field_frequency.set_value(100'000'000);
+    field_frequency.set_value(transmitter_model.target_frequency());
     field_frequency.on_change = [this](rf::Frequency f) {
         if (current())
             current()->metadata.center_frequency = f;

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -56,7 +56,7 @@ class PlaylistView : public View {
     NavigationView& nav_;
     TxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
-        "tx_playlist", app_settings::Mode::TX};
+        "tx_replay", app_settings::Mode::TX};
 
     // More header == less spectrum view.
     static constexpr ui::Dim header_height = 6 * 16;


### PR DESCRIPTION
To resolve #1844 

- For the App that we're now calling Replay, renamed the "playlist.ini" file to "replay.ini" so that users can find it.  (The old replay code was deprecated so there shouldn't be any name conflict.
- When the app starts, initialize the transmit frequency to the last transmit frequency used by the app (versus to 100MHz).  (If there is no .ini file, then the global frequency from pmem will be used as the default.)

Note that normally every capture will will have an associated text file containing the transmit frequency anyway and the old default 100MHz on the screen quickly disappeared anyway when one of those files is loaded.  But in case there are none of those text files, I can see that it may be useful for the app to remember the last frequency transmitted.