### PR TITLE
Just shift menu icons up 1 row when hit bottom

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2019 Elia Yehuda (z4ziggy)
+ * Copyright (C) 2023 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -170,7 +171,7 @@ bool BtnGridView::set_highlighted(int32_t new_value) {
     if (((uint32_t)new_value > offset) && ((new_value - offset) >= displayed_max)) {
         // Shift BtnGridView up
         highlighted_item = new_value;
-        offset = new_value - displayed_max + rows_;
+        offset += rows_;
         update_items();
         set_dirty();
     } else if ((uint32_t)new_value < offset) {


### PR DESCRIPTION
Resolves #1872 

When scrolling app icons to see the apps past the bottom of the screen, keep the existing icons in their original columns and just shift them up exactly 1 row instead of moving them to a different column.  (The movement to a new column was inconsistent, too, depending on which column was highlighted.)  The Settings and Utility screens were affected due to having more icons than would fit on the screen.

Test version:
[portapack-h1_h2-mayhem.bin.zip](https://github.com/portapack-mayhem/mayhem-firmware/files/14226159/portapack-h1_h2-mayhem.bin.zip)

(BTW, the copyright update was for my "blacklist" code from 2023, not for this trivial 1-line fix.  :-)