### PR TITLE
Add color to position info lines in Notepad

### DIFF
--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -427,6 +427,9 @@ TextEditorView::TextEditorView(NavigationView& nav)
             &text_size,
         });
 
+    text_position.set_style(&Styles::bg_dark_blue);
+    text_size.set_style(&Styles::bg_dark_blue);
+
     viewer.set_font_zoom(enable_zoom);
 
     viewer.on_select = [this]() {

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -86,6 +86,12 @@ const Style Styles::bg_blue{
     .foreground = Color::white(),
 };
 
+const Style Styles::bg_dark_blue{
+    .font = font::fixed_8x16,
+    .background = Color::dark_blue(),
+    .foreground = Color::white(),
+};
+
 const Style Styles::light_grey{
     .font = font::fixed_8x16,
     .background = Color::black(),

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -58,6 +58,9 @@ class Styles {
     /* Blue background. */
     static const Style bg_blue;
 
+    /* Dark blue background. */
+    static const Style bg_dark_blue;
+
     /* Light grey foreground. */
     static const Style light_grey;
 


### PR DESCRIPTION
When viewing a file with more than 16 lines in the Notepad app, the 2 lines of positional information at the bottom of the screen looked like it could be part of the file, since it was displayed in the same style font/color.

This PR changes the background color for the two bottom lines to dark blue, to distinguish them from the file contents.

BEFORE:

![BEFORE](https://github.com/portapack-mayhem/mayhem-firmware/assets/129641948/aca43c63-930e-4a15-bdcf-f35bee9e8415)


AFTER:

![SCR_0074](https://github.com/portapack-mayhem/mayhem-firmware/assets/129641948/b899cf32-4382-4f7f-a5f3-0b6b86e05127)
