### PR TITLE
Eliminate unnecessary NumberField to save code space

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -119,7 +119,7 @@ SPECOptionsView::SPECOptionsView(
         &text_speed,
         &field_speed,
         &text_rx_cal,
-        hackrf_r9 ? &field_rx_iq_phase_cal_2839 : &field_rx_iq_phase_cal_2837  // max2839 has 6 bits [0..63],  max2837 has 5 bits [0..31]
+        &field_rx_iq_phase_cal
     });
 
     options_config.set_selected_index(view->get_spec_bw_index());
@@ -132,17 +132,11 @@ SPECOptionsView::SPECOptionsView(
         view->set_spec_trigger(v);
     };
 
-    if (hackrf_r9) {                                                                        // MAX2839 has 6 bits RX IQ CAL phasse adjustment.
-        field_rx_iq_phase_cal_2839.set_value(view->get_spec_iq_phase_calibration_value());  // using  accessor function of AnalogAudioView to read iq_phase_calibration_value from rx_audio.ini
-        field_rx_iq_phase_cal_2839.on_change = [this, view](int32_t v) {
-            view->set_spec_iq_phase_calibration_value(v);  // using  accessor function of AnalogAudioView to write inside SPEC submenu, register value to max283x and save it to rx_audio.ini
-        };
-    } else {                                                                                // MAX2837 has 5 bits RX IQ CAL phase adjustment.
-        field_rx_iq_phase_cal_2837.set_value(view->get_spec_iq_phase_calibration_value());  // using  accessor function of AnalogAudioView to read iq_phase_calibration_value from rx_audio.ini
-        field_rx_iq_phase_cal_2837.on_change = [this, view](int32_t v) {
-            view->set_spec_iq_phase_calibration_value(v);  // using  accessor function of AnalogAudioView to write inside SPEC submenu, register value to max283x and save it to rx_audio.ini
-        };
-    }
+    field_rx_iq_phase_cal.set_range(0, hackrf_r9 ? 63 : 31);                       // max2839 has 6 bits [0..63],  max2837 has 5 bits [0..31]
+    field_rx_iq_phase_cal.set_value(view->get_spec_iq_phase_calibration_value());  // using  accessor function of AnalogAudioView to read iq_phase_calibration_value from rx_audio.ini
+    field_rx_iq_phase_cal.on_change = [this, view](int32_t v) {
+        view->set_spec_iq_phase_calibration_value(v);  // using  accessor function of AnalogAudioView to write inside SPEC submenu, register value to max283x and save it to rx_audio.ini
+    };
 }
 
 /* AnalogAudioView *******************************************************/

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -119,7 +119,7 @@ SPECOptionsView::SPECOptionsView(
         &text_speed,
         &field_speed,
         &text_rx_cal,
-        &field_rx_iq_phase_cal
+        &field_rx_iq_phase_cal,
     });
 
     options_config.set_selected_index(view->get_spec_bw_index());

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -136,17 +136,10 @@ class SPECOptionsView : public View {
     Text text_rx_cal{
         {19 * 8, 0 * 16, 11 * 8, 1 * 16},  // 18 (x col.) x char_size,  12 (length) x 8 blanking space to delete previous chars.
         "Rx_IQ_CAL  "};
-    NumberField field_rx_iq_phase_cal_2837{
+    NumberField field_rx_iq_phase_cal{
         {28 * 8, 0 * 16},
         2,
-        {0, 31},  // 5 bits IQ CAL phase adjustment.
-        1,
-        ' ',
-    };
-    NumberField field_rx_iq_phase_cal_2839{
-        {28 * 8, 0 * 16},
-        2,
-        {0, 63},  // 6 bits IQ CAL phase adjustment.
+        {0, 63},  // 5 or 6 bits IQ CAL phase adjustment (range updated later)
         1,
         ' ',
     };

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -338,7 +338,7 @@ MicTXView::MicTXView(
                   &field_rxlna,
                   &field_rxvga,
                   &field_rxamp,
-                  hackrf_r9 ? &field_tx_iq_phase_cal_2839 : &field_tx_iq_phase_cal_2837,
+                  &field_tx_iq_phase_cal,
                   &tx_button,
                   &tx_icon});
 
@@ -372,19 +372,12 @@ MicTXView::MicTXView(
     };
 
     radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
-    if (hackrf_r9) {  // MAX2839 has 6 bits IQ CAL phasse adjustment.
-        field_tx_iq_phase_cal_2839.set_value(iq_phase_calibration_value);
-        field_tx_iq_phase_cal_2839.on_change = [this](int32_t v) {
-            iq_phase_calibration_value = v;
-            radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
-        };
-    } else {  // MAX2837 has 5 bits IQ CAL phase adjustment.
-        field_tx_iq_phase_cal_2837.set_value(iq_phase_calibration_value);
-        field_tx_iq_phase_cal_2837.on_change = [this](int32_t v) {
-            iq_phase_calibration_value = v;
-            radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
-        };
-    }
+    field_tx_iq_phase_cal.set_range(0, hackrf_r9 ? 63 : 31);  // max2839 has 6 bits [0..63],  max2837 has 5 bits [0..31]
+    field_tx_iq_phase_cal.set_value(iq_phase_calibration_value);
+    field_tx_iq_phase_cal.on_change = [this](int32_t v) {
+        iq_phase_calibration_value = v;
+        radio::set_tx_max283x_iq_phase_calibration(iq_phase_calibration_value);
+    };
 
     options_gain.on_change = [this](size_t, int32_t v) {
         mic_gain_x10 = v;

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -342,18 +342,10 @@ class MicTXView : public View {
         ' ',
     };
 
-    NumberField field_tx_iq_phase_cal_2837{
+    NumberField field_tx_iq_phase_cal{
         {24 * 8, (33 * 8)},
         2,
-        {0, 31},  // 5 bits IQ CAL phase adjustment.
-        1,
-        ' ',
-    };
-
-    NumberField field_tx_iq_phase_cal_2839{
-        {24 * 8, (33 * 8)},
-        2,
-        {0, 63},  // 6 bits IQ CAL phasse adjustment.
+        {0, 63},  // 5 or 6 bits IQ CAL phase adjustment (range updated later)
         1,
         ' ',
     };


### PR DESCRIPTION
Eliminated extra NumberField in the iq_phase_calibration code to save 200 bytes of ROM space (as mentioned in PR #1963)

FYI, @Brumi-2021 