### PR TITLE
Encoder rotation rate multiplier support

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -3,6 +3,7 @@
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2023 gullradriel, Nilorea Studio Inc.
  * Copyright (C) 2023 Kyle Reed
+ * Copyright (C) 2024 Mark Thompson
  * Copyleft (ɔ) 2024 zxkmm under GPL license
  *
  * This file is part of PortaPack.
@@ -680,13 +681,16 @@ void SetQRCodeView::focus() {
 SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
     add_children({&labels,
                   &field_encoder_dial_sensitivity,
+                  &field_encoder_rate_multiplier,
                   &button_save,
                   &button_cancel});
 
-    field_encoder_dial_sensitivity.set_by_value(pmem::config_encoder_dial_sensitivity());
+    field_encoder_dial_sensitivity.set_by_value(pmem::encoder_dial_sensitivity());
+    field_encoder_rate_multiplier.set_value(pmem::encoder_rate_multiplier());
 
     button_save.on_select = [&nav, this](Button&) {
         pmem::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());
+        pmem::set_encoder_rate_multiplier(field_encoder_rate_multiplier.value());
         nav.pop();
     };
 

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -3,6 +3,7 @@
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2023 gullradriel, Nilorea Studio Inc.
  * Copyright (C) 2023 Kyle Reed
+ * Copyright (C) 2024 Mark Thompson
  * Copyleft (ɔ) 2024 zxkmm under GPL license
  *
  * This file is part of PortaPack.
@@ -555,6 +556,7 @@ class SetQRCodeView : public View {
 };
 
 using portapack::persistent_memory::encoder_dial_sensitivity;
+using portapack::persistent_memory::encoder_rate_multiplier;
 
 class SetEncoderDialView : public View {
    public:
@@ -566,17 +568,29 @@ class SetEncoderDialView : public View {
 
    private:
     Labels labels{
-        {{1 * 8, 1 * 16}, "Adjusts how many steps to", Color::light_grey()},
-        {{1 * 8, 2 * 16}, "change the encoder value.", Color::light_grey()},
-        {{2 * 8, 4 * 16}, "Dial sensitivity:", Color::light_grey()},
+        {{1 * 8, 1 * 16}, "Adjusts sensitivity to dial", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "rotation position (number of", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "steps per full rotation):", Color::light_grey()},
+        {{2 * 8, 5 * 16}, "Dial sensitivity:", Color::light_grey()},
+        {{1 * 8, 8 * 16}, "Adjusts sensitivity to dial", Color::light_grey()},
+        {{1 * 8, 9 * 16}, "rotation rate (default 1", Color::light_grey()},
+        {{1 * 8, 10 * 16}, "means no rate dependency):", Color::light_grey()},
+        {{3 * 8, 12 * 16}, "Rate multiplier:", Color::light_grey()},
     };
 
     OptionsField field_encoder_dial_sensitivity{
-        {20 * 8, 4 * 16},
+        {20 * 8, 5 * 16},
         6,
         {{"LOW", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOW},
          {"NORMAL", encoder_dial_sensitivity::DIAL_SENSITIVITY_NORMAL},
          {"HIGH", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGH}}};
+
+    NumberField field_encoder_rate_multiplier{
+        {20 * 8, 12 * 16},
+        2,
+        {1, 10},
+        1,
+        ' '};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},

--- a/firmware/application/hw/debounce.cpp
+++ b/firmware/application/hw/debounce.cpp
@@ -24,6 +24,9 @@
 
 #include "utility.hpp"
 
+#include "portapack.hpp"
+#include "portapack_persistent_memory.hpp"
+
 uint8_t Debounce::state() {
     uint8_t v = state_to_report_;
     simulated_pulse_ = false;
@@ -154,6 +157,10 @@ uint8_t EncoderDebounce::state() {
     return state_;
 }
 
+uint8_t EncoderDebounce::rotation_rate() {
+    return last_rotation_rate_;
+}
+
 // Returns TRUE if encoder position phase bits changed (after debouncing)
 bool EncoderDebounce::feed(const uint8_t phase_bits) {
     history_ = (history_ << 2) | phase_bits;
@@ -164,14 +171,21 @@ bool EncoderDebounce::feed(const uint8_t phase_bits) {
     // But, checking for equal seems to cause issues with at least 1 user's encoder, so we're treating the input
     // as "stable" if at least ONE input bit is consistent for 4 ticks...
     uint8_t diff = (history_ ^ expected_stable_history);
-    if ((diff == 0) || ((diff & 0b01010101) == 0) || ((diff & 0b10101010) == 0)) {
+    if (((diff & 0b01010101) == 0) || ((diff & 0b10101010) == 0)) {
         // Has the debounced input value changed?
         if (state_ != phase_bits) {
             state_ = phase_bits;
+
+            // Rate multiplier is for larger delta increments when dial is rotated rapidly.
+            last_rotation_rate_ = rotation_rate_downcounter_;
+            rotation_rate_downcounter_ = portapack::persistent_memory::encoder_rate_multiplier();
             return true;
         }
     }
 
-    // Unstable input, or no change
+    // Unstable input, or no change.
+    // Decrement rotation rate detector once per timer tick.
+    if (rotation_rate_downcounter_ > 1)
+        rotation_rate_downcounter_--;
     return false;
 }

--- a/firmware/application/hw/debounce.hpp
+++ b/firmware/application/hw/debounce.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -70,10 +71,15 @@ class EncoderDebounce {
 
     uint8_t state();  // returns debounced phase bits from encoder
 
+    uint8_t rotation_rate();  // returns last rotation rate
+
    private:
     uint8_t history_{0};  // shift register of previous reads from encoder
 
     uint8_t state_{0};  // actual encoder output state (after debounce logic)
+
+    uint8_t last_rotation_rate_{1};
+    uint8_t rotation_rate_downcounter_{1};  // down-counter to estimate rotation speed
 };
 
 #endif /*__DEBOUNCE_H__*/

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -63,7 +64,7 @@ int_fast8_t Encoder::update(const uint_fast8_t phase_bits) {
 
     // Require 2 state changes in same direction to register movement -- for additional level of contact switch debouncing
     if (direction == prev_direction) {
-        if ((sensitivity_map[portapack::persistent_memory::config_encoder_dial_sensitivity()] & (1 << state)) == 0)
+        if ((sensitivity_map[portapack::persistent_memory::encoder_dial_sensitivity()] & (1 << state)) == 0)
             return 0;
         return direction;
     }

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/irq_controls.cpp
+++ b/firmware/application/irq_controls.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -166,7 +167,7 @@ static bool encoder_update(const uint8_t raw) {
 }
 
 static bool encoder_read() {
-    auto delta = encoder.update(encoder_debounce.state());
+    auto delta = encoder.update(encoder_debounce.state()) * encoder_debounce.rotation_rate();
 
     if (injected_encoder > 0) {
         if (injected_encoder == 1) delta = -1;

--- a/firmware/application/irq_controls.hpp
+++ b/firmware/application/irq_controls.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *
@@ -246,8 +247,11 @@ void set_config_audio_mute(bool v);
 void set_config_speaker_disable(bool v);
 void set_config_backlight_timer(const backlight_config_t& new_value);
 void set_disable_touchscreen(bool v);
-uint8_t config_encoder_dial_sensitivity();
+
+uint8_t encoder_dial_sensitivity();
 void set_encoder_dial_sensitivity(uint8_t v);
+uint8_t encoder_rate_multiplier();
+void set_encoder_rate_multiplier(uint8_t v);
 
 uint32_t config_mode_storage_direct();
 void set_config_mode_storage_direct(uint32_t v);


### PR DESCRIPTION
Resolves issue #1853 

This PR adds support for a configurable encoder rotation rate multiplier (turn dial faster for larger jumps).  Configure using the Settings -> Encoder app.  The settings applies to all encoder dial rotations (not just when changing frequency), so please experiment with it in different apps.

BTW, a value of 10 means that the encoder "delta" output can jump _up to_ +10 or -10 maximum per "step" (versus +1 or -1) if the encoder is turned at a very fast rate. 

Currently, the default is disabled (rate multiplier value of 1).

Test version available on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1205738051507195925