### PR TITLE
Stop audio DMA in baseband::shutdown()

### DIFF
--- a/firmware/baseband/baseband.cpp
+++ b/firmware/baseband/baseband.cpp
@@ -27,6 +27,7 @@
 #include "portapack_dma.hpp"
 
 #include "gpdma.hpp"
+#include "audio_dma.hpp"
 
 static void init() {
     // Audio DMA initialization was moved to baseband proc's that actually use DMA audio, to save memory.
@@ -64,6 +65,8 @@ void __late_init(void) {
 
 void _default_exit(void) {
     // TODO: Is this complete?
+
+    audio::dma::disable();
 
     nvicDisableVector(DMA_IRQn);
 


### PR DESCRIPTION
Fixes a longstanding issue that the audio DMA engines, once started, continued to run freely after baseband::shutdown() was called.  It wasn't as much of an issue before PR's #1982 and #1987 because all background processes were starting both audio-input and audio-output DMA engines and letting them run forever.

This issue was causing the Microphone app to crash when switching between baseband processes that perform DMA operations in different directions.  

Fixes #1998

Test firmware available here:  https://discord.com/channels/719669764804444213/722101917135798312/1219496508400078899