### PR TITLE
added crc32 command to usb shell

### DIFF
--- a/firmware/application/usb_serial_shell_filesystem.cpp
+++ b/firmware/application/usb_serial_shell_filesystem.cpp
@@ -26,6 +26,8 @@
 #include "string_format.hpp"
 #include <cstring>
 
+#include "crc.hpp"
+
 static File* shell_file = nullptr;
 
 static bool report_on_error(BaseSequentialStream* chp, File::Error& error) {
@@ -370,4 +372,35 @@ void cmd_sd_write_binary(BaseSequentialStream* chp, int argc, char* argv[]) {
     } while (size > 0);
 
     chprintf(chp, "ok\r\n");
+}
+
+void cmd_sd_crc32(BaseSequentialStream* chp, int argc, char* argv[]) {
+    if (argc != 1) {
+        chprintf(chp, "usage: crc32 <path>\r\n");
+        return;
+    }
+
+    auto path = path_from_string8(argv[0]);
+    File* crc_file = new File();
+    auto error = crc_file->open(path, true, false);
+    if (report_on_error(chp, error)) return;
+
+    uint8_t buffer[64];
+    CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+
+    while (true) {
+        auto bytes_read = crc_file->read(buffer, 64);
+        if (report_on_error(chp, bytes_read)) return;
+
+        if (bytes_read.value() > 0) {
+            crc.process_bytes((void*)buffer, bytes_read.value());
+        }
+
+        if (64 != bytes_read.value()) {
+            chprintf(chp, "CRC32: 0x%08X\r\n", crc.checksum());
+            return;
+        }
+    }
+
+    delete crc_file;
 }

--- a/firmware/application/usb_serial_shell_filesystem.hpp
+++ b/firmware/application/usb_serial_shell_filesystem.hpp
@@ -42,6 +42,7 @@ void cmd_sd_read(BaseSequentialStream* chp, int argc, char* argv[]);
 void cmd_sd_read_binary(BaseSequentialStream* chp, int argc, char* argv[]);
 void cmd_sd_write(BaseSequentialStream* chp, int argc, char* argv[]);
 void cmd_sd_write_binary(BaseSequentialStream* chp, int argc, char* argv[]);
+void cmd_sd_crc32(BaseSequentialStream* chp, int argc, char* argv[]);
 
 static std::filesystem::path path_from_string8(char* path) {
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
@@ -62,6 +63,7 @@ static std::filesystem::path path_from_string8(char* path) {
     {"ftell", cmd_sd_tell},            \
     {"fread", cmd_sd_read},            \
     {"frb", cmd_sd_read_binary},       \
-    {"fwrite", cmd_sd_write},           \
-    {"fwb", cmd_sd_write_binary}
+    {"fwrite", cmd_sd_write},          \
+    {"fwb", cmd_sd_write_binary},      \
+    {"crc32", cmd_sd_crc32}
 // clang-format on


### PR DESCRIPTION
This pull request adds a new command to the usb shell: crc32

![grafik](https://github.com/portapack-mayhem/mayhem-firmware/assets/13151053/d8a38591-9c5f-41d8-8bb9-94f9614a38fe)
