### PR TITLE
Show on_encoder delta in Buttons Test app

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -323,6 +323,11 @@ bool ControlsSwitchesWidget::on_key(const KeyEvent key) {
     return true;
 }
 
+bool ControlsSwitchesWidget::on_encoder(const EncoderEvent delta) {
+    last_delta = delta;
+    return true;
+}
+
 void ControlsSwitchesWidget::paint(Painter& painter) {
     const auto pos = screen_pos();
 
@@ -405,6 +410,8 @@ void ControlsSwitchesWidget::paint(Painter& painter) {
 
         switches_event >>= 1;
     }
+
+    painter.draw_string({5 * 8, 12 * 16}, Styles::light_grey, to_string_dec_int(last_delta, 3));
 }
 
 void ControlsSwitchesWidget::on_frame_sync() {

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -252,18 +252,21 @@ class ControlsSwitchesWidget : public Widget {
         Rect parent_rect)
         : Widget{parent_rect},
           key_event_mask(0),
-          long_press_key_event_mask{0} {
+          long_press_key_event_mask{0},
+          last_delta{0} {
         set_focusable(true);
     }
 
     void on_show() override;
     bool on_key(const KeyEvent key) override;
+    bool on_encoder(const EncoderEvent delta) override;
 
     void paint(Painter& painter) override;
 
    private:
     uint8_t key_event_mask;
     uint8_t long_press_key_event_mask;
+    EncoderEvent last_delta;
 
     MessageHandlerRegistration message_handler_frame_sync{
         Message::ID::DisplayFrameSync,
@@ -285,6 +288,7 @@ class DebugControlsView : public View {
    private:
     Labels labels{
         {{8 * 8, 1 * 16}, "Controls State", Color::white()},
+        {{0 * 8, 11 * 16}, "Dial:", Color::grey()},
         {{0 * 8, 14 * 16}, "Long-Press Mode:", Color::grey()}};
 
     ControlsSwitchesWidget switches_widget{


### PR DESCRIPTION
Show on_encoder delta values in the Debug -> Buttons Test app.  This is helpful for determining if the encoder is connected properly (delta should be positive with clockwise rotation), and for observing the output from the rate multiplier.

![SCR_0076](https://github.com/portapack-mayhem/mayhem-firmware/assets/129641948/8000210c-df8a-4bf9-8f67-cc6983f1465f)
