### PR TITLE
Revert "Brightness settings fixes"

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -763,10 +763,12 @@ SetFakeBrightnessView::SetFakeBrightnessView(NavigationView& nav) {
     field_fake_brightness.set_by_value(pmem::fake_brightness_level());
     checkbox_brightness_switch.set_value(pmem::apply_fake_brightness());
 
+    checkbox_brightness_switch.on_select = [this](Checkbox&, bool v) {
+        pmem::set_apply_fake_brightness(v);
+    };
+
     button_save.on_select = [&nav, this](Button&) {
-        pmem::set_apply_fake_brightness(checkbox_brightness_switch.value());
         pmem::set_fake_brightness_level(field_fake_brightness.selected_index_value());
-        send_system_refresh();
         nav.pop();
     };
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -330,8 +330,21 @@ SystemStatusView::SystemStatusView(
     toggle_fake_brightness.on_change = [this, &nav](bool v) {
         set_dirty();
         pmem::set_apply_fake_brightness(v);
+        if (nav.is_valid() && v) {
+            nav.display_modal(
+                "Brightness",
+                "You have enabled brightness\n"
+                "adjustment. Performance\n"
+                "will be impacted slightly.");
+
+            // TODO: refresh interface to prevent reboot requirement
+            // TODO: increase performance
+        } else if (!v) {
+            nav.display_modal(
+                "Brightness",
+                "Brightness adjust disabled.");
+        }
         refresh();
-        parent()->set_dirty();  // The parent of NavigationView shal be the SystemView
     };
 
     button_bias_tee.on_select = [this](ImageButton&) {
@@ -399,9 +412,6 @@ void SystemStatusView::refresh() {
     // Converter
     button_converter.set_bitmap(pmem::config_updown_converter() ? &bitmap_icon_downconvert : &bitmap_icon_upconvert);
     button_converter.set_foreground(pmem::config_converter() ? Color::red() : Color::light_grey());
-
-    // Brightness
-    toggle_fake_brightness.set_value(pmem::apply_fake_brightness());
 
     set_dirty();
 }


### PR DESCRIPTION
Reverts portapack-mayhem/mayhem-firmware#1863
@u-foka i'm so sorry, it seems you should verify the nav before pop, to prevent boot fail.
we can work together and you can submit fix again, it's a really nice fix!
sorry again and thank you!
