### PR TITLE
Fix compiler warning in Calculator app

### DIFF
--- a/firmware/application/external/calculator/ivt.hpp
+++ b/firmware/application/external/calculator/ivt.hpp
@@ -1867,7 +1867,7 @@ static byte menuselect(byte lines) {  // Selection (1 line = 16 items)
 // *** S T A C K
 
 static void floatstack() {
-    memcpy(ds, &ds[1], (DATASTACKSIZE - 1) * sizeof(double));
+    memmove(ds, &ds[1], (DATASTACKSIZE - 1) * sizeof(double));
     dp--;
 }
 


### PR DESCRIPTION
Fixed compiler warning on this line.  The memmove() function supports overlapping copy operations, whereas the memcpy() function might or might not.

I can't figure out how to use the Calculator app either, but I didn't like seeing the compiler warning.  :-)