### PR TITLE
Fixed Pacman pause button

### DIFF
--- a/firmware/application/external/pacman/ui_pacman.cpp
+++ b/firmware/application/external/pacman/ui_pacman.cpp
@@ -25,19 +25,31 @@ void PacmanView::focus() {
 void PacmanView::paint(Painter& painter) {
     (void)painter;
     static Playfield _game;
+    static bool wait_for_button_release{false};
 
     if (!initialized) {
         initialized = true;
         _game.Init();
     }
 
-    auto switches_debounced = get_switches_state().to_ulong();
+    auto switches_raw = swizzled_switches() & ((1 << (int)Switch::Right) | (1 << (int)Switch::Left) | (1 << (int)Switch::Down) | (1 << (int)Switch::Up) | (1 << (int)Switch::Sel) | (1 << (int)Switch::Dfu));
 
-    but_RIGHT = (switches_debounced & 0x01) == 0x01;
-    but_LEFT = (switches_debounced & 0x02) == 0x02;
-    but_DOWN = (switches_debounced & 0x04) == 0x04;
-    but_UP = (switches_debounced & 0x08) == 0x08;
-    but_A = (switches_debounced & 0x10) == 0x10;
+    // For the Select (Start/Pause) button, wait for release to avoid repeat
+    uint8_t buttons_to_wait_for = (1 << (int)Switch::Sel);
+    if (wait_for_button_release) {
+        if ((switches_raw & buttons_to_wait_for) == 0)
+            wait_for_button_release = false;
+        switches_raw &= ~buttons_to_wait_for;
+    } else {
+        if (switches_raw & buttons_to_wait_for)
+            wait_for_button_release = true;
+    }
+
+    but_RIGHT = (switches_raw & (1 << (int)Switch::Right)) != 0;
+    but_LEFT = (switches_raw & (1 << (int)Switch::Left)) != 0;
+    but_DOWN = (switches_raw & (1 << (int)Switch::Down)) != 0;
+    but_UP = (switches_raw & (1 << (int)Switch::Up)) != 0;
+    but_A = (switches_raw & (1 << (int)Switch::Sel)) != 0;
 
     _game.Step();
 }


### PR DESCRIPTION
* Fixed Pause button in Pacman, which was difficult to activate/deactivate previously because firmware wasn't waiting for button to be released.
* Use raw switch inputs instead of going through Debounce code, for very slightly improved button response times.
 
Pacman still doesn't seem to turn on a dime though; that could be a bug (or "feature") elsewhere.