### PR TITLE
Added Reboot app to Debug menu

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -457,6 +457,17 @@ DebugPeripheralsMenuView::DebugPeripheralsMenuView(NavigationView& nav) {
     set_max_rows(2);  // allow wider buttons
 }
 
+/* DebugReboot **********************************************/
+
+DebugReboot::DebugReboot(NavigationView& nav) {
+    (void)nav;
+
+    LPC_RGU->RESET_CTRL[0] = (1 << 0);
+
+    while (1)
+        __WFE();
+}
+
 /* DebugMenuView *********************************************************/
 
 DebugMenuView::DebugMenuView(NavigationView& nav) {
@@ -472,6 +483,7 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         {"Peripherals", ui::Color::dark_cyan(), &bitmap_icon_peripherals, [&nav]() { nav.push<DebugPeripheralsMenuView>(); }},
         {"Pers. Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
         //{ "Radio State",	ui::Color::white(),	nullptr,	[&nav](){ nav.push<NotImplementedView>(); } },
+        {"Reboot", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<DebugReboot>(); }},
         {"SD Card", ui::Color::dark_cyan(), &bitmap_icon_sdcard, [&nav]() { nav.push<SDCardDebugView>(); }},
         {"Temperature", ui::Color::dark_cyan(), &bitmap_icon_temperature, [&nav]() { nav.push<TemperatureView>(); }},
         {"Touch Test", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugScreenTest>(); }},

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -424,6 +424,11 @@ class DebugPeripheralsMenuView : public BtnGridView {
     std::string title() const override { return "Peripherals"; };
 };
 
+class DebugReboot : public BtnGridView {
+   public:
+    DebugReboot(NavigationView& nav);
+};
+
 class DebugMenuView : public BtnGridView {
    public:
     DebugMenuView(NavigationView& nav);


### PR DESCRIPTION
I was doing some testing to see if things are initialized the same after flashing firmware (and rebooting) as they are after a power cycle, and I thought that having a way to reset the PortaPack _without_ having to do a flash operation might be helpful.

Simplest app possible.  I didn't bother with a warning screen, it just reboots.