### PR TITLE
Treat encoder rate multiplier value of 0 in pmem the same as 1

### DIFF
--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -461,7 +461,6 @@ void init() {
 
     // Firmware upgrade handling - adjust newly defined fields where 0 is an invalid default
     if (fake_brightness_level() == 0) set_fake_brightness_level(BRIGHTNESS_50);
-    if (encoder_rate_multiplier() == 0) set_encoder_rate_multiplier(1);
 }
 
 void persist() {
@@ -994,7 +993,7 @@ void set_encoder_dial_sensitivity(uint8_t v) {
 }
 uint8_t encoder_rate_multiplier() {
     uint8_t v = data->encoder_rate_multiplier;
-    if (v == 0) v = 1;  // this same check is in pmem init() so should not be needed here
+    if (v == 0) v = 1;  // minimum value is 1; treat 0 the same as 1
     return v;
 }
 void set_encoder_rate_multiplier(uint8_t v) {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -229,7 +229,9 @@ struct data_t {
     uint16_t fake_brightness_level : 4;
 
     // Encoder rotation rate multiplier for larger increments when rotated rapidly
-    uint16_t encoder_rate_multiplier : 8;
+    uint16_t encoder_rate_multiplier : 4;
+
+    uint16_t UNUSED : 4;
 
     // Headphone volume in centibels.
     int16_t headphone_volume_cb;
@@ -296,6 +298,8 @@ struct data_t {
           encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL),
           fake_brightness_level(BRIGHTNESS_50),
           encoder_rate_multiplier(1),
+          UNUSED(0),
+
           headphone_volume_cb(-600),
           misc_config(),
           ui_config2(),
@@ -989,7 +993,9 @@ void set_encoder_dial_sensitivity(uint8_t v) {
     data->encoder_dial_sensitivity = v;
 }
 uint8_t encoder_rate_multiplier() {
-    return data->encoder_rate_multiplier;
+    uint8_t v = data->encoder_rate_multiplier;
+    if (v == 0) v = 1;  // this same check is in pmem init() so should not be needed here
+    return v;
 }
 void set_encoder_rate_multiplier(uint8_t v) {
     data->encoder_rate_multiplier = v;


### PR DESCRIPTION
Some users needed to reset their pmem after the addition of the encoder rate multiplier code (PR #1876), in order to get their encoder dials to work.  **This should not have been necessary** since pmem init code was already checking for a 0 value and setting it to 1, but just in case in this PR I've moved the check to the encoder_rate_multiplier() function so that a value of 0 in pmem is treated the same as 1.

I've also reduced the encoder rate multiplier field in pmem to 4 bits (other bits were not needed)