### PR TITLE
Level fix and beep, RSSI avg fix

### DIFF
--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -209,6 +209,7 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     uint8_t rx_sat = ((uint32_t)shared_memory.m4_performance_counter) * 100 / 127;
     if (last_rx_sat != rx_sat) {
         last_rx_sat = rx_sat;
+
         uint8_t br = 0;
         uint8_t bg = 0;
         uint8_t bb = 0;
@@ -249,7 +250,6 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
             field_bw.set_by_value(0);
             receiver_model.set_am_configuration(0);
             field_bw.on_change = [this](size_t index, OptionsField::value_t n) { radio_bw = index ; receiver_model.set_am_configuration(n); };
-            text_ctcss.set("             ");
             break;
         case NFM_MODULATION:
             audio_sampling_rate = audio::Rate::Hz_24000;
@@ -270,7 +270,6 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
             // bw 200k (0) default
             field_bw.set_by_value(0);
             field_bw.on_change = [this](size_t index, OptionsField::value_t n) { radio_bw = index ; receiver_model.set_wfm_configuration(n); };
-            text_ctcss.set("             ");
             break;
         case SPEC_MODULATION:
             audio_sampling_rate = audio::Rate::Hz_24000;
@@ -295,6 +294,9 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
         // Reset receiver model to fix bug when going from SPEC to audio, the sound is distorted.
         receiver_model.set_sampling_rate(3072000);
         receiver_model.set_baseband_bandwidth(1750000);
+    }
+    if (new_mod != NFM_MODULATION) {
+        text_ctcss.set("             ");
     }
 
     m4_manage_stat_update();  // rx_sat hack

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -189,8 +189,8 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     }
 
     if (beep) {
-        uint32_t beep_freq = 400 + ((80 + statistics.max_db) * 7600) / 85;
-        baseband::request_audio_beep(beep_freq, 24000, 100);
+        uint32_t beep_freq = ((132 + statistics.max_db) * 3000) / 120;
+        baseband::request_audio_beep(beep_freq, 24000, 1000);
     }
 
     // refresh sat

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -91,9 +91,6 @@ LevelView::LevelView(NavigationView& nav)
     // activate vertical bar mode
     rssi.set_vertical_rssi(true);
 
-    change_mode(radio_mode);              // Start on AM
-    field_mode.set_by_value(radio_mode);  // Reflect the mode into the manual selector
-
     freq_ = receiver_model.target_frequency();
     button_frequency.set_text("<" + to_string_short_freq(freq_) + " MHz>");
 
@@ -126,11 +123,13 @@ LevelView::LevelView(NavigationView& nav)
         button_frequency.set_text("<" + to_string_short_freq(freq_) + " MHz>");
     };
 
+    freqman_set_modulation_option(field_mode);
     field_mode.on_change = [this](size_t, OptionsField::value_t v) {
         if (v != -1) {
             change_mode(v);
         }
     };
+    field_mode.set_by_value(radio_mode);  // Reflect the mode into the manual selector
 
     rssi_resolution.on_change = [this](size_t, OptionsField::value_t v) {
         if (v != -1) {
@@ -163,7 +162,6 @@ LevelView::LevelView(NavigationView& nav)
     peak_mode.set_selected_index(2);
     rssi_resolution.set_selected_index(1);
     // FILL STEP OPTIONS
-    freqman_set_modulation_option(field_mode);
     freqman_set_step_option_short(step_mode);
     freq_stats_rssi.set_style(&Styles::white);
     freq_stats_db.set_style(&Styles::white);

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -135,6 +135,7 @@ LevelView::LevelView(NavigationView& nav)
     };
 
     field_audio_mode.on_change = [this](size_t, OptionsField::value_t v) {
+        audio_mode = v;
         if (v == 0) {
             audio::output::stop();
         } else if (v == 1) {
@@ -142,7 +143,6 @@ LevelView::LevelView(NavigationView& nav)
             audio::output::start();
             receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // WM8731 hack.
         }
-        audio_mode = v;
         m4_manage_stat_update();  // rx_sat hack
     };
     field_audio_mode.set_selected_index(audio_mode);
@@ -189,8 +189,8 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     }
 
     if (beep) {
-        uint32_t beep_freq = 400 + ((85 + statistics.max_db) * 23600) / 90;
-        baseband::request_audio_beep(beep_freq, 24000, 50);
+        uint32_t beep_freq = 400 + ((80 + statistics.max_db) * 7600) / 85;
+        baseband::request_audio_beep(beep_freq, 24000, 100);
     }
 
     // refresh sat
@@ -233,6 +233,7 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
 
     radio_mode = new_mod;
 
+    audio::output::stop();
     receiver_model.disable();
     baseband::shutdown();
 

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -65,6 +65,7 @@ class LevelView : public View {
     bool beep = false;
     bool rx_sat_status = false;
     uint8_t radio_mode = 0;
+    uint8_t radio_bw = 0;
     uint8_t audio_mode = 0;
     int32_t beep_squelch = 0;
     audio::Rate audio_sampling_rate = audio::Rate::Hz_48000;
@@ -76,6 +77,7 @@ class LevelView : public View {
             {"beep_squelch"sv, &beep_squelch},
             {"audio_mode"sv, &audio_mode},
             {"radio_mode"sv, &radio_mode},
+            {"radio_bw"sv, &radio_bw},
         }};
 
     Labels labels{

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -75,6 +75,7 @@ class LevelView : public View {
         {
             {"beep_squelch"sv, &beep_squelch},
             {"audio_mode"sv, &audio_mode},
+            {"radio_mode"sv, &radio_mode},
         }};
 
     Labels labels{

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -63,7 +63,6 @@ class LevelView : public View {
 
     rf::Frequency freq_ = {0};
     bool beep = false;
-    bool rx_sat_status = false;
     uint8_t radio_mode = 0;
     uint8_t radio_bw = 0;
     uint8_t audio_mode = 0;
@@ -134,10 +133,6 @@ class LevelView : public View {
         ' ',
     };
 
-    Text text_ctcss{
-        {22 * 8, 3 * 16 + 4, 8 * 8, 1 * 8},
-        ""};
-
     // RSSI: XX/XX/XXX
     Text freq_stats_rssi{
         {0 * 8, 3 * 16 + 4, 15 * 8, 1 * 16},
@@ -176,6 +171,10 @@ class LevelView : public View {
     Text freq_stats_rx{
         {0 * 8, 5 * 16 + 4, 10 * 8, 1 * 16},
     };
+
+    Text text_ctcss{
+        {12 * 8, 5 * 16 + 4, 8 * 8, 1 * 8},
+        ""};
 
     RSSIGraph rssi_graph{
         // 240x320  =>

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -55,8 +55,6 @@ class LevelView : public View {
     NavigationView& nav_;
 
     RxRadioState radio_state_{};
-    app_settings::SettingsManager settings_{
-        "rx_level", app_settings::Mode::RX};
 
     size_t change_mode(freqman_index_t mod_type);
     void on_statistics_update(const ChannelStatistics& statistics);
@@ -68,7 +66,16 @@ class LevelView : public View {
     bool rx_sat_status = false;
     uint8_t radio_mode = 0;
     uint8_t audio_mode = 0;
+    int32_t beep_squelch = 0;
     audio::Rate audio_sampling_rate = audio::Rate::Hz_48000;
+
+    app_settings::SettingsManager settings_{
+        "rx_level",
+        app_settings::Mode::RX,
+        {
+            {"beep_squelch"sv, &beep_squelch},
+            {"audio_mode"sv, &audio_mode},
+        }};
 
     Labels labels{
         {{0 * 8, 0 * 16}, "LNA:   VGA:   AMP:  VOL:     ", Color::light_grey()},
@@ -112,13 +119,25 @@ class LevelView : public View {
         {{"audio off", 0},
          {"audio on", 1}}};
 
+    Text text_beep_squelch{
+        {21 * 8, 3 * 16 + 4, 4 * 8, 1 * 8},
+        "Bip>"};
+
+    NumberField field_beep_squelch{
+        {25 * 8, 3 * 16 + 4},
+        3,
+        {-120, 12},
+        1,
+        ' ',
+    };
+
     Text text_ctcss{
         {22 * 8, 3 * 16 + 4, 8 * 8, 1 * 8},
         ""};
 
-    // RSSI: XX/XX/XXX,dt: XX
+    // RSSI: XX/XX/XXX
     Text freq_stats_rssi{
-        {0 * 8, 3 * 16 + 4, 22 * 8, 1 * 16},
+        {0 * 8, 3 * 16 + 4, 15 * 8, 1 * 16},
     };
 
     // Power: -XXX db
@@ -157,12 +176,12 @@ class LevelView : public View {
 
     RSSIGraph rssi_graph{
         // 240x320  =>
-        {0, 6 * 16 + 4, 240 - 5 * 8, 320 - (6 * 16 + 4)},
+        {0, 6 * 16 + 8, 240 - 5 * 8, 320 - (6 * 16)},
     };
 
     RSSI rssi{
         // 240x320  =>
-        {240 - 5 * 8, 6 * 16 + 4, 5 * 8, 320 - (6 * 16 + 4)},
+        {240 - 5 * 8, 6 * 16 + 8, 5 * 8, 320 - (6 * 16)},
     };
 
     void handle_coded_squelch(const uint32_t value);

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -61,8 +61,14 @@ class LevelView : public View {
     size_t change_mode(freqman_index_t mod_type);
     void on_statistics_update(const ChannelStatistics& statistics);
     void set_display_freq(int64_t freq);
+    void m4_manage_stat_update();  // to finely adjust the RxSaturation usage
 
     rf::Frequency freq_ = {0};
+    bool beep = false;
+    bool rx_sat_status = false;
+    uint8_t radio_mode = 0;
+    uint8_t audio_mode = 0;
+    audio::Rate audio_sampling_rate = audio::Rate::Hz_48000;
 
     Labels labels{
         {{0 * 8, 0 * 16}, "LNA:   VGA:   AMP:  VOL:     ", Color::light_grey()},
@@ -100,15 +106,11 @@ class LevelView : public View {
         {0 * 8, 2 * 16 + 8, 15 * 8, 1 * 8},
         ""};
 
-    OptionsField audio_mode{
+    OptionsField field_audio_mode{
         {21 * 8, 1 * 16},
         9,
-        {
-            {"audio off", 0},
-            {"audio on", 1}
-            //{"tone on", 2},
-            //{"tone off", 3},
-        }};
+        {{"audio off", 0},
+         {"audio on", 1}}};
 
     Text text_ctcss{
         {22 * 8, 3 * 16 + 4, 8 * 8, 1 * 8},

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -30,6 +30,7 @@
 #include "dsp_decimate.hpp"
 #include "spectrum_collector.hpp"
 #include "stream_input.hpp"
+#include "message.hpp"
 
 #include <array>
 #include <memory>
@@ -92,6 +93,9 @@ class CaptureProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
+    void on_signal_message(const RequestSignalMessage& message);
+    void on_beep_message(const AudioBeepMessage& message);
+
     size_t baseband_fs = 3072000;  // aka: sample_rate
     static constexpr auto spectrum_rate_hz = 50.0f;
 

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -134,7 +134,7 @@ class Message {
 };
 
 struct RSSIStatistics {
-    uint16_t accumulator{0};
+    uint32_t accumulator{0};
     uint8_t min{0};
     uint8_t max{0};
     uint16_t count{0};


### PR DESCRIPTION
RSSI:
- a previous change to accumulator variable made it useless and overflowing. This is the message.hpp fix.

Level:
- fixed audio lost on mode changes
- added beep based on db level in spec mode when audio is on