### PR TITLE
Radiosonde QR code fixes

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -858,7 +858,7 @@ void SettingsMenuView::on_populate() {
         {"Radio", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [this]() { nav_.push<SetRadioView>(); }},
         {"SD Card", ui::Color::dark_cyan(), &bitmap_icon_sdcard, [this]() { nav_.push<SetSDCardView>(); }},
         {"User Interface", ui::Color::dark_cyan(), &bitmap_icon_options_ui, [this]() { nav_.push<SetUIView>(); }},
-        {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [this]() { nav_.push<SetQRCodeView>(); }},
+        //{"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [this]() { nav_.push<SetQRCodeView>(); }},
         {"Brightness", ui::Color::dark_cyan(), &bitmap_icon_brightness, [this]() { nav_.push<SetFakeBrightnessView>(); }},
         {"Menu Color", ui::Color::dark_cyan(), &bitmap_icon_brightness, [this]() { nav_.push<SetMenuColorView>(); }},
     });

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -92,17 +92,18 @@ SondeView::SondeView(NavigationView& nav)
 
     // QR code with geo URI
     button_see_qr.on_select = [this, &nav](Button&) {
+        std::string geo_uri = "geo:" + to_string_decimal(geopos.lat(), 5) + "," + to_string_decimal(geopos.lon(), 5);  // 5 decimal digits for ~1 meter accuracy
         nav.push<QRCodeView>(geo_uri.data());
     };
 
     button_see_map.on_select = [this, &nav](Button&) {
         geomap_view_ = nav.push<GeoMapView>(
             sonde_id,
-            gps_info.alt,
+            geopos.altitude(),
             GeoPos::alt_unit::METERS,
             GeoPos::spd_unit::HIDDEN,
-            gps_info.lat,
-            gps_info.lon,
+            geopos.lat(),
+            geopos.lon(),
             999);  // set a dummy heading out of range to draw a cross...probably not ideal?
         nav.set_on_pop([this]() {
             geomap_view_ = nullptr;
@@ -151,8 +152,6 @@ void SondeView::focus() {
 void SondeView::on_packet(const sonde::Packet& packet) {
     if (!use_crc || packet.crc_ok())  // euquiq: Reject bad packet if crc is on
     {
-        geo_uri = "geo:" + to_string_decimal(gps_info.lat, 5) + "," + to_string_decimal(gps_info.lon, 5);  // 5 decimal digits for ~1 meter accuracy
-
         text_signature.set(packet.type_string());
 
         sonde_id = packet.serial_number();  // used also as tag on the geomap

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -92,7 +92,7 @@ SondeView::SondeView(NavigationView& nav)
 
     // QR code with geo URI
     button_see_qr.on_select = [this, &nav](Button&) {
-        nav.push<QRCodeView>(geo_uri);
+        nav.push<QRCodeView>(geo_uri.data());
     };
 
     button_see_map.on_select = [this, &nav](Button&) {
@@ -148,50 +148,10 @@ void SondeView::focus() {
     field_frequency.focus();
 }
 
-// used to convert float to character pointer, since unfortunately function like
-// sprintf and c_str aren't supported.
-char* SondeView::float_to_char(float x, char* p) {
-    char* s = p + 9;                             // go to end of buffer
-    uint16_t decimals;                           // variable to store the decimals
-    int units;                                   // variable to store the units (part to left of decimal place)
-    if (x < 0) {                                 // take care of negative numbers
-        decimals = (int)(x * -100000) % 100000;  // make 1000 for 3 decimals etc.
-        units = (int)(-1 * x);
-    } else {  // positive numbers
-        decimals = (int)(x * 100000) % 100000;
-        units = (int)x;
-    }
-
-    // TODO: more elegant solution (loop?)
-    *--s = (decimals % 10) + '0';
-    decimals /= 10;
-    *--s = (decimals % 10) + '0';
-    decimals /= 10;
-    *--s = (decimals % 10) + '0';
-    decimals /= 10;
-    *--s = (decimals % 10) + '0';
-    decimals /= 10;
-    *--s = (decimals % 10) + '0';
-    *--s = '.';
-
-    while (units > 0) {
-        *--s = (units % 10) + '0';
-        units /= 10;
-    }
-    if (x < 0) *--s = '-';  // unary minus sign for negative numbers
-    return s;
-}
-
 void SondeView::on_packet(const sonde::Packet& packet) {
     if (!use_crc || packet.crc_ok())  // euquiq: Reject bad packet if crc is on
     {
-        char buffer_lat[10] = {};
-        char buffer_lon[10] = {};
-
-        strcpy(geo_uri, "geo:");
-        strcat(geo_uri, float_to_char(gps_info.lat, buffer_lat));
-        strcat(geo_uri, ",");
-        strcat(geo_uri, float_to_char(gps_info.lon, buffer_lon));
+        geo_uri = "geo:" + to_string_decimal(gps_info.lat, 5) + "," + to_string_decimal(gps_info.lon, 5);  // 5 decimal digits for ~1 meter accuracy
 
         text_signature.set(packet.type_string());
 

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -89,8 +89,6 @@ class SondeView : public View {
 
     std::unique_ptr<SondeLogger> logger{};
 
-    std::string geo_uri{};
-
     sonde::GPS_data gps_info{};
     sonde::temp_humid temp_humid_info{};
     std::string sonde_id{};

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -89,7 +89,7 @@ class SondeView : public View {
 
     std::unique_ptr<SondeLogger> logger{};
 
-    char geo_uri[32] = {};
+    std::string geo_uri{};
 
     sonde::GPS_data gps_info{};
     sonde::temp_humid temp_humid_info{};
@@ -208,7 +208,6 @@ class SondeView : public View {
     void on_gps(const GPSPosDataMessage* msg);
     void on_orientation(const OrientationDataMessage* msg);
     void on_packet(const sonde::Packet& packet);
-    char* float_to_char(float x, char* p);
 };
 
 } /* namespace ui */

--- a/firmware/application/ui/ui_qrcode.cpp
+++ b/firmware/application/ui/ui_qrcode.cpp
@@ -59,43 +59,19 @@ void QRCodeImage::paint(Painter& painter) {
     // The structure to manage the QR code
     QRCode qrcode;
 
-    // Either small or large QR code can be shown..
+    int qr_version = 10;
 
-    if (portapack::persistent_memory::show_bigger_qr_code()) {  // show large QR code
-        int qr_version = 2;
+    // Allocate a chunk of memory to store the QR code
+    uint8_t qrcodeBytes[qrcode_getBufferSize(qr_version)];
 
-        // Allocate a chunk of memory to store the QR code
-        uint8_t qrcodeBytes[qrcode_getBufferSize(qr_version)];
+    qrcode_initText(&qrcode, qrcodeBytes, qr_version, ECC_HIGH, qr_text_);
 
-        qrcode_initText(&qrcode, qrcodeBytes, qr_version, ECC_HIGH, qr_text_);
+    display.fill_rectangle(Rect(57, 65, 126, 127), Color::white());
 
-        display.fill_rectangle(Rect(10, 30, 220, 220), Color::white());
-
-        for (uint8_t y = 0; y < qrcode.size; y++) {
-            for (uint8_t x = 0; x < qrcode.size; x++) {
-                if (qrcode_getModule(&qrcode, x, y)) {
-                    display.fill_rectangle(Rect(20 + (x * 8), 40 + (y * 8), 8, 8), Color::black());
-                }
-            }
-        }
-
-    }
-
-    else {  // show small QR code
-        int qr_version = 10;
-
-        // Allocate a chunk of memory to store the QR code
-        uint8_t qrcodeBytes[qrcode_getBufferSize(qr_version)];
-
-        qrcode_initText(&qrcode, qrcodeBytes, qr_version, ECC_HIGH, qr_text_);
-
-        display.fill_rectangle(Rect(57, 65, 126, 127), Color::white());
-
-        for (uint8_t y = 0; y < qrcode.size; y++) {
-            for (uint8_t x = 0; x < qrcode.size; x++) {
-                if (qrcode_getModule(&qrcode, x, y)) {
-                    display.fill_rectangle(Rect(63 + (x * 2), 71 + (y * 2), 2, 2), Color::black());
-                }
+    for (uint8_t y = 0; y < qrcode.size; y++) {
+        for (uint8_t x = 0; x < qrcode.size; x++) {
+            if (qrcode_getModule(&qrcode, x, y)) {
+                display.fill_rectangle(Rect(63 + (x * 2), 71 + (y * 2), 2, 2), Color::black());
             }
         }
     }

--- a/firmware/application/ui/ui_qrcode.cpp
+++ b/firmware/application/ui/ui_qrcode.cpp
@@ -89,12 +89,12 @@ void QRCodeImage::paint(Painter& painter) {
 
         qrcode_initText(&qrcode, qrcodeBytes, qr_version, ECC_HIGH, qr_text_);
 
-        display.fill_rectangle(Rect(92, 97, 63, 63), Color::white());
+        display.fill_rectangle(Rect(57, 65, 126, 127), Color::white());
 
         for (uint8_t y = 0; y < qrcode.size; y++) {
             for (uint8_t x = 0; x < qrcode.size; x++) {
                 if (qrcode_getModule(&qrcode, x, y)) {
-                    display.draw_pixel(Point(95 + x, 100 + y), Color::black());
+                    display.fill_rectangle(Rect(63 + (x * 2), 71 + (y * 2), 2, 2), Color::black());
                 }
             }
         }


### PR DESCRIPTION
1.  Fixed QR code issue when lat or lon was 0 degrees.  QR code URI was missing the 0 digit to the left of decimal point.  Now uses our standard function for float-to-string conversion, which doesn't have that problem.

2.  Fixed QR code to display the most recent packet's lat/lon coordinates (versus the previous packet's coordinates).

3.  Changed the "See QR" and "See on map" buttons to show the lat/lon location indicated on the screen.  This is usually the same as the coordinates from the last packet, but the user might have changed them manually since the last packet was received.  Now a QR code can be generated for any user-specified coordinates.

4.  Now using 4 pixels, versus 1 pixel, for every black dot in the "small" (type 10) location QR code for easier scanning (less of a challenge to focus).  Tested on Android & iPhone.

5.  Deprecate support for the "large" (type 2 low resolution) QR code, which did not work (since i-dunno-when) per testing on iPhone & Android, and is no longer needed since the "small" QR code is now 4X larger.  Saves 2KB of ROM space.