### PR TITLE
Fixed Pacman global object initialization

### DIFF
--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -1,8 +1,8 @@
 set(EXTCPPSRC
 
 	#pacman
-#	external/pacman/main.cpp
-#	external/pacman/ui_pacman.cpp
+	external/pacman/main.cpp
+	external/pacman/ui_pacman.cpp
 
 	#tetris
 	external/tetris/main.cpp
@@ -65,7 +65,7 @@ set(EXTCPPSRC
 )
 
 set(EXTAPPLIST
-#	pacman
+	pacman
 	afsk_rx
 	calculator
 	font_viewer

--- a/firmware/application/external/pacman/ui_pacman.cpp
+++ b/firmware/application/external/pacman/ui_pacman.cpp
@@ -13,7 +13,6 @@ namespace ui::external_app::pacman {
 #include "playfield.hpp"
 #pragma GCC diagnostic pop
 
-Playfield _game;
 
 PacmanView::PacmanView(NavigationView& nav)
     : nav_(nav) {
@@ -26,6 +25,7 @@ void PacmanView::focus() {
 
 void PacmanView::paint(Painter& painter) {
     (void)painter;
+    static Playfield _game;
 
     if (!initialized) {
         initialized = true;

--- a/firmware/application/external/pacman/ui_pacman.cpp
+++ b/firmware/application/external/pacman/ui_pacman.cpp
@@ -13,7 +13,6 @@ namespace ui::external_app::pacman {
 #include "playfield.hpp"
 #pragma GCC diagnostic pop
 
-
 PacmanView::PacmanView(NavigationView& nav)
     : nav_(nav) {
     add_children({&dummy});


### PR DESCRIPTION
Pac-man is working again!

With this change, Mayhem boot code doesn't try to initialize the playfield _game object in the external app memory space (in an invalid address range).

This should be the last fix needed to close external app shared code issue #1879.