### PR TITLE
Adding Rx IQ error phase CAL to SPEC Audio_App

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -133,6 +133,23 @@ class SPECOptionsView : public View {
         1,
         ' ',
     };
+    Text text_rx_cal{
+        {19 * 8, 0 * 16, 11 * 8, 1 * 16},  // 18 (x col.) x char_size,  12 (length) x 8 blanking space to delete previous chars.
+        "Rx_IQ_CAL  "};
+    NumberField field_rx_iq_phase_cal_2837{
+        {28 * 8, 0 * 16},
+        2,
+        {0, 31},  // 5 bits IQ CAL phase adjustment.
+        1,
+        ' ',
+    };
+    NumberField field_rx_iq_phase_cal_2839{
+        {28 * 8, 0 * 16},
+        2,
+        {0, 63},  // 6 bits IQ CAL phase adjustment.
+        1,
+        ' ',
+    };
 };
 
 class AnalogAudioView : public View {
@@ -152,14 +169,22 @@ class AnalogAudioView : public View {
     uint16_t get_spec_trigger();
     void set_spec_trigger(uint16_t trigger);
 
+    uint8_t get_spec_iq_phase_calibration_value();
+    void set_spec_iq_phase_calibration_value(uint8_t cal_value);
+
    private:
     static constexpr ui::Dim header_height = 3 * 16;
 
     NavigationView& nav_;
     RxRadioState radio_state_{};
+    uint8_t iq_phase_calibration_value{15};  // initial default RX IQ phase calibration value , used for both max2837 & max2839
     app_settings::SettingsManager settings_{
-        "rx_audio", app_settings::Mode::RX,
-        app_settings::Options::UseGlobalTargetFrequency};
+        "rx_audio",
+        app_settings::Mode::RX,
+        app_settings::Options::UseGlobalTargetFrequency,
+        {
+            {"iq_phase_calibration"sv, &iq_phase_calibration_value},  // we are saving and restoring that CAL from Settings.
+        }};
 
     const Rect options_view_rect{0 * 8, 1 * 16, 30 * 8, 1 * 16};
     const Rect nbfm_view_rect{0 * 8, 1 * 16, 18 * 8, 1 * 16};

--- a/firmware/application/hw/max2837.cpp
+++ b/firmware/application/hw/max2837.cpp
@@ -150,7 +150,7 @@ void MAX2837::init() {
 }
 
 void MAX2837::set_tx_LO_iq_phase_calibration(const size_t v) {
-    /*  IQ phase deg CAL adj  (+4 ...-4)  in 32 steps (5 bits), 00000 = +4deg (Q lags I by 94degs, default), 01111 = +0deg, 11111 = -4deg (Q lags I by 86degs) */
+    /* TX IQ phase deg CAL adj  (+4 ...-4)  in 32 steps (5 bits), 00000 = +4deg (Q lags I by 94degs, default), 01111 = +0deg, 11111 = -4deg (Q lags I by 86degs) */
 
     // TX calibration , Logic pins , ENABLE, RXENABLE, TXENABLE = 1,0,1 (5dec), and  Reg address 16, D1 (CAL mode 1):DO (CHIP ENABLE 1)
     set_mode(Mode::Tx_Calibration);  // write to ram 3 LOGIC Pins .
@@ -324,13 +324,40 @@ bool MAX2837::set_frequency(const rf::Frequency lo_frequency) {
 
     return true;
 }
-
-void MAX2837::set_rx_lo_iq_calibration(const size_t v) {
+/*
+void MAX2837::set_rx_lo_iq_calibration(const size_t v) {        // Original code , rewritten below
     _map.r.rx_top_rx_bias.RX_IQERR_SPI_EN = 1;
     _dirty[Register::RX_TOP_RX_BIAS] = 1;
     _map.r.rxrf_2.iqerr_trim = v;
     _dirty[Register::RXRF_2] = 1;
     flush();
+}
+*/
+
+void MAX2837::set_rx_LO_iq_phase_calibration(const size_t v) {
+    /*  RX IQ phase deg CAL adj  (+4 ...-4)  in 32 steps (5 bits), 00000 = +4deg (Q lags I by 94degs, default), 01111 = +0deg, 11111 = -4deg (Q lags I by 86degs) */
+
+    // RX calibration , Logic pins , ENABLE, RXENABLE, TXENABLE = 1,1,0 (3dec), and  Reg address 16, D1 (CAL mode 1):DO (CHIP ENABLE 1)
+    set_mode(Mode::Rx_Calibration);  // write to ram 3 LOGIC Pins .
+
+    gpio_max283x_enable.output();
+    gpio_max2837_rxenable.output();
+    gpio_max2837_txenable.output();
+
+    _map.r.spi_en.CAL_SPI = 1;  // Register Settings reg address 16,  D1 (CAL mode 1)
+    _map.r.spi_en.EN_SPI = 1;   // Register Settings reg address 16,  DO (CHIP ENABLE 1)
+    flush_one(Register::SPI_EN);
+
+    _map.r.rx_top_rx_bias.RX_IQERR_SPI_EN = 1;  // reg 8 D9, RX LO IQ Phase calibration SPI control. Active when Address 8 D<9> = 1.
+    flush_one(Register::RX_TOP_RX_BIAS);
+
+    _map.r.rxrf_2.iqerr_trim = v;  // reg 1  D9:D5, RX LO I/Q Phase SPI 5 bits Adjust
+    flush_one(Register::RXRF_2);
+
+    // Exit  Calibration mode,  Go back to reg 16, D1:D0 , Out of CALIBRATION , back to default conditions, but keep CS activated.
+    _map.r.spi_en.CAL_SPI = 0;  // Register Settings reg address 16,  D1 (0 = Normal operation (default)
+    _map.r.spi_en.EN_SPI = 1;   // Register Settings reg address 16,  DO (1 = Chip select enable )
+    flush_one(Register::SPI_EN);
 }
 
 void MAX2837::set_rx_bias_trim(const size_t v) {

--- a/firmware/application/hw/max2837.hpp
+++ b/firmware/application/hw/max2837.hpp
@@ -828,7 +828,7 @@ class MAX2837 : public MAX283x {
 
     bool set_frequency(const rf::Frequency lo_frequency) override;
 
-    void set_rx_lo_iq_calibration(const size_t v) override;
+    void set_rx_LO_iq_phase_calibration(const size_t v) override;
     void set_tx_LO_iq_phase_calibration(const size_t v) override;
     void set_rx_bias_trim(const size_t v);
     void set_vco_bias(const size_t v);

--- a/firmware/application/hw/max2839.hpp
+++ b/firmware/application/hw/max2839.hpp
@@ -82,11 +82,11 @@ struct RXENABLE_Type {
 static_assert(sizeof(RXENABLE_Type) == sizeof(reg_t), "RXENABLE_Type wrong size");
 
 struct RXRF_1_Type {
-    reg_t LNAband : 1;
+    reg_t LNAband : 2;  // Datasheet says D1:D0 , 2 bits, maybe  D1 Rx_B,  D0 Rx_A  , (original code said wrongly ,reg_t LNAband : 1; that was of for max2837, not max2839 )
     reg_t RESERVED0 : 1;
     reg_t MIMOmode : 1;
-    reg_t iqerr_trim : 5;
-    reg_t RESERVED1 : 6;
+    reg_t iqerr_trim : 6;  // Datasheet says D9_D4 , that means 6 bits,  (original code said wrongly ,reg_t iqerr_trim : 5;  )
+    reg_t RESERVED1 : 6;   // we are using 16 bits , even top part mapping  is not used
 };
 
 static_assert(sizeof(RXRF_1_Type) == sizeof(reg_t), "RXRF_1_Type wrong size");
@@ -689,7 +689,7 @@ class MAX2839 : public MAX283x {
     void set_lpf_rf_bandwidth_rx(const uint32_t bandwidth_minimum) override;
     void set_lpf_rf_bandwidth_tx(const uint32_t bandwidth_minimum) override;
     bool set_frequency(const rf::Frequency lo_frequency) override;
-    void set_rx_lo_iq_calibration(const size_t v) override;
+    void set_rx_LO_iq_phase_calibration(const size_t v) override;
     void set_tx_LO_iq_phase_calibration(const size_t v) override;
     void set_rx_buff_vcm(const size_t v) override;
 

--- a/firmware/application/hw/max283x.hpp
+++ b/firmware/application/hw/max283x.hpp
@@ -125,7 +125,7 @@ class MAX283x {
 
     virtual bool set_frequency(const rf::Frequency lo_frequency);
 
-    virtual void set_rx_lo_iq_calibration(const size_t v);
+    virtual void set_rx_LO_iq_phase_calibration(const size_t v);
     virtual void set_tx_LO_iq_phase_calibration(const size_t v);
 
     virtual void set_rx_buff_vcm(const size_t v);

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -253,6 +253,10 @@ void set_tx_max283x_iq_phase_calibration(const size_t v) {
     second_if->set_tx_LO_iq_phase_calibration(v);
 }
 
+void set_rx_max283x_iq_phase_calibration(const size_t v) {
+    second_if->set_rx_LO_iq_phase_calibration(v);
+}
+
 /*void enable(Configuration configuration) {
     configure(configuration);
 }

--- a/firmware/application/radio.hpp
+++ b/firmware/application/radio.hpp
@@ -55,6 +55,7 @@ void set_baseband_filter_bandwidth_tx(const uint32_t bandwidth_minimum);
 void set_baseband_rate(const uint32_t rate);
 void set_antenna_bias(const bool on);
 void set_tx_max283x_iq_phase_calibration(const size_t v);
+void set_rx_max283x_iq_phase_calibration(const size_t v);
 
 /* Use ReceiverModel or TransmitterModel instead. */
 // void enable(Configuration configuration);


### PR DESCRIPTION
Hi , this PR is adding small feature : Rx IQ phase error CALIBRATION ,  to the Audio App RX ,( inside the submenu SPECTRUM. )

Special thanks to @NotherNgineer , who taught me to save / restore that Rx CAL variable to /settings/rx_audio.ini , and helped me to finalize that job . (and also thanks to @kallanreed , for writting all those save/restore settings functions) . 

This feature actually has negligible effect in most of receiver use cases . And  in that sense is more an advanced experimental  engineering feature , than a real practical user benefit .  But as it was  already available in the max2837 / max2839 IC, let's add it as a minor advanced feature . 
 
It actually can improve (8 to 10 dB's from worse CAL point to the best one )  the receiver Image Reject Ratio  only  in the Receiver Applications that are using Zero IF-frequency tuning ,  like :
             a-) Spectrum mode inside Audio_rx Application  (we are applying that Rx CAL feature here in that PR)  
             b-) and  Looking glass  (it could be added also there in future PR ) .

It will not have any benefit to the other Receivers that are using Freq offset tuning (to avoid DC spike ) , like : 
             a-) Capture App 
             b-) or the rest of  WFM, NBFM , AM audio receivers.

Let me show you,  a practical set up to allow and test that Rx IQ phase error CAL feature .
It is easy if you have some other reference RF signal generator (or a second TX Hackrf ).

The way to validate that RX IQ ERROR PHASE CALIBRATION ,
Set up :  (see below pictures) 

1-) You need to use  a  RX receiver App with that PR , using an App   that uses central freq IF tuning ==>   going to Audio RX and select SPEC mode , and keeping the blue selected SPEC cursor , we move the submenu cursor , going to  the additional feature field ,  to adj. Rx_IQ_CAL . You need to start the set up to 0 CAL (min value) 

2-) Then , we transmit with a closer second Hackrf TX  a carrier with some +xx   freq.offset  from central (example if the BW is 5Mhz , you can start with a +2 Mhz offset tx)  , and place some other Hackrf receiver close enough to  just receive strong signal (but adjusting the TX side not so strong  to not produce intermodulation , otherwise re-adjust reducing  tx or  rx ) , and not so weak ,  till just getting the carrier +freq. clean (desired carrier signal)  ,  and its  bare visible Image mirror  Signal (in the other symetrical -xx mirror freq . (unwanted Image signal to be minimized) 

3-) Then adjust  Rx IQ phase CAL till minimizing the received Image "mirror" signal .

We have already validated in both platforms : RX Hackrf r9 (max2839),  and RX old Hackrf <=r6 version (max2837) 

![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/86470699/04354e88-e06a-448c-b5d3-874dac2367d3)

![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/86470699/81f846bc-5a07-4054-af86-21b04c2093c4)


  




