### PR TITLE
More debug Audio Beep Test tweaks

### DIFF
--- a/firmware/application/external/audio_test/ui_audio_test.cpp
+++ b/firmware/application/external/audio_test/ui_audio_test.cpp
@@ -35,39 +35,51 @@ AudioTestView::AudioTestView(NavigationView& nav)
     add_children({&labels,
                   &options_sample_rate,
                   &field_frequency,
+                  &options_step,
                   &field_duration,
                   &field_volume,
                   &toggle_speaker});
 
     audio::set_rate(audio::Rate::Hz_24000);
     options_sample_rate.on_change = [this](size_t, int32_t v) {
-        if (options_sample_rate.selected_index_value() == 24000) {
-            audio::set_rate(audio::Rate::Hz_24000);
-            field_frequency.set_range(100, v / 2);  // 24000/128 = ~100 (audio_dma uses 128 samples)
-        } else {
-            audio::set_rate(audio::Rate::Hz_48000);
-            field_frequency.set_range(200, v / 2);  // 48000/128 = ~200
+        switch (v) {
+            case 12000:
+                audio::set_rate(audio::Rate::Hz_12000);
+                break;
+            case 24000:
+                audio::set_rate(audio::Rate::Hz_24000);
+                break;
+            case 48000:
+                audio::set_rate(audio::Rate::Hz_48000);
+                break;
         }
+        field_frequency.set_range(v / 128, v / 2);
         update_audio_beep();
     };
+    options_sample_rate.set_selected_index(0, 1);
 
-    field_frequency.set_value(1000);
     field_frequency.on_change = [this](int32_t) {
         update_audio_beep();
     };
+    field_frequency.set_value(1000);
 
-    field_duration.set_value(100);
+    options_step.on_change = [this](size_t, int32_t v) {
+        field_frequency.set_step(v);
+    };
+    options_step.set_by_value(100);
+
     field_duration.on_change = [this](int32_t v) {
         (void)v;
         update_audio_beep();
     };
+    field_duration.set_value(100);
 
     toggle_speaker.on_change = [this](bool v) {
         beep = v;
         update_audio_beep();
     };
 
-    field_volume.set_value(0);
+    field_volume.set_value(0);  // seems that a change is required to force update, so setting to 0 first
     field_volume.set_value(80);
 
     audio::set_rate(audio::Rate::Hz_24000);

--- a/firmware/application/external/audio_test/ui_audio_test.hpp
+++ b/firmware/application/external/audio_test/ui_audio_test.hpp
@@ -46,20 +46,31 @@ class AudioTestView : public View {
     Labels labels{
         {{7 * 8, 3 * 16}, "Audio Beep Test", Color::light_grey()},
         {{0 * 8, 6 * 16}, "Sample Rate (Hz):", Color::light_grey()},
+        {{25 * 8, 7 * 16}, "Step:", Color::light_grey()},
         {{0 * 8, 8 * 16}, "Frequency (Hz):", Color::light_grey()},
         {{0 * 8, 10 * 16}, "Duration (ms):", Color::light_grey()},
+        {{25 * 8, 10 * 16}, "0=con", Color::light_grey()},
         {{0 * 8, 12 * 16}, "Volume:", Color::light_grey()}};
 
     OptionsField options_sample_rate{
         {18 * 8, 6 * 16},
         5,
         {{"24000", 24000},
-         {"48000", 48000}}};
+         {"48000", 48000},
+         {"12000", 12000}}};
+
+    OptionsField options_step{
+        {26 * 8, 8 * 16},
+        4,
+        {{"   1", 1},
+         {"  10", 10},
+         {" 100", 100},
+         {"1000", 1000}}};
 
     NumberField field_frequency{
         {18 * 8, 8 * 16},
         5,
-        {100, 24000 / 2},
+        {},
         100,
         ' ',
         true};

--- a/firmware/baseband/tone_gen.cpp
+++ b/firmware/baseband/tone_gen.cpp
@@ -27,7 +27,13 @@
 // Functions for audio beep (used by Sonde RSSI)
 void ToneGen::configure_beep(const uint32_t freq, const uint32_t sample_rate) {
     f_delta_ = (float)(freq * sizeof(sine_table_i8)) / sample_rate;
-    f_tone_phase_ = sizeof(sine_table_i8) / 4;  // Start at sine peak to handle case of freq=sample_rate/2
+    f_tone_phase_ = 0.0;
+
+    // For higher frequencies, start at sine peak to handle case of freq=sample_rate/2;
+    // we don't want to sample the sine wave only when it's crossing 0!
+    // There is still an amplitude issue though depending on magnitude of selected sine sample deltas.
+    if (f_delta_ >= sizeof(sine_table_i8) / 4)
+        f_tone_phase_ = sizeof(sine_table_i8) / 4;
 }
 
 int16_t ToneGen::process_beep() {


### PR DESCRIPTION
For audio debug, added support for 12KHz sample rate and configurable audio frequency step.

In configure_beep (tone_gen), revert to start sampling the sine wave at 0 for frequencies below sample_rate/4 (trying to avoid a tiny pop in the speaker when the beep starts, yet still make sure there are non-zero samples at high frequencies)