### PR TITLE
Fix #1982 (enable DMA interrupt for all apps)

### DIFF
--- a/firmware/baseband/audio_dma.cpp
+++ b/firmware/baseband/audio_dma.cpp
@@ -203,7 +203,6 @@ void init_audio_out() {
     // LPC_GPDMA->SYNC |= (1 << gpdma_tx_peripheral);
     configure_tx();
     enable_tx();
-    nvicEnableVector(DMA_IRQn, CORTEX_PRIORITY_MASK(LPC_DMA_IRQ_PRIORITY));
 }
 
 void init_audio_in() {
@@ -211,7 +210,6 @@ void init_audio_in() {
     // LPC_GPDMA->SYNC |= (1 << gpdma_rx_peripheral);
     configure_rx();
     enable_rx();
-    nvicEnableVector(DMA_IRQn, CORTEX_PRIORITY_MASK(LPC_DMA_IRQ_PRIORITY));
 }
 
 void disable() {

--- a/firmware/baseband/baseband.cpp
+++ b/firmware/baseband/baseband.cpp
@@ -30,6 +30,7 @@
 
 static void init() {
     // Audio DMA initialization was moved to baseband proc's that actually use DMA audio, to save memory.
+    nvicEnableVector(DMA_IRQn, CORTEX_PRIORITY_MASK(LPC_DMA_IRQ_PRIORITY));
 }
 
 static void halt() {


### PR DESCRIPTION
Fix for PR #1982 oops -- looks like DMA interrupts need to be enabled for apps that don't use audio too.