### PR TITLE
Radiosonde beep tone tweaks

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -131,8 +131,8 @@ void MicTXView::set_tx(bool enable) {
     } else {
         if (transmitting && rogerbeep_enabled) {
             baseband::request_beep(RequestSignalMessage::Signal::RogerBeepRequest);  // Transmit the roger beep
-            transmitting = false;      // And flag the end of the transmission so ...
-        } else {                       // (if roger beep was enabled, this will be executed after the beep ends transmitting.
+            transmitting = false;                                                    // Flag the end of the transmission (transmitter will be disabled after the beep)
+        } else {
             transmitting = false;
             configure_baseband();
             transmitter_model.disable();

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -130,7 +130,7 @@ void MicTXView::set_tx(bool enable) {
         portapack::pin_i2s0_rx_sda.mode(3);  // This is already done in audio::init but gets changed by the CPLD overlay reprogramming
     } else {
         if (transmitting && rogerbeep_enabled) {
-            baseband::request_beep();  // Transmit the roger beep
+            baseband::request_beep(RequestSignalMessage::Signal::RogerBeepRequest);  // Transmit the roger beep
             transmitting = false;      // And flag the end of the transmission so ...
         } else {                       // (if roger beep was enabled, this will be executed after the beep ends transmitting.
             transmitting = false;

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -130,8 +130,8 @@ void MicTXView::set_tx(bool enable) {
         portapack::pin_i2s0_rx_sda.mode(3);  // This is already done in audio::init but gets changed by the CPLD overlay reprogramming
     } else {
         if (transmitting && rogerbeep_enabled) {
-            baseband::request_beep(RequestSignalMessage::Signal::RogerBeepRequest);  // Transmit the roger beep
-            transmitting = false;                                                    // Flag the end of the transmission (transmitter will be disabled after the beep)
+            baseband::request_roger_beep();  // Transmit the roger beep
+            transmitting = false;            // Flag the end of the transmission (transmitter will be disabled after the beep)
         } else {
             transmitting = false;
             configure_baseband();

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2017 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -70,16 +70,19 @@ SondeView::SondeView(NavigationView& nav)
 
     geopos.set_read_only(true);
 
+    check_beep.set_value(beep);
     check_beep.on_select = [this](Checkbox&, bool v) {
         beep = v;
         if (v)
             baseband::request_beep(RequestSignalMessage::Signal::SimpleAudioBeepRequest);
     };
 
+    check_log.set_value(logging);
     check_log.on_select = [this](Checkbox&, bool v) {
         logging = v;
     };
 
+    check_crc.set_value(use_crc);
     check_crc.on_select = [this](Checkbox&, bool v) {
         use_crc = v;
     };

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -74,8 +74,8 @@ SondeView::SondeView(NavigationView& nav)
     check_beep.set_value(beep);
     check_beep.on_select = [this](Checkbox&, bool v) {
         beep = v;
-        if (v)
-            baseband::request_beep(RequestSignalMessage::Signal::SimpleAudioBeepRequest);
+        if (beep)
+            baseband::request_audio_beep(1000, 60);  // 1khz tone for 60ms to acknowledge enablement
     };
 
     check_log.set_value(logging);
@@ -226,7 +226,7 @@ void SondeView::on_packet(const sonde::Packet& packet) {
         }
 
         if (beep) {
-            baseband::request_beep(RequestSignalMessage::Signal::RSSIBeepRequest);
+            baseband::request_rssi_beep();
         }
     }
 }

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -73,7 +73,7 @@ SondeView::SondeView(NavigationView& nav)
     check_beep.on_select = [this](Checkbox&, bool v) {
         beep = v;
         if (v)
-            baseband::request_beep();
+            baseband::request_beep(RequestSignalMessage::Signal::SimpleAudioBeepRequest);
     };
 
     check_log.on_select = [this](Checkbox&, bool v) {
@@ -222,7 +222,7 @@ void SondeView::on_packet(const sonde::Packet& packet) {
         }
 
         if (beep) {
-            baseband::request_beep();
+            baseband::request_beep(RequestSignalMessage::Signal::RSSIBeepRequest);
         }
     }
 }

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2017 Furrtek
+ * Copyright (C) 2024 Mark Thompson
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -74,13 +74,19 @@ class SondeView : public View {
         1750000 /* bandwidth */,
         2457600 /* sampling rate */
     };
-    app_settings::SettingsManager settings_{
-        "rx_sonde", app_settings::Mode::RX};
-
-    std::unique_ptr<SondeLogger> logger{};
+    bool beep{false};
     bool logging{false};
     bool use_crc{false};
-    bool beep{false};
+    app_settings::SettingsManager settings_{
+        "rx_sonde",
+        app_settings::Mode::RX,
+        {
+            {"beep"sv, &beep},
+            {"logging"sv, &logging},
+            {"use_crc"sv, &use_crc},
+        }};
+
+    std::unique_ptr<SondeLogger> logger{};
 
     char geo_uri[32] = {};
 

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -433,4 +433,21 @@ void request_beep(RequestSignalMessage::Signal beep_type) {
     send_message(&message);
 }
 
+void request_roger_beep() {
+    request_beep(RequestSignalMessage::Signal::RogerBeepRequest);
+}
+
+void request_rssi_beep() {
+    request_beep(RequestSignalMessage::Signal::RSSIBeepRequest);
+}
+
+void request_beep_stop() {
+    request_beep(RequestSignalMessage::Signal::BeepStopRequest);
+}
+
+void request_audio_beep(uint32_t freq, uint32_t duration_ms) {
+    AudioBeepMessage message{freq, duration_ms};
+    send_message(&message);
+}
+
 } /* namespace baseband */

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -428,8 +428,8 @@ void replay_stop() {
     send_message(&message);
 }
 
-void request_beep() {
-    RequestSignalMessage message{RequestSignalMessage::Signal::BeepRequest};
+void request_beep(RequestSignalMessage::Signal beep_type) {
+    RequestSignalMessage message{beep_type};
     send_message(&message);
 }
 

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -89,7 +89,11 @@ void set_siggen_tone(const uint32_t tone);
 void set_siggen_config(const uint32_t bw, const uint32_t shape, const uint32_t duration);
 void set_spectrum_painter_config(const uint16_t width, const uint16_t height, bool update, int32_t bw);
 void set_subghzd_config(uint8_t modulation, uint32_t sampling_rate);
-void request_beep(RequestSignalMessage::Signal beep_type);
+
+void request_roger_beep();
+void request_rssi_beep();
+void request_beep_stop();
+void request_audio_beep(uint32_t freq, uint32_t duration_ms);
 
 void run_image(const portapack::spi_flash::image_tag_t image_tag);
 void run_prepared_image(const uint32_t m4_code);

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -89,7 +89,7 @@ void set_siggen_tone(const uint32_t tone);
 void set_siggen_config(const uint32_t bw, const uint32_t shape, const uint32_t duration);
 void set_spectrum_painter_config(const uint16_t width, const uint16_t height, bool update, int32_t bw);
 void set_subghzd_config(uint8_t modulation, uint32_t sampling_rate);
-void request_beep();
+void request_beep(RequestSignalMessage::Signal beep_type);
 
 void run_image(const portapack::spi_flash::image_tag_t image_tag);
 void run_prepared_image(const uint32_t m4_code);

--- a/firmware/baseband/proc_mictx.cpp
+++ b/firmware/baseband/proc_mictx.cpp
@@ -155,7 +155,7 @@ void MicTXProcessor::on_message(const Message* const msg) {
             break;
 
         case Message::ID::RequestSignal:
-            if (request_message.signal == RequestSignalMessage::Signal::BeepRequest) {
+            if (request_message.signal == RequestSignalMessage::Signal::RogerBeepRequest) {
                 beep_index = 0;
                 beep_timer = 0;
                 play_beep = true;

--- a/firmware/baseband/proc_sonde.cpp
+++ b/firmware/baseband/proc_sonde.cpp
@@ -57,26 +57,15 @@ void SondeProcessor::execute(const buffer_c8_t& buffer) {
 void SondeProcessor::on_message(const Message* const msg) {
     switch (msg->id) {
         case Message::ID::RequestSignal:
-            if ((*reinterpret_cast<const RequestSignalMessage*>(msg)).signal == RequestSignalMessage::Signal::RSSIBeepRequest) {
-                float rssi_ratio = (float)last_rssi / RSSI_CEILING;
-                uint32_t beep_duration = 0;
+            on_signal_message(*reinterpret_cast<const RequestSignalMessage*>(msg));
+            break;
 
-                if (rssi_ratio <= PROPORTIONAL_BEEP_THRES) {
-                    beep_duration = BEEP_MIN_DURATION;
-                } else if (rssi_ratio < 1) {
-                    beep_duration = rssi_ratio * BEEP_DURATION_RANGE + BEEP_MIN_DURATION;
-                } else {
-                    beep_duration = BEEP_DURATION_RANGE + BEEP_MIN_DURATION;
-                }
-
-                audio::dma::beep_start(beep_freq, AUDIO_SAMPLE_RATE, beep_duration);
-            } else if ((*reinterpret_cast<const RequestSignalMessage*>(msg)).signal == RequestSignalMessage::Signal::SimpleAudioBeepRequest) {
-                audio::dma::beep_start(BEEP_SIMPLE_FREQ, AUDIO_SAMPLE_RATE, BEEP_MIN_DURATION);
-            }
+        case Message::ID::AudioBeep:
+            on_beep_message(*reinterpret_cast<const AudioBeepMessage*>(msg));
             break;
 
         case Message::ID::PitchRSSIConfigure:
-            pitch_rssi_config(*reinterpret_cast<const PitchRSSIConfigureMessage*>(msg));
+            on_pitch_rssi_config(*reinterpret_cast<const PitchRSSIConfigureMessage*>(msg));
             break;
 
         default:
@@ -84,7 +73,28 @@ void SondeProcessor::on_message(const Message* const msg) {
     }
 }
 
-void SondeProcessor::pitch_rssi_config(const PitchRSSIConfigureMessage& message) {
+void SondeProcessor::on_signal_message(const RequestSignalMessage& message) {
+    if (message.signal == RequestSignalMessage::Signal::RSSIBeepRequest) {
+        float rssi_ratio = (float)last_rssi / RSSI_CEILING;
+        uint32_t beep_duration = 0;
+
+        if (rssi_ratio <= PROPORTIONAL_BEEP_THRES) {
+            beep_duration = BEEP_MIN_DURATION;
+        } else if (rssi_ratio < 1) {
+            beep_duration = rssi_ratio * BEEP_DURATION_RANGE + BEEP_MIN_DURATION;
+        } else {
+            beep_duration = BEEP_DURATION_RANGE + BEEP_MIN_DURATION;
+        }
+
+        audio::dma::beep_start(beep_freq, AUDIO_SAMPLE_RATE, beep_duration);
+    }
+}
+
+void SondeProcessor::on_beep_message(const AudioBeepMessage& message) {
+    audio::dma::beep_start(message.freq, AUDIO_SAMPLE_RATE, message.duration_ms);
+}
+
+void SondeProcessor::on_pitch_rssi_config(const PitchRSSIConfigureMessage& message) {
     pitch_rssi_enabled = message.enabled;
 
     beep_freq = message.rssi * RSSI_PITCH_WEIGHT + BEEP_BASE_FREQ;

--- a/firmware/baseband/proc_sonde.hpp
+++ b/firmware/baseband/proc_sonde.hpp
@@ -170,7 +170,9 @@ class SondeProcessor : public BasebandProcessor {
         baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
     RSSIThread rssi_thread{};
 
-    void pitch_rssi_config(const PitchRSSIConfigureMessage& message);
+    void on_signal_message(const RequestSignalMessage& message);
+    void on_beep_message(const AudioBeepMessage& message);
+    void on_pitch_rssi_config(const PitchRSSIConfigureMessage& message);
 };
 
 #endif /*__PROC_ERT_H__*/

--- a/firmware/baseband/proc_sonde.hpp
+++ b/firmware/baseband/proc_sonde.hpp
@@ -97,7 +97,7 @@
 
 #define BEEP_MIN_DURATION 60
 #define BEEP_DURATION_RANGE 100
-#define BEEP_BASE_FREQ 320  // Lowest audible freq for some PortaPack speakers
+#define BEEP_BASE_FREQ 400  // Lowest audible freq for some PortaPack speakers
 #define BEEP_MAX_FREQ 8000  // Highest audible freq for some PortaPack speakers
 #define BEEP_SIMPLE_FREQ 1000
 #define RSSI_CEILING 1000

--- a/firmware/baseband/proc_sonde.hpp
+++ b/firmware/baseband/proc_sonde.hpp
@@ -97,10 +97,12 @@
 
 #define BEEP_MIN_DURATION 60
 #define BEEP_DURATION_RANGE 100
-#define BEEP_BASE_FREQ 200
+#define BEEP_BASE_FREQ 320  // Lowest audible freq for some PortaPack speakers
+#define BEEP_MAX_FREQ 8000  // Highest audible freq for some PortaPack speakers
+#define BEEP_SIMPLE_FREQ 1000
 #define RSSI_CEILING 1000
 #define PROPORTIONAL_BEEP_THRES 0.8
-#define RSSI_PITCH_WEIGHT 0.5
+#define RSSI_PITCH_WEIGHT (float(BEEP_MAX_FREQ - BEEP_BASE_FREQ) / RSSI_CEILING)
 #define AUDIO_SAMPLE_RATE 24000
 
 class SondeProcessor : public BasebandProcessor {

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -121,6 +121,7 @@ class Message {
         GPSPosData = 63,
         OrientationData = 64,
         EnvironmentData = 65,
+        AudioBeep = 66,
         MAX
     };
 
@@ -1167,7 +1168,7 @@ class RequestSignalMessage : public Message {
         FillRequest = 1,
         RogerBeepRequest = 2,
         RSSIBeepRequest = 3,
-        SimpleAudioBeepRequest = 4,
+        BeepStopRequest = 4,
         Squelched = 5,
     };
 
@@ -1363,4 +1364,16 @@ class EnvironmentDataMessage : public Message {
     uint16_t light = 0;     // lux
 };
 
+class AudioBeepMessage : public Message {
+   public:
+    constexpr AudioBeepMessage(
+        uint32_t freq = 1000,
+        uint32_t duration_ms = 100)
+        : Message{ID::AudioBeep},
+          freq{freq},
+          duration_ms{duration_ms} {
+    }
+    uint32_t freq = 1000;
+    uint32_t duration_ms = 100;
+};
 #endif /*__MESSAGE_H__*/

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -1165,8 +1165,10 @@ class RequestSignalMessage : public Message {
    public:
     enum class Signal : char {
         FillRequest = 1,
-        BeepRequest = 2,
-        Squelched = 3
+        RogerBeepRequest = 2,
+        RSSIBeepRequest = 3,
+        SimpleAudioBeepRequest = 4,
+        Squelched = 5,
     };
 
     constexpr RequestSignalMessage(


### PR DESCRIPTION
1.  Modified signal message enums to distinguish between Roger Beep (transmitted by the Mic app) and RSSI Beep (an audible speaker/headphone beep used by the Radiosonde app).  Also added a "Stop Beep" option (not currently used).
2. Added a new "Audio Beep" message type where audio freq and duration can be specified to the baseband code.
3. Changed Radiosonde RSSI audio beep frequency range to 400 Hz to 8 KHz (audio frequency range that my PortaPack speaker can produce).  The original minimum 200 Hz couldn't be heard on the little speaker of one of my units.
4. When Beep checkbox is enabled in Radiosonde, make a 1KHz beep sound, versus a beep tone that's dependent on the current RSSI level.  1KHz is more easily heard than the 400 Hz.
5. Modified Radiosonde app to save Beep, Logging, and CRC checkbox settings in app settings .ini file.

I'm still assuming here that the max RSSI level is 1000 as in the proc_sonde.hpp header file (haven't verified if that's really the case yet)

Test firmware available here:
https://discord.com/channels/719669764804444213/722101917135798312/1220241565876883497