### PR TITLE
Solves random USB/LSB mode in SSB Mic App (H1R1).

### DIFF
--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -116,8 +116,9 @@ void set_direction(const rf::Direction new_direction) {
     /* TODO: Refactor all the various "Direction" enumerations into one. */
     /* TODO: Only make changes if direction changes, but beware of clock enabling. */
 
-    // Prevents ghosting when switching back to RX from TX mode.
-    hackrf::cpld::load_sram_no_verify();
+    // That below code line , was used to prevent RX interf ghosting when switching back to RX from any TX mode, but in recent code. it seems not necessary.
+    // Deleting that load_sram_no_verify() (or the original , load_sram() ), solves random TX swap I/Q  problem in H1R1 , others OK- (and no side effects to all).
+    // hackrf::cpld::load_sram_no_verify();  // After commit "removed the use of the hackrf cpld eeprom #1732", in a H1R1,  Mic App wrong SSB TX with random USB/LSB change.    
 
     direction = new_direction;
 

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -118,7 +118,7 @@ void set_direction(const rf::Direction new_direction) {
 
     // That below code line , was used to prevent RX interf ghosting when switching back to RX from any TX mode, but in recent code. it seems not necessary.
     // Deleting that load_sram_no_verify() (or the original , load_sram() ), solves random TX swap I/Q  problem in H1R1 , others OK- (and no side effects to all).
-    // hackrf::cpld::load_sram_no_verify();  // After commit "removed the use of the hackrf cpld eeprom #1732", in a H1R1,  Mic App wrong SSB TX with random USB/LSB change.    
+    // hackrf::cpld::load_sram_no_verify();  // After commit "removed the use of the hackrf cpld eeprom #1732", in a H1R1,  Mic App wrong SSB TX with random USB/LSB change.
 
     direction = new_direction;
 


### PR DESCRIPTION
Hello ,  (hopefully this time a clean PR ) ,
from that PR https://github.com/portapack-mayhem/mayhem-firmware/pull/1732 , my H1R1 was sending randomly SSB USB /LSB even selecting USB or viceversa.

![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/86470699/3a87b149-296c-444a-9249-d730aa9328a4)

The strange thing was that my other H2R2 and r9 was working correctly . (no random TX swap USB/LSB in Mic Ap)
After deep investigation and trying to re-update the Hackrf CPLD , we could not solve it .

But ,I found two possible countermeasures to solve it :

i-) reverting Bernd's PR

ii-) small change to previous Bernd's PR , disabling 1 line , that I added long time ago , and was used in the past in all the exit of the TX code to avoid ghost interference in reception. Since then many code has been changed , and also that line was deleted from all tx exit code .

After discussing it with Bernd, and doing several test , we both decided to go for (ii) .

We have confirmed that  this PR solves H1R1  random SSB USB/LSB swap problem , and keeping also working well in H2R2 , r9 (no swap neither) 
.
And so far ,  I do not see any ghost channel issue , but I will keep evaluating it . I just could evaluate it on r9 (because the knob rotary encoder is not working now in H1R1 , H2R2 (*1) - but this is a total separated problem , I already mentioned to @NotherNgineer

Note (*1) :Not related at all , to this PR problem one . Recently , my rotary knob encoder in H1R1 , and H2R2 are not working with today's "next" fw , at all (but in r9 working well ) , maybe it is just a matter of reseting some user setting ??? .