### PR TITLE
Modified FileMan button colors for visibility

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -694,7 +694,7 @@ FileManagerView::FileManagerView(
 
     button_show_hidden_files.on_select = [this]() {
         show_hidden_files = !show_hidden_files;
-        button_show_hidden_files.set_color(show_hidden_files ? Color::green() : Color::dark_grey());
+        button_show_hidden_files.set_color(show_hidden_files ? Color::dark_green() : Color::dark_grey());
         reload_current();
     };
 }

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -261,26 +261,26 @@ class FileManagerView : public FileManBaseView {
         {22 * 8, 29 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_new_dir,
-        Color::green()};
+        Color::dark_green()};
 
     NewButton button_new_file{
         {26 * 8, 29 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_new_file,
-        Color::green()};
+        Color::dark_green()};
 
     NewButton button_open_notepad{
         {0 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_notepad,
-        Color::orange()};
+        Color::dark_orange()};
 
     NewButton button_rename_timestamp{
 
         {4 * 8, 29 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_options_datetime,
-        Color::orange(),
+        Color::dark_blue(),
         /*vcenter*/ true};
 
     NewButton button_open_iq_trim{
@@ -288,7 +288,7 @@ class FileManagerView : public FileManBaseView {
         {4 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_trim,
-        Color::orange()};
+        Color::dark_orange()};
 
     NewButton button_show_hidden_files{
         {17 * 8, 34 * 8, 4 * 8, 32},


### PR DESCRIPTION
1.  Darkened the foreground color of button icons that were difficult to see.
2.  Changed the "rename_timestamp" button icon to the same foreground color as "rename" (blue).

I'm not sure at what point these button icons were made difficult to see (did "NewButton" background color get brighter?), but these simple foreground color changes makes the icons much easier to see.

Fixes #1989 

Test firmware available here:
https://discord.com/channels/719669764804444213/722101917135798312/1219496508400078899