### PR TITLE
added all and all-safe attack types to blespam

### DIFF
--- a/firmware/application/external/blespam/ui_blespam.cpp
+++ b/firmware/application/external/blespam/ui_blespam.cpp
@@ -509,6 +509,44 @@ void BLESpamView::createFastPairPacket() {
     std::copy(res.begin(), res.end(), advertisementData);
 }
 
+void BLESpamView::createAnyPacket(bool safe) {
+    ATK_TYPE type[] = {
+        ATK_ANDROID,
+        ATK_IOS,
+        ATK_WINDOWS,
+        ATK_SAMSUNG,
+        ATK_IOS_CRASH};
+    ATK_TYPE attackType = type[rand() % (COUNT_OF(type) - (1 ? safe : 0))];
+    createPacket(attackType);
+}
+
+void BLESpamView::createPacket(ATK_TYPE attackType) {
+    switch (attackType) {
+        case ATK_IOS_CRASH:
+            createIosPacket(true);
+            break;
+        case ATK_IOS:
+            createIosPacket(false);
+            break;
+        case ATK_SAMSUNG:
+            createSamsungPacket();
+            break;
+        case ATK_WINDOWS:
+            createWindowsPacket();
+            break;
+        case ATK_ALL_SAFE:
+            createAnyPacket(true);
+            break;
+        case ATK_ALL:
+            createAnyPacket(false);
+            break;
+        default:
+        case ATK_ANDROID:
+            createFastPairPacket();
+            break;
+    }
+}
+
 void BLESpamView::changePacket(bool forced = false) {
     counter++;  // need to send it multiple times to be accepted
     if (counter >= 4 || forced) {
@@ -517,24 +555,7 @@ void BLESpamView::changePacket(bool forced = false) {
         randomizeMac();
         randomChn();
         if (randomDev || forced) {
-            switch (attackType) {
-                case ATK_IOS_CRASH:
-                    createIosPacket(true);
-                    break;
-                case ATK_IOS:
-                    createIosPacket(false);
-                    break;
-                case ATK_SAMSUNG:
-                    createSamsungPacket();
-                    break;
-                case ATK_WINDOWS:
-                    createWindowsPacket();
-                    break;
-                default:
-                case ATK_ANDROID:
-                    createFastPairPacket();
-                    break;
-            }
+            createPacket(attackType);
         }
 // rate limit console display
 #ifdef BLESPMUSECONSOLE

--- a/firmware/application/external/blespam/ui_blespam.hpp
+++ b/firmware/application/external/blespam/ui_blespam.hpp
@@ -49,7 +49,9 @@ enum ATK_TYPE {
     ATK_IOS,
     ATK_IOS_CRASH,
     ATK_WINDOWS,
-    ATK_SAMSUNG
+    ATK_SAMSUNG,
+    ATK_ALL_SAFE,
+    ATK_ALL
 };
 enum PKT_TYPE {
     PKT_TYPE_INVALID_TYPE,
@@ -124,7 +126,9 @@ class BLESpamView : public View {
          {"iOs", 1},
          {"iOs crash", 2},
          {"Windows", 3},
-         {"Samsung", 4}}};
+         {"Samsung", 4},
+         {"All-Safe", 5},
+         {"All", 6}}};
 
     bool is_running{false};
 
@@ -148,6 +152,8 @@ class BLESpamView : public View {
     void createIosPacket(bool crash);
     void createSamsungPacket();
     void createWindowsPacket();
+    void createAnyPacket(bool safe);
+    void createPacket(ATK_TYPE attackType);
     void changePacket(bool forced);
     void on_tx_progress(const bool done);
 


### PR DESCRIPTION
Extended the BLEspam attack types to support All and All-Safe (all except iOS crash) which will randomly pick between the attack types. This will allow the spammer to work without knowing the target device type.