### PR TITLE
Set fake brightness to 50% default if never configured in Settings

### DIFF
--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -728,6 +728,10 @@ void set_config_backlight_timer(const backlight_config_t& new_value) {
 
 void set_apply_fake_brightness(const bool v) {
     data->ui_config.apply_fake_brightness = v;
+
+    // The fake_brightness_level field in PMEM will be 0 if it was never enabled before; pick a valid value
+    if (data->fake_brightness_level == 0)
+        data->fake_brightness_level = BRIGHTNESS_50;
 }
 
 uint32_t pocsag_last_address() {


### PR DESCRIPTION
Following a firmware upgrade or after erasing pmem, if fake brightness was first turned on by clicking the icon on the title bar and it had never been enabled using the Settings->Brightness app, then the fake brightness level in pmem was still 0 (100% brightness), meaning performance would be slightly reduced but no brightness change occurred.  This could cause users to question the purpose of the icon.

After this change, in this same upgrade or erased-pmem scenario, if the user enables Brightness the first time via the title bar the brightness will go to a default level of 50%.

Sorry, @zxkmm, I should have realized this during the code review.

(I am still thinking that perhaps clicking the icon multiple times should cycle through each of the levels, but that could be a future PR.)