### PR TITLE
support "clean" files

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -450,7 +450,7 @@ void FileManagerView::on_rename(std::string_view hint) {
 
 void FileManagerView::on_delete() {
     if (is_directory(get_selected_full_path()) && !is_empty_directory(get_selected_full_path())) {
-        nav_.display_modal("Delete", "Directory not empty!");
+        nav_.display_modal("Delete", "Directory not empty;\nUse \"clean\" button\nto clean it first");
         return;
     }
 

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -402,6 +402,7 @@ void FileSaveView::refresh_widgets() {
 void FileManagerView::refresh_widgets(const bool v) {
     button_rename.hidden(v);
     button_delete.hidden(v);
+    button_clean.hidden(v);
     button_cut.hidden(v);
     button_copy.hidden(v);
     button_paste.hidden(v);
@@ -472,6 +473,51 @@ void FileManagerView::on_delete() {
                     reload_current();
             }
         });
+}
+
+void FileManagerView::on_clean() {
+    if (is_directory(get_selected_full_path()) && !is_empty_directory(get_selected_full_path())) {
+        ////selected a dir, who is not empty, del sub files
+        nav_.push<ModalMessageView>(
+            "Delete", "Will delete all sub files\nexclude sub-folders,\nin this folder\nAre you sure?", YESNO,
+            [this](bool choice) {
+                if (choice) {
+                    std::vector<std::filesystem::path> file_list;
+                    file_list = scan_root_files(get_selected_full_path(), u"*");
+
+                    for (const auto& file_name : file_list) {
+                        std::filesystem::path current_full_path = get_selected_full_path() / file_name;
+                        delete_file(current_full_path);
+                    }
+                    reload_current();
+                }
+            });
+    } else if (!is_directory(get_selected_full_path()) && !is_empty_directory(get_selected_full_path())) {
+        ////selected a file, will del it and all others in this dir
+        nav_.push<ModalMessageView>(
+            "Delete", "Will delete all files\nexclude sub-folders\nin this folder,\nAre you sure?", YESNO,
+            [this](bool choice) {
+                if (choice) {
+                    std::vector<std::filesystem::path> file_list;
+                    file_list = scan_root_files(get_selected_full_path().parent_path(), u"*");
+
+                    for (const auto& file_name : file_list) {
+                        std::filesystem::path current_full_path = get_selected_full_path().parent_path() / file_name;
+                        delete_file(current_full_path);
+                    }
+                    reload_current();
+                }
+            });
+
+    } else if (is_directory(get_selected_full_path()) && is_empty_directory(get_selected_full_path())) {
+        ////sel an empty dir, threw
+        nav_.display_modal("Forbid", "You selected an empty dir;\nUse delete button \ninstead of clean button\nto delete it");
+        return;
+    } else {
+        ////edge case e.g. probably . or .. (maybe not needed?)
+        nav_.display_modal("Forbid", "Not able to do that");
+        return;
+    }
 }
 
 void FileManagerView::on_new_dir() {
@@ -560,6 +606,7 @@ FileManagerView::FileManagerView(
         &text_date,
         &button_rename,
         &button_delete,
+        &button_clean,
         &button_cut,
         &button_copy,
         &button_paste,
@@ -604,6 +651,11 @@ FileManagerView::FileManagerView(
     button_delete.on_select = [this]() {
         if (selected_is_valid())
             on_delete();
+    };
+
+    button_clean.on_select = [this]() {
+        if (selected_is_valid())
+            on_clean();
     };
 
     button_cut.on_select = [this]() {

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -234,9 +234,9 @@ class FileManagerView : public FileManBaseView {
         Color::red()};
 
     NewButton button_clean{
-        {17 * 8, 34 * 8, 4 * 8, 32},
+        {13 * 8, 34 * 8, 4 * 8, 32},
         {},
-        &bitmap_icon_tools_wipesd,
+        &bitmap_icon_scanner,
         Color::red()};
 
     NewButton button_cut{
@@ -291,7 +291,7 @@ class FileManagerView : public FileManBaseView {
         Color::orange()};
 
     NewButton button_show_hidden_files{
-        {13 * 8, 34 * 8, 4 * 8, 32},
+        {17 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_hide,
         Color::dark_grey()};

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -207,6 +207,7 @@ class FileManagerView : public FileManBaseView {
     void refresh_widgets(const bool v);
     void on_rename(std::string_view hint);
     void on_delete();
+    void on_clean();
     void on_paste();
     void on_new_dir();
     void on_new_file();
@@ -227,9 +228,15 @@ class FileManagerView : public FileManBaseView {
         Color::dark_blue()};
 
     NewButton button_delete{
-        {4 * 8, 29 * 8, 4 * 8, 32},
+        {9 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_trash,
+        Color::red()};
+
+    NewButton button_clean{
+        {17 * 8, 34 * 8, 4 * 8, 32},
+        {},
+        &bitmap_icon_tools_wipesd,
         Color::red()};
 
     NewButton button_cut{
@@ -269,14 +276,16 @@ class FileManagerView : public FileManBaseView {
         Color::orange()};
 
     NewButton button_rename_timestamp{
-        {4 * 8, 34 * 8, 4 * 8, 32},
+
+        {4 * 8, 29 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_options_datetime,
         Color::orange(),
         /*vcenter*/ true};
 
     NewButton button_open_iq_trim{
-        {9 * 8, 34 * 8, 4 * 8, 32},
+
+        {4 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_trim,
         Color::orange()};


### PR DESCRIPTION
today when i'm debugging, i see it's extremely painful that can't recursive del files or at least del multiple files. (i need to clean up DEBUG dir.)

giving the fact that it COULD be dangerous to implement recursive del in simple way (for example when too much sub-levels in stack and it crashed at the half way by out of ram during del, which could leading damage filesystem),

i decided to implement this clean feature, which will do:

- select a dir to clean: del all sub-files exclude sub-dirs
- sel a file to clean: del all files in same dir, exclude dirs and sub-dirs
- forbid other situation like select `.` or `..` or `empty dir` etc.

tested with up to 200 files and it done very quick

CONSIDER THIS AS AN WORK AROUND, AND WHEN SOMEONE MADE BETTER IMPLEMENTATION, WE CAN REMOVE THIS FEAT.