### PR TITLE
Cycle through brightness levels when icon selected

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -329,9 +329,9 @@ SystemStatusView::SystemStatusView(
         refresh();
     };
 
-    toggle_fake_brightness.on_change = [this, &nav](bool v) {
+    button_fake_brightness.on_select = [this](ImageButton&) {
         set_dirty();
-        pmem::set_apply_fake_brightness(v);
+        pmem::toggle_fake_brightness_level();
         refresh();
         if (nullptr != parent()) {
             parent()->set_dirty();  // The parent of NavigationView shal be the SystemView
@@ -359,7 +359,6 @@ SystemStatusView::SystemStatusView(
     toggle_speaker.set_value(pmem::config_speaker_disable());
     toggle_mute.set_value(pmem::config_audio_mute());
     toggle_stealth.set_value(pmem::stealth_mode());
-    toggle_fake_brightness.set_value(pmem::apply_fake_brightness());
 
     audio::output::stop();
     audio::output::update_audio_mute();
@@ -381,7 +380,7 @@ void SystemStatusView::refresh() {
     // Display "Disable speaker" icon only if AK4951 Codec which has separate speaker/headphone control
     if (audio::speaker_disable_supported() && !pmem::ui_hide_speaker()) status_icons.add(&toggle_speaker);
 
-    if (!pmem::ui_hide_fake_brightness()) status_icons.add(&toggle_fake_brightness);
+    if (!pmem::ui_hide_fake_brightness()) status_icons.add(&button_fake_brightness);
 
     if (!pmem::ui_hide_sd_card()) status_icons.add(&sd_card_status_view);
     status_icons.update_layout();
@@ -404,8 +403,8 @@ void SystemStatusView::refresh() {
     button_converter.set_bitmap(pmem::config_updown_converter() ? &bitmap_icon_downconvert : &bitmap_icon_upconvert);
     button_converter.set_foreground(pmem::config_converter() ? Color::red() : Color::light_grey());
 
-    // Brightness
-    toggle_fake_brightness.set_value(pmem::apply_fake_brightness());
+    // Fake Brightness
+    button_fake_brightness.set_foreground(pmem::apply_fake_brightness() ? Color::green() : Color::light_grey());
 
     set_dirty();
 }

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -266,9 +266,11 @@ class SystemStatusView : public View {
         Color::light_grey(),
         Color::dark_grey()};
 
-    ImageToggle toggle_fake_brightness{
+    ImageButton button_fake_brightness{
         {0, 0, 2 * 8, 1 * 16},
-        &bitmap_icon_brightness};
+        &bitmap_icon_brightness,
+        Color::green(),
+        Color::dark_grey()};
 
     SDCardStatusView sd_card_status_view{
         {0, 0 * 16, 2 * 8, 1 * 16}};

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -276,6 +276,7 @@ void set_apply_fake_brightness(const bool v);
 // level (color change level):
 uint8_t fake_brightness_level();
 void set_fake_brightness_level(uint8_t v);
+void toggle_fake_brightness_level();
 
 /* Recon app */
 bool recon_autosave_freqs();


### PR DESCRIPTION
I didn't like having to open the Settings -> Brightness app to adjust brightness levels, so I'm proposing here to cycle through the 4 levels upon each press of the Brightness icon on the title bar.

PREVIOUSLY, each press of the Brightness icon only cycled on/off, as follows:
   100% (disabled) -> level specified in Brightness app -> 100%

PROPOSED in this PR, each press of the Brightness icon cycles as follows:
    100% (disabled) -> 50% -> 25% -> 12.5% -> 100%

Test version attached:
[portapack-h1_h2-mayhem.bin.zip](https://github.com/portapack-mayhem/mayhem-firmware/files/14222427/portapack-h1_h2-mayhem.bin.zip)
