### PR TITLE
Disabled unused baseband "no-op" process

### DIFF
--- a/firmware/application/external/calculator/main.cpp
+++ b/firmware/application/external/calculator/main.cpp
@@ -76,7 +76,7 @@ __attribute__((section(".external_app.app_calculator.application_information"), 
     /*.icon_color = */ ui::Color::yellow().v,
     /*.menu_location = */ app_location_t::UTILITIES,
 
-    /*.m4_app_tag = portapack::spi_flash::image_tag_noop */ {'\0', '\0', '\0', '\0'},  // optional
-    /*.m4_app_offset = */ 0x00000000,                                                  // will be filled at compile time
+    /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
 };
 }

--- a/firmware/application/external/font_viewer/main.cpp
+++ b/firmware/application/external/font_viewer/main.cpp
@@ -76,7 +76,7 @@ __attribute__((section(".external_app.app_font_viewer.application_information"),
     /*.icon_color = */ ui::Color::cyan().v,
     /*.menu_location = */ app_location_t::DEBUG,
 
-    /*.m4_app_tag = portapack::spi_flash::image_tag_noop */ {'\0', '\0', '\0', '\0'},
+    /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},
     /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
 };
 }

--- a/firmware/application/external/pacman/main.cpp
+++ b/firmware/application/external/pacman/main.cpp
@@ -76,7 +76,7 @@ __attribute__((section(".external_app.app_pacman.application_information"), used
     /*.icon_color = */ ui::Color::yellow().v,
     /*.menu_location = */ app_location_t::UTILITIES,
 
-    /*.m4_app_tag = portapack::spi_flash::image_tag_noop */ {'\0', '\0', '\0', '\0'},  // optional
-    /*.m4_app_offset = */ 0x00000000,                                                  // will be filled at compile time
+    /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
 };
 }

--- a/firmware/application/external/tetris/main.cpp
+++ b/firmware/application/external/tetris/main.cpp
@@ -76,7 +76,7 @@ __attribute__((section(".external_app.app_tetris.application_information"), used
     /*.icon_color = */ ui::Color::orange().v,
     /*.menu_location = */ app_location_t::UTILITIES,
 
-    /*.m4_app_tag = portapack::spi_flash::image_tag_noop */ {'\0', '\0', '\0', '\0'},  // optional
-    /*.m4_app_offset = */ 0x00000000,                                                  // will be filled at compile time
+    /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
 };
 }

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -290,7 +290,7 @@ macro(DeclareTargets chunk_tag name)
 			DEPENDS ${PROJECT_NAME}.elf ${MAKE_IMAGE_CHUNK}
 			VERBATIM
 		)
-		
+
 		set(BASEBAND_IMAGES ${BASEBAND_IMAGES} ${PROJECT_NAME}.img)
 
 	else()
@@ -434,12 +434,12 @@ set(MODE_CPPSRC
 )
 DeclareTargets(PNFM nfm_audio)
 
-### No op
-
-set(MODE_CPPSRC
-	proc_noop.cpp
-)
-DeclareTargets(PNOP no_operation)
+#### No op
+#
+#set(MODE_CPPSRC
+#	proc_noop.cpp
+#)
+#DeclareTargets(PNOP no_operation)
 
 ### OOK
 
@@ -519,7 +519,7 @@ set(MODE_CPPSRC
 )
 DeclareTargets(PWFM wfm_audio)
 
-### SubGhz Decoders 
+### SubGhz Decoders
 
 set(MODE_CPPSRC
 	proc_subghzd.cpp
@@ -554,7 +554,7 @@ set(MODE_INCDIR
 )
 set(MODE_CPPSRC
 	sd_over_usb/proc_sd_over_usb.cpp
-	
+
 	sd_over_usb/scsi.c
 	sd_over_usb/diskio.c
 	sd_over_usb/sd_over_usb.c
@@ -672,7 +672,7 @@ set(BASEBAND_IMAGES ${BASEBAND_IMAGES} terminator.img)
 #######################################################################
 
 project(baseband)
-	
+
 add_custom_command(
 	OUTPUT ${PROJECT_NAME}.img
 	COMMAND cat ${BASEBAND_IMAGES} > ${PROJECT_NAME}.img


### PR DESCRIPTION
Removing the unused no-op baseband process from the ROM saves 6KB of ROM space.

The external app changes are just to correct the comment (these apps didn't use the no-op process).

(Some trailing whitespace was also removed automatically when saving the CMakeLists.txt file)