### PR TITLE
Remove unused text_info widget

### DIFF
--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -320,10 +320,6 @@ class BMPView : public View {
     void focus() override;
 
    private:
-    Text text_info{
-        {4 * 8, 284, 20 * 8, 16},
-        "Version " VERSION_STRING};
-
     Button button_done{
         {240, 0, 1, 1},
         ""};


### PR DESCRIPTION
Removed unused text_info widget with version string, as suggested by @zxkmm 

It wasn't using any code space, but it was just confusing since it didn't serve any purpose.