### PR TITLE
In Audio app, update iq_phase_cal in radio when starting SPEC mode

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -137,6 +137,8 @@ SPECOptionsView::SPECOptionsView(
     field_rx_iq_phase_cal.on_change = [this, view](int32_t v) {
         view->set_spec_iq_phase_calibration_value(v);  // using  accessor function of AnalogAudioView to write inside SPEC submenu, register value to max283x and save it to rx_audio.ini
     };
+
+    view->set_spec_iq_phase_calibration_value(view->get_spec_iq_phase_calibration_value());  // initialize iq_phase_calibration in radio
 }
 
 /* AnalogAudioView *******************************************************/


### PR DESCRIPTION
The iq_phase_calibration value from the .ini file was not being programmed into the radio when starting Spec mode in the Audio app, therefore it was only taking effect if the user changed the value while SPEC mode was running.

Fixes this minor issue in PR #1963, per @Brumi-2021