### PR TITLE
Add progress bar to Soundboard app

### DIFF
--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -51,7 +52,7 @@ void SoundBoardView::stop() {
 
 void SoundBoardView::handle_replay_thread_done(const uint32_t return_code) {
     stop();
-    // progressbar.set_value(0);
+    progressbar.set_value(0);
 
     if (return_code == ReplayThread::END_OF_FILE) {
         if (check_random.value()) {
@@ -100,7 +101,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
 
     playing_id = id;
 
-    // progressbar.set_max(reader->sample_count());
+    progressbar.set_max(reader->sample_count());
 
     // button_play.set_bitmap(&bitmap_stop);
 
@@ -148,8 +149,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
 }*/
 
 void SoundBoardView::on_tx_progress(const uint32_t progress) {
-    (void)progress;  // avoid warning
-                     // progressbar.set_value(progress);
+    progressbar.set_value(progress);
 }
 
 void SoundBoardView::on_select_entry() {
@@ -213,7 +213,7 @@ void SoundBoardView::refresh_list() {
 
         for (size_t n = 0; n < file_list.size(); n++) {
             menu_view.add_item({file_list[n].string().substr(0, 30),
-                                ui::Color::white(),
+                                ui::Color::dark_magenta(),
                                 nullptr,
                                 [this](KeyEvent) {
                                     on_select_entry();
@@ -240,7 +240,7 @@ SoundBoardView::SoundBoardView(
                   &options_tone_key,
                   //&text_title,
                   //&text_duration,
-                  //&progressbar,
+                  &progressbar,
                   &field_volume,
                   &text_volume_disabled,
                   &page_info,

--- a/firmware/application/apps/soundboard_app.hpp
+++ b/firmware/application/apps/soundboard_app.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -103,7 +104,7 @@ class SoundBoardView : public View {
         "<="};
 
     Text page_info{
-        {0, 30 * 8 - 4, 30 * 8, 16}};
+        {0, 29 * 8, 30 * 8, 16}};
 
     MenuView menu_view{
         {0, 0, 240, 175},
@@ -142,9 +143,9 @@ class SoundBoardView : public View {
         6,
         "Random"};
 
-    // ProgressBar progressbar {
-    //	{ 0 * 8, 30 * 8 - 4, 30 * 8, 16 }
-    // };
+    ProgressBar progressbar {
+        { 0 * 8, 31 * 8 + 2, 30 * 8, 4 }
+    };
 
     TransmitterView tx_view{
         16 * 16,

--- a/firmware/application/apps/soundboard_app.hpp
+++ b/firmware/application/apps/soundboard_app.hpp
@@ -143,9 +143,8 @@ class SoundBoardView : public View {
         6,
         "Random"};
 
-    ProgressBar progressbar {
-        { 0 * 8, 31 * 8 + 2, 30 * 8, 4 }
-    };
+    ProgressBar progressbar{
+        {0 * 8, 31 * 8 + 2, 30 * 8, 4}};
 
     TransmitterView tx_view{
         16 * 16,

--- a/firmware/application/apps/ui_view_wav.cpp
+++ b/firmware/application/apps/ui_view_wav.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2017 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/apps/ui_view_wav.hpp
+++ b/firmware/application/apps/ui_view_wav.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2017 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -126,7 +127,7 @@ class ViewWavView : public View {
         Color::white()};
 
     ProgressBar progressbar{
-        {0 * 8, 11 * 16, 30 * 8, 8}};
+        {0 * 8, 11 * 16, 30 * 8, 4}};
 
     NumberField field_pos_seconds{
         {9 * 8, 12 * 16},


### PR DESCRIPTION
- Added progress bar to Soundboard app, resolves #1830 (requested by @zxkmm).
- Changed file name colors to magenta to match File Manager, and to distinguish the file list from other text right below.
- Modified progress bar in WAV viewer to use same dimensions.
- Updated Copyright (for the audio-output support I added earlier, not for this trivial change which code was already in place for)

Test version attached:
[portapack-h1_h2-mayhem.bin.zip](https://github.com/portapack-mayhem/mayhem-firmware/files/14226924/portapack-h1_h2-mayhem.bin.zip)
