### PR TITLE
Record gps lat, lon, satinuse from recorder app if there was gps signal.

### DIFF
--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -461,6 +461,15 @@ std::string path::string() const {
     return conv.to_bytes(native());
 }
 
+// appends a string to the end of filename, but leaves the extension asd.txt + "fg" -> asdfg.txt
+path& path::append_filename(const string_type& str) {
+    const auto t = extension().native();
+    _s.erase(_s.size() - t.size());  // remove extension
+    _s += str;                       // append string
+    _s += t;                         // add back extension
+    return *this;
+}
+
 path& path::replace_extension(const path& replacement) {
     const auto t = extension().native();
     _s.erase(_s.size() - t.size());

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -155,6 +155,8 @@ struct path {
 
     path& replace_extension(const path& replacement = path());
 
+    path& append_filename(const string_type& str);
+
    private:
     string_type _s;
 };

--- a/firmware/application/metadata_file.hpp
+++ b/firmware/application/metadata_file.hpp
@@ -29,6 +29,9 @@
 struct capture_metadata {
     rf::Frequency center_frequency;
     uint32_t sample_rate;
+    float latitude = 0;
+    float longitude = 0;
+    uint8_t satinuse = 0;
 };
 
 std::filesystem::path get_metadata_path(const std::filesystem::path& capture_path);
@@ -36,4 +39,5 @@ std::filesystem::path get_metadata_path(const std::filesystem::path& capture_pat
 Optional<File::Error> write_metadata_file(const std::filesystem::path& path, capture_metadata metadata);
 Optional<capture_metadata> read_metadata_file(const std::filesystem::path& path);
 
+bool parse_float_meta(std::string_view str, float& out_val);
 #endif  // __METADATA_FILE_HPP__

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -205,6 +205,11 @@ void RecordView::start() {
         return;
     }
 
+    // check for geo data, if present append filename with _GEO
+    if (latitude != 0 && longitude != 0 && latitude < 200 && longitude < 200) {
+        base_path.append_filename(u"_GEO");
+    }
+
     std::unique_ptr<stream::Writer> writer;
     switch (file_type) {
         case FileType::WAV: {

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -223,7 +223,7 @@ void RecordView::start() {
         case FileType::RawS8:
         case FileType::RawS16: {
             const auto metadata_file_error = write_metadata_file(
-                get_metadata_path(base_path), {receiver_model.target_frequency(), sampling_rate});
+                get_metadata_path(base_path), {receiver_model.target_frequency(), sampling_rate, latitude, longitude, satinuse});
             if (metadata_file_error.is_valid()) {
                 handle_error(metadata_file_error.value());
                 return;
@@ -340,6 +340,12 @@ void RecordView::trim_capture() {
     }
 
     trim_path = {};
+}
+
+void RecordView::on_gps(const GPSPosDataMessage* msg) {
+    latitude = msg->lat;
+    longitude = msg->lon;
+    satinuse = msg->satinuse;
 }
 
 void RecordView::handle_capture_thread_done(const File::Error error) {

--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -88,12 +88,17 @@ class RecordView : public View {
 
     OversampleRate get_oversample_rate(uint32_t sample_rate);
 
+    void on_gps(const GPSPosDataMessage* msg);
     // bool pitch_rssi_enabled = false;
 
     // Time Stamp
     bool filename_date_frequency = false;
     bool filename_as_is = false;
     rtc::RTC datetime{};
+
+    float latitude = 0;  // for wardriwing with ext module
+    float longitude = 0;
+    uint8_t satinuse = 0;  // to see if there was enough sats used or not
 
     const std::filesystem::path filename_stem_pattern;
     const std::filesystem::path folder;
@@ -146,6 +151,13 @@ class RecordView : public View {
         [this](const Message* const p) {
             const auto message = *reinterpret_cast<const CaptureThreadDoneMessage*>(p);
             this->handle_capture_thread_done(message.error);
+        }};
+
+    MessageHandlerRegistration message_handler_gps{
+        Message::ID::GPSPosData,
+        [this](Message* const p) {
+            const auto message = static_cast<const GPSPosDataMessage*>(p);
+            this->on_gps(message);
         }};
 };
 

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -905,8 +905,8 @@ static void cmd_cpld_read(BaseSequentialStream* chp, int argc, char* argv[]) {
 }
 
 static void cmd_gotgps(BaseSequentialStream* chp, int argc, char* argv[]) {
-    const char* usage = "usage: gotgps <lat> <lon> [altitude] [speed]\r\n";
-    if (argc < 2 || argc > 4) {
+    const char* usage = "usage: gotgps <lat> <lon> [altitude] [speed] [satinuse]\r\n";
+    if (argc < 2 || argc > 5) {
         chprintf(chp, usage);
         return;
     }
@@ -914,9 +914,11 @@ static void cmd_gotgps(BaseSequentialStream* chp, int argc, char* argv[]) {
     float lon = atof(argv[1]);
     int32_t altitude = 0;
     int32_t speed = 0;
+    uint8_t satinuse = 0;
     if (argc >= 3) altitude = strtol(argv[2], NULL, 10);
     if (argc >= 4) speed = strtol(argv[3], NULL, 10);
-    GPSPosDataMessage msg{lat, lon, altitude, speed};
+    if (argc >= 5) satinuse = strtol(argv[4], NULL, 10);
+    GPSPosDataMessage msg{lat, lon, altitude, speed, satinuse};
     EventDispatcher::send_message(msg);
     chprintf(chp, "ok\r\n");
 }

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -1313,17 +1313,20 @@ class GPSPosDataMessage : public Message {
         float lat = 200.0,
         float lon = 200.0,
         int32_t altitude = 0,
-        int32_t speed = 0)
+        int32_t speed = 0,
+        uint8_t satinuse = 0)
         : Message{ID::GPSPosData},
           lat{lat},
           lon{lon},
           altitude{altitude},
-          speed{speed} {
+          speed{speed},
+          satinuse{satinuse} {
     }
     float lat = 200.0;
     float lon = 200.0;
     int32_t altitude = 0;
     int32_t speed = 0;
+    uint8_t satinuse = 0;
 };
 
 class OrientationDataMessage : public Message {


### PR DESCRIPTION
Added the ability to Recorder to store GPS data with recordings.
If an external GPS module present and sent valid data while the app was open (before start recording) it stores the latitude, longitude, and sats in use data to the metadata file (txt).

If the recording has GPS data, the filename will be appended with _GEO, so users will notice, if they share it, it can have sensitive data.

If you record multiple signals, and the GPS module works fine, each recording will have the latest gps data.

This PR is only to store the coordinates, no display! 
Great for wardriving.

Requested here:
https://github.com/portapack-mayhem/mayhem-firmware/issues/1966

For that issue, there could be an external app that loads the TXTs from capture folder, and what file has coordinates, those could be added to a map. I don't wanted to integrate this to any exists app, not to confuse users without ext GPS.
