### PR TITLE
Added beep duration parameter

### DIFF
--- a/firmware/baseband/audio_dma.hpp
+++ b/firmware/baseband/audio_dma.hpp
@@ -47,7 +47,7 @@ void init_audio_in();
 void init_audio_out();
 void disable();
 void shrink_tx_buffer(bool shrink);
-void beep_start(uint32_t freq, uint32_t sample_rate);
+void beep_start(uint32_t freq, uint32_t sample_rate, uint32_t beep_duration_ms);
 void beep_stop();
 
 audio::buffer_t tx_empty_buffer();

--- a/firmware/baseband/proc_sonde.cpp
+++ b/firmware/baseband/proc_sonde.cpp
@@ -59,7 +59,7 @@ void SondeProcessor::on_message(const Message* const msg) {
         case Message::ID::RequestSignal:
             if ((*reinterpret_cast<const RequestSignalMessage*>(msg)).signal == RequestSignalMessage::Signal::BeepRequest) {
                 float rssi_ratio = (float)last_rssi / (float)RSSI_CEILING;
-                int beep_duration = 0;
+                uint32_t beep_duration = 0;
 
                 if (rssi_ratio <= PROPORTIONAL_BEEP_THRES) {
                     beep_duration = BEEP_MIN_DURATION;
@@ -69,9 +69,7 @@ void SondeProcessor::on_message(const Message* const msg) {
                     beep_duration = BEEP_DURATION_RANGE + BEEP_MIN_DURATION;
                 }
 
-                audio::dma::beep_start(beep_freq, AUDIO_SAMPLE_RATE);
-                chThdSleepMilliseconds(beep_duration);
-                audio::dma::beep_stop();
+                audio::dma::beep_start(beep_freq, AUDIO_SAMPLE_RATE, beep_duration);
             }
             break;
 


### PR DESCRIPTION
Added a beep duration parameter (DMA interrupt down-counter) so that the background task won't have to hang in the message handler waiting for the beep time to elapse.

Related to PR #2012 and enhancement suggestion #1973.

(The audio quality is still lacking, so I will be working on that.)