### PR TITLE
freqman: limiting description size to 30, and minor fix

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -228,7 +228,7 @@ void FrequencyManagerView::on_edit_freq() {
 
 void FrequencyManagerView::on_edit_desc() {
     temp_buffer_ = current_entry().description;
-    text_prompt(nav_, temp_buffer_, desc_edit_max, [this](std::string& new_desc) {
+    text_prompt(nav_, temp_buffer_, freqman_max_desc_size, [this](std::string& new_desc) {
         auto entry = current_entry();
         entry.description = std::move(new_desc);
         db_.replace_entry(current_index(), entry);

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -61,11 +61,11 @@ class FreqManBaseView : public View {
 
     /* The top section (category) is 20px tall. */
     Labels label_category{
-        {{0, 2}, "Category:", Color::light_grey()}};
+        {{0, 2}, "F:", Color::light_grey()}};
 
     OptionsField options_category{
-        {9 * 8, 2},
-        14 /* length */,
+        {3 * 8, 2},
+        20 /* length */,
         {}};
 
     FreqManUIList freqlist_view{

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -40,8 +40,6 @@ class FreqManBaseView : public View {
 
     void focus() override;
 
-    static constexpr size_t desc_edit_max = 0x80;
-
    protected:
     using options_t = OptionsField::options_t;
 

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -376,7 +376,7 @@ bool parse_freqman_entry(std::string_view str, freqman_entry& entry) {
         } else if (key == "c") {
             entry.tone = parse_tone_key(value);
         } else if (key == "d") {
-            entry.description = trim(value);
+            entry.description = trim(value).substr(0, freqman_max_desc_size);
         } else if (key == "f") {
             entry.type = freqman_type::Single;
             parse_int(value, entry.frequency_a);
@@ -492,7 +492,7 @@ freqman_entry FreqmanDB::operator[](Index index) const {
             return entry;
         else if (read_raw_) {
             entry.type = freqman_type::Raw;
-            entry.description = trim(*line_text);
+            entry.description = trim(*line_text).substr(0, freqman_max_desc_size);
             return entry;
         }
     }

--- a/firmware/application/freqman_db.hpp
+++ b/firmware/application/freqman_db.hpp
@@ -162,6 +162,9 @@ std::string freqman_entry_get_step_string_short(freqman_index_t step);
  * ensure app memory stability. */
 constexpr size_t freqman_default_max_entries = 150;
 
+/* Limiting description to 30 as specified by the format */
+constexpr size_t freqman_max_desc_size = 30;
+
 struct freqman_load_options {
     /* Loads all entries when set to 0. */
     size_t max_entries{freqman_default_max_entries};


### PR DESCRIPTION
I refreshed the documentation and set back the limit of 30 characters per entry descriptions.
- TextEdit is also limited to 30.
- existing too long lines are untouched in file until edited.

Solves https://github.com/portapack-mayhem/mayhem-firmware/issues/1384

- Edited 'category' to only display "F: filename"

Solves https://github.com/portapack-mayhem/mayhem-firmware/issues/1363
