### PR TITLE
Improved Audio Beep Test to add configurable Sample Rate

### DIFF
--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -75,7 +75,7 @@ SondeView::SondeView(NavigationView& nav)
     check_beep.on_select = [this](Checkbox&, bool v) {
         beep = v;
         if (beep)
-            baseband::request_audio_beep(1000, 60);  // 1khz tone for 60ms to acknowledge enablement
+            baseband::request_audio_beep(1000, 24000, 60);  // 1khz tone for 60ms to acknowledge enablement
     };
 
     check_log.set_value(logging);

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -445,8 +445,8 @@ void request_beep_stop() {
     request_beep(RequestSignalMessage::Signal::BeepStopRequest);
 }
 
-void request_audio_beep(uint32_t freq, uint32_t duration_ms) {
-    AudioBeepMessage message{freq, duration_ms};
+void request_audio_beep(uint32_t freq, uint32_t sample_rate, uint32_t duration_ms) {
+    AudioBeepMessage message{freq, sample_rate, duration_ms};
     send_message(&message);
 }
 

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -93,7 +93,7 @@ void set_subghzd_config(uint8_t modulation, uint32_t sampling_rate);
 void request_roger_beep();
 void request_rssi_beep();
 void request_beep_stop();
-void request_audio_beep(uint32_t freq, uint32_t duration_ms);
+void request_audio_beep(uint32_t freq, uint32_t sample_rate, uint32_t duration_ms);
 
 void run_image(const portapack::spi_flash::image_tag_t image_tag);
 void run_prepared_image(const uint32_t m4_code);

--- a/firmware/application/external/audio_test/ui_audio_test.hpp
+++ b/firmware/application/external/audio_test/ui_audio_test.hpp
@@ -45,20 +45,27 @@ class AudioTestView : public View {
 
     Labels labels{
         {{7 * 8, 3 * 16}, "Audio Beep Test", Color::light_grey()},
-        {{0 * 8, 6 * 16}, "Frequency (Hz):", Color::light_grey()},
-        {{0 * 8, 8 * 16}, "Duration (ms):", Color::light_grey()},
-        {{0 * 8, 10 * 16}, "Volume:", Color::light_grey()}};
+        {{0 * 8, 6 * 16}, "Sample Rate (Hz):", Color::light_grey()},
+        {{0 * 8, 8 * 16}, "Frequency (Hz):", Color::light_grey()},
+        {{0 * 8, 10 * 16}, "Duration (ms):", Color::light_grey()},
+        {{0 * 8, 12 * 16}, "Volume:", Color::light_grey()}};
+
+    OptionsField options_sample_rate{
+        {18 * 8, 6 * 16},
+        5,
+        {{"24000", 24000},
+         {"48000", 48000}}};
 
     NumberField field_frequency{
-        {16 * 8, 6 * 16},
+        {18 * 8, 8 * 16},
         5,
-        {100, 24000},
+        {100, 24000 / 2},
         100,
         ' ',
         true};
 
     NumberField field_duration{
-        {16 * 8, 8 * 16},
+        {18 * 8, 10 * 16},
         5,
         {0, 60000},
         50,
@@ -66,10 +73,10 @@ class AudioTestView : public View {
         true};
 
     AudioVolumeField field_volume{
-        {19 * 8, 10 * 16}};
+        {21 * 8, 12 * 16}};
 
     ImageToggle toggle_speaker{
-        {19 * 8, 12 * 16, 2 * 8, 1 * 16},
+        {21 * 8, 14 * 16, 2 * 8, 1 * 16},
         &bitmap_icon_speaker_mute,
         &bitmap_icon_speaker,
         Color::light_grey(),

--- a/firmware/baseband/proc_audio_beep.cpp
+++ b/firmware/baseband/proc_audio_beep.cpp
@@ -52,7 +52,7 @@ void AudioBeepProcessor::on_signal_message(const RequestSignalMessage& message) 
 }
 
 void AudioBeepProcessor::on_beep_message(const AudioBeepMessage& message) {
-    audio::dma::beep_start(message.freq, AUDIO_SAMPLE_RATE, message.duration_ms);
+    audio::dma::beep_start(message.freq, message.sample_rate, message.duration_ms);
 }
 
 int main() {

--- a/firmware/baseband/proc_sonde.cpp
+++ b/firmware/baseband/proc_sonde.cpp
@@ -86,12 +86,12 @@ void SondeProcessor::on_signal_message(const RequestSignalMessage& message) {
             beep_duration = BEEP_DURATION_RANGE + BEEP_MIN_DURATION;
         }
 
-        audio::dma::beep_start(beep_freq, AUDIO_SAMPLE_RATE, beep_duration);
+        audio::dma::beep_start(beep_freq, DEFAULT_AUDIO_SAMPLE_RATE, beep_duration);
     }
 }
 
 void SondeProcessor::on_beep_message(const AudioBeepMessage& message) {
-    audio::dma::beep_start(message.freq, AUDIO_SAMPLE_RATE, message.duration_ms);
+    audio::dma::beep_start(message.freq, message.sample_rate, message.duration_ms);
 }
 
 void SondeProcessor::on_pitch_rssi_config(const PitchRSSIConfigureMessage& message) {

--- a/firmware/baseband/proc_sonde.hpp
+++ b/firmware/baseband/proc_sonde.hpp
@@ -103,7 +103,7 @@
 #define RSSI_CEILING 1000
 #define PROPORTIONAL_BEEP_THRES 0.8
 #define RSSI_PITCH_WEIGHT (float(BEEP_MAX_FREQ - BEEP_BASE_FREQ) / RSSI_CEILING)
-#define AUDIO_SAMPLE_RATE 24000
+#define DEFAULT_AUDIO_SAMPLE_RATE 24000
 
 class SondeProcessor : public BasebandProcessor {
    public:

--- a/firmware/baseband/tone_gen.cpp
+++ b/firmware/baseband/tone_gen.cpp
@@ -27,7 +27,7 @@
 // Functions for audio beep (used by Sonde RSSI)
 void ToneGen::configure_beep(const uint32_t freq, const uint32_t sample_rate) {
     f_delta_ = (float)(freq * sizeof(sine_table_i8)) / sample_rate;
-    f_tone_phase_ = 0.0;
+    f_tone_phase_ = sizeof(sine_table_i8) / 4;  // Start at sine peak to handle case of freq=sample_rate/2
 }
 
 int16_t ToneGen::process_beep() {

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -1368,12 +1368,15 @@ class AudioBeepMessage : public Message {
    public:
     constexpr AudioBeepMessage(
         uint32_t freq = 1000,
+        uint32_t sample_rate = 24000,
         uint32_t duration_ms = 100)
         : Message{ID::AudioBeep},
           freq{freq},
+          sample_rate{sample_rate},
           duration_ms{duration_ms} {
     }
     uint32_t freq = 1000;
+    uint32_t sample_rate = 24000;
     uint32_t duration_ms = 100;
 };
 #endif /*__MESSAGE_H__*/


### PR DESCRIPTION
"Sample Rate" is now configurable in the Audio Beep Test debug app.

This required modifying the audio beep message to include sample_rate as a parameter.