### PR TITLE
Disable LTO for external apps

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -52,7 +52,7 @@ set(USE_LINK_GC yes)
 # Linker extra options here.
 set(USE_LDOPT)
 
-# Enable this if you want link time optimizations (LTO)
+# Enable this if you want link time optimizations (LTO) - this flag affects chibios only
 set(USE_LTO no)
 
 # If enabled, this option allows to compile the application in THUMB mode.
@@ -293,7 +293,7 @@ set(CPPSRC
 	# apps/ui_jammer.cpp
     # apps/ui_keyfob.cpp
 	# apps/ui_lcr.cpp
-	apps/ui_level.cpp  
+	apps/ui_level.cpp
 	apps/ui_looking_glass_app.cpp
 	apps/ui_mictx.cpp
 	apps/ui_modemsetup.cpp
@@ -304,7 +304,7 @@ set(CPPSRC
 	apps/ui_pocsag_tx.cpp
 	apps/ui_rds.cpp
 	apps/ui_recon_settings.cpp
-	apps/ui_recon.cpp  
+	apps/ui_recon.cpp
 	apps/ui_remote.cpp
 	apps/ui_scanner.cpp
 	apps/ui_sd_over_usb.cpp
@@ -492,6 +492,7 @@ add_custom_command(
 )
 
 add_executable(${PROJECT_NAME}.elf ${CSRC} ${CPPSRC} ${ASMSRC})
+set_source_files_properties(${EXTCPPSRC} PROPERTIES COMPILE_FLAGS -fno-lto)
 set_target_properties(${PROJECT_NAME}.elf PROPERTIES LINK_DEPENDS ${LDSCRIPT})
 add_definitions(${DEFS})
 include_directories(. ${INCDIR})

--- a/firmware/tools/check_for_shared_external_code.py
+++ b/firmware/tools/check_for_shared_external_code.py
@@ -49,5 +49,5 @@ for i in range(0, len(image), 4):
 	snippet = image[i:i+4]
 	val = int.from_bytes(snippet, byteorder='little')
 	offset = val & 0xFFFF
-	if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size) and ((val & 0x3)==0):
+	if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size):
 		print ("External code address", hex(val),"at offset", hex(i),"in", sys.argv[1])

--- a/firmware/tools/export_external_apps.py
+++ b/firmware/tools/export_external_apps.py
@@ -76,7 +76,7 @@ def patch_image(path, image_data, search_address, replace_address):
 			external_application_image += new_snippet
 		else:
 			external_application_image += snippet
-			if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size) and ((val & 0x3)==0):
+			if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size):
 				print ("WARNING: External code address", hex(val), "at offset", hex(x*4), "in", path)
 
 	return external_application_image

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -91,7 +91,7 @@ for i in range(0, len(spi_image), 4):
 	snippet = spi_image[i:i+4]
 	val = int.from_bytes(snippet, byteorder='little')
 	checksum += val
-	if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size) and ((val & 0x3)==0):
+	if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size):
 		print ("WARNING: External code address", hex(val), "at offset", hex(i), "in", sys.argv[3])
 
 final_checksum = 0


### PR DESCRIPTION
For issue #1879:

With this one-line CMAKE file change, 
`set_source_files_properties(${EXTCPPSRC} PROPERTIES COMPILE_FLAGS -fno-lto)`
GCC LTO optimization is now disabled when compiling external apps, which also seems to prevent the linker from doing the LTO optimization with the external apps.  This appears to prevent the unwanted code sharing between external apps, and between main firmware and external apps.  The linker still does LTO optimization for the rest of the firmware that is compiled with LTO enabled, which is important because LTO saves almost 50KB of ROM space.

After this change, a search of the firmware & external app binaries yields no values that look like potential addresses into the 0xADxxxxxx external app memory address region.  In addition, most* of the apps that were broken after PR #1881 (due to faults having been enabled when accessing the invalid memory addresses) are now working again.  (The apps that didn't work after PR #1881 are listed in issue #1879)

*The exceptions are Tetris & Pacman, which still seem to somehow prevent power-up even after disabling LTO, so they remain disabled until that is sorted out.

BTW, this change consumes 3KB more ROM space, presumably because firmware is no longer trying to utilize code in the external app memory space.

A test version is available on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1206848162375934002

(If anyone has any better way of resolving this issue, other suggestions/PR's are of course welcome)