### PR TITLE
Show true M0 free heap space in DFU overlay

### DIFF
--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -38,23 +38,29 @@ DfuMenu::DfuMenu(NavigationView& nav)
                   &text_info_line_5,
                   &text_info_line_6,
                   &text_info_line_7,
-                  &text_info_line_8});
+                  &text_info_line_8,
+                  &text_info_line_9,
+                  &text_info_line_10});
 }
 
 void DfuMenu::paint(Painter& painter) {
     auto utilisation = get_cpu_utilisation_in_percent();
+    size_t m0_fragmented_free_space = 0;
+    const auto m0_fragments = chHeapStatus(NULL, &m0_fragmented_free_space);
 
     text_info_line_1.set(to_string_dec_uint(chCoreStatus(), 6));
-    text_info_line_2.set(to_string_dec_uint((uint32_t)get_free_stack_space(), 6));
-    text_info_line_3.set(to_string_dec_uint(utilisation, 6));
-    text_info_line_4.set(to_string_dec_uint(shared_memory.m4_heap_usage, 6));
-    text_info_line_5.set(to_string_dec_uint(shared_memory.m4_stack_usage, 6));
-    text_info_line_6.set(to_string_dec_uint(shared_memory.m4_performance_counter, 6));
-    text_info_line_7.set(to_string_dec_uint(shared_memory.m4_buffer_missed, 6));
-    text_info_line_8.set(to_string_dec_uint(chTimeNow() / 1000, 6));
+    text_info_line_2.set(to_string_dec_uint(m0_fragmented_free_space, 6));
+    text_info_line_3.set(to_string_dec_uint(m0_fragments, 6));
+    text_info_line_4.set(to_string_dec_uint((uint32_t)get_free_stack_space(), 6));
+    text_info_line_5.set(to_string_dec_uint(utilisation, 6));
+    text_info_line_6.set(to_string_dec_uint(shared_memory.m4_heap_usage, 6));
+    text_info_line_7.set(to_string_dec_uint(shared_memory.m4_stack_usage, 6));
+    text_info_line_8.set(to_string_dec_uint(shared_memory.m4_performance_counter, 6));
+    text_info_line_9.set(to_string_dec_uint(shared_memory.m4_buffer_missed, 6));
+    text_info_line_10.set(to_string_dec_uint(chTimeNow() / 1000, 6));
 
     constexpr auto margin = 5;
-    constexpr auto lines = 8 + 2;
+    constexpr auto lines = 10 + 2;
 
     painter.fill_rectangle(
         {{6 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -49,14 +49,16 @@ class DfuMenu : public View {
     Text text_head{{6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT, 11 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, "Performance"};
 
     Labels labels{
-        {{6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT}, "M0 heap:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 6 * LINE_HEIGHT}, "M0 stack:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 7 * LINE_HEIGHT}, "M0 cpu %:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 8 * LINE_HEIGHT}, "M4 heap:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 9 * LINE_HEIGHT}, "M4 stack:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 10 * LINE_HEIGHT}, "M4 cpu %:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 11 * LINE_HEIGHT}, "M4 miss:", Color::dark_cyan()},
-        {{6 * CHARACTER_WIDTH, 12 * LINE_HEIGHT}, "uptime:", Color::dark_cyan()}};
+        {{6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT}, "M0 core:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 6 * LINE_HEIGHT}, "M0 heap:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 7 * LINE_HEIGHT}, "M0 frags:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 8 * LINE_HEIGHT}, "M0 stack:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 9 * LINE_HEIGHT}, "M0 cpu %:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 10 * LINE_HEIGHT}, "M4 heap:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 11 * LINE_HEIGHT}, "M4 stack:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 12 * LINE_HEIGHT}, "M4 cpu %:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 13 * LINE_HEIGHT}, "M4 miss:", Color::dark_cyan()},
+        {{6 * CHARACTER_WIDTH, 14 * LINE_HEIGHT}, "uptime:", Color::dark_cyan()}};
 
     Text text_info_line_1{{15 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
     Text text_info_line_2{{15 * CHARACTER_WIDTH, 6 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
@@ -66,6 +68,8 @@ class DfuMenu : public View {
     Text text_info_line_6{{15 * CHARACTER_WIDTH, 10 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
     Text text_info_line_7{{15 * CHARACTER_WIDTH, 11 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
     Text text_info_line_8{{15 * CHARACTER_WIDTH, 12 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_9{{15 * CHARACTER_WIDTH, 13 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_10{{15 * CHARACTER_WIDTH, 14 * LINE_HEIGHT, 6 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
 };
 
 class DfuMenu2 : public View {


### PR DESCRIPTION
Previously the DFU overlay was showing M0 free "core" memory and labeling it "M0 heap".

In this PR, I have added the actual "M0 heap" memory space and fragment count to the DFU overlay, and re-labeled the free core memory "M0 core".