### PR TITLE
Warning for shared external code during build

### DIFF
--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -1,12 +1,12 @@
 set(EXTCPPSRC
 
 	#pacman
-	external/pacman/main.cpp
-	external/pacman/ui_pacman.cpp
+#	external/pacman/main.cpp
+#	external/pacman/ui_pacman.cpp
 
 	#tetris
-	external/tetris/main.cpp
-	external/tetris/ui_tetris.cpp
+#	external/tetris/main.cpp
+#	external/tetris/ui_tetris.cpp
 
 	#afsk_rx
 	external/afsk_rx/main.cpp
@@ -65,7 +65,7 @@ set(EXTCPPSRC
 )
 
 set(EXTAPPLIST
-	pacman
+#	pacman
 	afsk_rx
 	calculator
 	font_viewer
@@ -79,5 +79,5 @@ set(EXTAPPLIST
 	gpssim
 	spainter
 	keyfob
-	tetris
+#	tetris
 )

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2023 Bernd Herzog
+    Copyright (C) 2024 Mark Thompson
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,22 +17,27 @@
 
 MEMORY
 {
-    /* external apps: regions can't overlap so addresses are corrected after build */
-    ram_external_app_pacman     (rwx) : org = 0xEEE90000, len = 32k
-    ram_external_app_afsk_rx    (rwx) : org = 0xEEEA0000, len = 32k
-    ram_external_app_calculator (rwx) : org = 0xEEEB0000, len = 32k
-    ram_external_app_font_viewer(rwx) : org = 0xEEEC0000, len = 32k
-    ram_external_app_blespam(rwx) : org = 0xEEED0000, len = 32k
-    ram_external_app_analogtv(rwx) : org = 0xEEEE0000, len = 32k
-    ram_external_app_nrf_rx(rwx) : org = 0xEEEF0000, len = 32k
-    ram_external_app_coasterp(rwx) : org = 0xEEF00000, len = 32k
-    ram_external_app_lge(rwx) : org = 0xEEF10000, len = 32k
-    ram_external_app_lcr(rwx) : org = 0xEEF20000, len = 32k
-    ram_external_app_jammer(rwx) : org = 0xEEF30000, len = 32k
-    ram_external_app_gpssim(rwx) : org = 0xEEF40000, len = 32k
-    ram_external_app_spainter(rwx) : org = 0xEEF50000, len = 32k
-    ram_external_app_keyfob(rwx) : org = 0xEEF60000, len = 32k
-    ram_external_app_tetris(rwx) : org = 0xEEF70000, len = 32k
+    /*
+     * External apps: regions can't overlap so addresses are corrected after build.
+     * Picking uncommon address values for search & replace in binaries (no false positives) - 0xADB00000-0xADEF0000 seems to be good.
+     * Also need to consider processor memory map - reading 0xADxxxxxx generates a fault which may be better than unexpected behavior.
+     * External app address ranges below must match those in python file "external_app_info.py".
+     */
+    ram_external_app_pacman     (rwx) : org = 0xADB00000, len = 32k
+    ram_external_app_afsk_rx    (rwx) : org = 0xADB10000, len = 32k
+    ram_external_app_calculator (rwx) : org = 0xADB20000, len = 32k
+    ram_external_app_font_viewer(rwx) : org = 0xADB30000, len = 32k
+    ram_external_app_blespam(rwx) : org = 0xADB40000, len = 32k
+    ram_external_app_analogtv(rwx) : org = 0xADB50000, len = 32k
+    ram_external_app_nrf_rx(rwx) : org = 0xADB60000, len = 32k
+    ram_external_app_coasterp(rwx) : org = 0xADB70000, len = 32k
+    ram_external_app_lge(rwx) : org = 0xADB80000, len = 32k
+    ram_external_app_lcr(rwx) : org = 0xADB90000, len = 32k
+    ram_external_app_jammer(rwx) : org = 0xADBA0000, len = 32k
+    ram_external_app_gpssim(rwx) : org = 0xADBB0000, len = 32k
+    ram_external_app_spainter(rwx) : org = 0xADBC0000, len = 32k
+    ram_external_app_keyfob(rwx) : org = 0xADBD0000, len = 32k
+    ram_external_app_tetris(rwx) : org = 0xADBE0000, len = 32k
 }
 
 SECTIONS
@@ -59,7 +65,6 @@ SECTIONS
         KEEP(*(.external_app.app_font_viewer.application_information));
         *(*ui*external_app*font_viewer*);
     } > ram_external_app_font_viewer
-
 
     .external_app_blespam : ALIGN(4) SUBALIGN(4)
     {
@@ -91,13 +96,11 @@ SECTIONS
         *(*ui*external_app*lge*);
     } > ram_external_app_lge
 
-
     .external_app_lcr : ALIGN(4) SUBALIGN(4)
     {
         KEEP(*(.external_app.app_lcr.application_information));
         *(*ui*external_app*lcr*);
     } > ram_external_app_lcr
-
 
     .external_app_jammer : ALIGN(4) SUBALIGN(4)
     {
@@ -110,7 +113,6 @@ SECTIONS
         KEEP(*(.external_app.app_gpssim.application_information));
         *(*ui*external_app*gpssim*);
     } > ram_external_app_gpssim
-
 
     .external_app_spainter : ALIGN(4) SUBALIGN(4)
     {

--- a/firmware/tools/check_for_shared_external_code.py
+++ b/firmware/tools/check_for_shared_external_code.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Mark Thompson
+#
+# This file is part of PortaPack.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+import sys
+from external_app_info import maximum_application_size
+from external_app_info import external_apps_address_start
+from external_app_info import external_apps_address_end
+
+usage_message = """
+PortaPack ROM image checker for possible shared external code addresses
+
+Usage: <command> <input-file>
+"""
+
+def read_image(path):
+	f = open(path, 'rb')
+	data = f.read()
+	f.close()
+	return data
+
+if len(sys.argv) != 2:
+	print(usage_message)
+	sys.exit(-1)
+
+image = read_image(sys.argv[1])
+image = bytearray(image)
+
+for i in range(0, len(image), 4):
+	snippet = image[i:i+4]
+	val = int.from_bytes(snippet, byteorder='little')
+	offset = val & 0xFFFF
+	if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size) and ((val & 0x3)==0):
+		print ("External code address", hex(val),"at offset", hex(i),"in", sys.argv[1])

--- a/firmware/tools/external_app_info.py
+++ b/firmware/tools/external_app_info.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Mark Thompson
+#
+# This file is part of PortaPack.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+# external app address ranges below must match those in linker file "external.ld"
+maximum_application_size = 32*1024
+external_apps_address_start = 0xADB00000
+external_apps_address_end = 0xADF00000


### PR DESCRIPTION
To help with issue #1879:

- Changed the external code linking address range from 0xEExxxxxx to 0xADxxxxxx to avoid false positives when searching binaries for possible shared external code (there were too many 0xEE's)
- Changing the address range to 0xADxxxxxx also results in an immediate CPU fault when this address range is unexpectedly accessed (versus reading 0's and causing indeterminate behavior).  If firmware has reached past the power-up stage, then the offending code address will show up on the GURU meditation fault screen, which may help to debug.
- Added warning messages to the python build scripts when a potential shared external code address is discovered.  I'm not halting the make because of the possibility that the value found in the binary might not be an actual address at all.  (I don't see any false positives at the moment but it could happen in the future)
- **Temporarily disabled Pacman & Tetris** since our power-up code in firmware was sharing some code with them.  Note that several other apps are affected by this shared code problem (see #1879) but only these two happened to impact the ability of firmware to boot up.

I'm highlighting the last one due to its extreme importance!!  It's vital to get Pacman & Tetris working again ASAP!!  :-)

I am still working on an actual WORKAROUND for the shared external code issue, but this PR should help to detect the problem.