### PR TITLE
Eliminate unneeded screen flashing when scrolling menu

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -173,13 +173,15 @@ bool BtnGridView::set_highlighted(int32_t new_value) {
         highlighted_item = new_value;
         offset += rows_;
         update_items();
-        set_dirty();
+        // refresh whole screen (display flickers) only if scrolling last row up and a blank button is needed at the bottom
+        if ((new_value + rows_ > item_count) && (item_count % rows_) != 0)
+            set_dirty();
     } else if ((uint32_t)new_value < offset) {
         // Shift BtnGridView down
         highlighted_item = new_value;
         offset = (new_value / rows_) * rows_;
         update_items();
-        set_dirty();
+        // no need to set_dirty() here since all buttons have been repainted
     } else {
         // Just update highlight
         highlighted_item = new_value;


### PR DESCRIPTION
Fixes #1896

No more screen flashes when scrolling up (every button is already repainted in the up case).

No more screen flashes when scrolling down, except when it's necessary to paint an empty button on the last row (that could be fixed too but maybe a future PR).