### PR TITLE
Fix Pacman pause button glitches

### DIFF
--- a/firmware/application/external/pacman/ui_pacman.cpp
+++ b/firmware/application/external/pacman/ui_pacman.cpp
@@ -33,23 +33,27 @@ void PacmanView::paint(Painter& painter) {
     }
 
     auto switches_raw = swizzled_switches() & ((1 << (int)Switch::Right) | (1 << (int)Switch::Left) | (1 << (int)Switch::Down) | (1 << (int)Switch::Up) | (1 << (int)Switch::Sel) | (1 << (int)Switch::Dfu));
+    auto switches_debounced = get_switches_state().to_ulong();
 
     // For the Select (Start/Pause) button, wait for release to avoid repeat
     uint8_t buttons_to_wait_for = (1 << (int)Switch::Sel);
     if (wait_for_button_release) {
-        if ((switches_raw & buttons_to_wait_for) == 0)
+        if ((switches_debounced & buttons_to_wait_for) == 0)
             wait_for_button_release = false;
-        switches_raw &= ~buttons_to_wait_for;
+        switches_debounced &= ~buttons_to_wait_for;
     } else {
-        if (switches_raw & buttons_to_wait_for)
+        if (switches_debounced & buttons_to_wait_for)
             wait_for_button_release = true;
     }
 
+    // For the directional buttons, use the raw inputs for fastest response time
     but_RIGHT = (switches_raw & (1 << (int)Switch::Right)) != 0;
     but_LEFT = (switches_raw & (1 << (int)Switch::Left)) != 0;
     but_DOWN = (switches_raw & (1 << (int)Switch::Down)) != 0;
     but_UP = (switches_raw & (1 << (int)Switch::Up)) != 0;
-    but_A = (switches_raw & (1 << (int)Switch::Sel)) != 0;
+
+    // For the pause button, use the debounced input to avoid glitches, and OR in the value to make sure that we don't clear it before it's seen
+    but_A |= (switches_debounced & (1 << (int)Switch::Sel)) != 0;
 
     _game.Step();
 }


### PR DESCRIPTION
The select button was mysteriously getting triggered during game play (causing random pauses) since I recently changed it to use the raw switches.  Maybe I'm bumping it while using the adjacent keys, or maybe electrical crosstalk.  Either way, it works better if I use the debounced input for the pause button.

I'm continuing to use the raw switches input for the directional buttons to provide slightly better theoretical response.

(Also note that if you trigger a Pause while the cherries appear, then it won't actually say Pause because the cherries icon apparently takes precedence.  Not fixing that one at this time.)