### PR TITLE
Level app: coloration of RxSat value

### DIFF
--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -174,20 +174,20 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     uint8_t rx_sat = ((uint32_t)shared_memory.m4_performance_counter) * 100 / 127;
     last_rx_sat = rx_sat;
     freq_stats_rx.set("RxSat: " + to_string_dec_uint(rx_sat) + "%");
-    uint8_t r = 0;
-    uint8_t g = 0;
-    uint8_t b = 0;
+    uint8_t br = 0;
+    uint8_t bg = 0;
+    uint8_t bb = 0;
     if (rx_sat <= 80) {
-        g = (255 * rx_sat) / 80;
-        b = 255 - g;
+        bg = (255 * rx_sat) / 80;
+        bb = 255 - bg;
     } else if (rx_sat > 80) {
-        r = (255 * (rx_sat - 80)) / 20;
-        g = 255 - r;
+        br = (255 * (rx_sat - 80)) / 20;
+        bg = 255 - br;
     }
     Style style_freq_stats_rx{
         .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = {r, g, b},
+        .background = {br, bg, bb},
+        .foreground = {255, 255, 255},
     };
     freq_stats_rx.set_style(&style_freq_stats_rx);
 

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -27,6 +27,7 @@
 #include "baseband_api.hpp"
 #include "file.hpp"
 #include "oversample.hpp"
+#include "ui_font_fixed_8x16.hpp"
 
 using namespace portapack;
 using namespace tonekey;
@@ -162,12 +163,6 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
         last_max_db = statistics.max_db;
         freq_stats_db.set("Power: " + to_string_dec_int(statistics.max_db) + " db");
     }
-    // refresh sat
-    uint8_t rx_sat = ((uint32_t)shared_memory.m4_performance_counter) * 100 / 127;
-    if (last_rx_sat != rx_sat) {
-        last_rx_sat = rx_sat;
-        freq_stats_rx.set("RxSat: " + to_string_dec_uint(rx_sat) + "%");
-    }
     // refresh rssi
     if (last_min_rssi != rssi_graph.get_graph_min() || last_avg_rssi != rssi_graph.get_graph_avg() || last_max_rssi != rssi_graph.get_graph_max()) {
         last_min_rssi = rssi_graph.get_graph_min();
@@ -175,6 +170,27 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
         last_max_rssi = rssi_graph.get_graph_max();
         freq_stats_rssi.set("RSSI: " + to_string_dec_uint(last_min_rssi) + "/" + to_string_dec_uint(last_avg_rssi) + "/" + to_string_dec_uint(last_max_rssi) + ", dt: " + to_string_dec_uint(rssi_graph.get_graph_delta()));
     }
+    // refresh sat
+    uint8_t rx_sat = ((uint32_t)shared_memory.m4_performance_counter) * 100 / 127;
+    last_rx_sat = rx_sat;
+    freq_stats_rx.set("RxSat: " + to_string_dec_uint(rx_sat) + "%");
+    uint8_t r = 0;
+    uint8_t g = 0;
+    uint8_t b = 0;
+    if (rx_sat <= 80) {
+        g = (255 * rx_sat) / 80;
+        b = 255 - g;
+    } else if (rx_sat > 80) {
+        r = (255 * (rx_sat - 80)) / 20;
+        g = 255 - r;
+    }
+    Style style_freq_stats_rx{
+        .font = font::fixed_8x16,
+        .background = Color::black(),
+        .foreground = {r, g, b},
+    };
+    freq_stats_rx.set_style(&style_freq_stats_rx);
+
 } /* on_statistic_updates */
 
 size_t LevelView::change_mode(freqman_index_t new_mod) {

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -116,12 +116,12 @@ class LevelView : public View {
 
     // RSSI: XX/XX/XXX,dt: XX
     Text freq_stats_rssi{
-        {0 * 8, 3 * 16 + 4, 22 * 8, 14},
+        {0 * 8, 3 * 16 + 4, 22 * 8, 1 * 16},
     };
 
     // Power: -XXX db
     Text freq_stats_db{
-        {0 * 8, 4 * 16 + 4, 14 * 8, 14},
+        {0 * 8, 4 * 16 + 4, 15 * 8, 1 * 16},
     };
 
     OptionsField peak_mode{
@@ -150,7 +150,7 @@ class LevelView : public View {
 
     // RxSat: XX%
     Text freq_stats_rx{
-        {0 * 8, 5 * 16 + 4, 10 * 8, 14},
+        {0 * 8, 5 * 16 + 4, 10 * 8, 1 * 16},
     };
 
     RSSIGraph rssi_graph{
@@ -160,7 +160,7 @@ class LevelView : public View {
 
     RSSI rssi{
         // 240x320  =>
-        {240 - 5 * 8, 5 * 16 + 4, 5 * 8, 320 - (5 * 16 + 4)},
+        {240 - 5 * 8, 6 * 16 + 4, 5 * 8, 320 - (6 * 16 + 4)},
     };
 
     void handle_coded_squelch(const uint32_t value);


### PR DESCRIPTION
That PR add a coloration of the whole "RxSat: XXX%" string, with the following rules:
- 80% of sat is the ideal value
- RxSat <= 80 => gradient from (rxSat 0,red) to (rxSat 80,green) 
- RxSat > 80 => gradient from (rxSat 80,green) to (rxSat 100,red) 
## Screenshots
![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/3157857/58220bf7-5fca-41ca-bcec-8cf310994a4d)![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/3157857/cfea6b70-8cfa-4511-9f9d-fcd1b670cbae)![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/3157857/2256a067-bd99-4604-958d-2d85cf454167)