### PR TITLE
Revert accidental button color changes

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -694,7 +694,7 @@ FileManagerView::FileManagerView(
 
     button_show_hidden_files.on_select = [this]() {
         show_hidden_files = !show_hidden_files;
-        button_show_hidden_files.set_color(show_hidden_files ? Color::dark_green() : Color::dark_grey());
+        button_show_hidden_files.set_color(show_hidden_files ? Color::green() : Color::dark_grey());
         reload_current();
     };
 }

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -261,19 +261,19 @@ class FileManagerView : public FileManBaseView {
         {22 * 8, 29 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_new_dir,
-        Color::dark_green()};
+        Color::green()};
 
     NewButton button_new_file{
         {26 * 8, 29 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_new_file,
-        Color::dark_green()};
+        Color::green()};
 
     NewButton button_open_notepad{
         {0 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_notepad,
-        Color::dark_orange()};
+        Color::orange()};
 
     NewButton button_rename_timestamp{
 
@@ -288,7 +288,7 @@ class FileManagerView : public FileManBaseView {
         {4 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_trim,
-        Color::dark_orange()};
+        Color::orange()};
 
     NewButton button_show_hidden_files{
         {17 * 8, 34 * 8, 4 * 8, 32},

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -523,7 +523,7 @@ class NewButton : public Widget {
    protected:
     virtual Style paint_style();
     Color color_;
-    Color bg_color_{Color::light_grey()};
+    Color bg_color_{Color::grey()};
 
    private:
     std::string text_;


### PR DESCRIPTION
1.  Revert accidental change of NewButton default background color (should have been grey but was set to light_grey accidentally in PR #1905 right before the 2.0.0 firmware release)

2.  Revert some of the foreground color changes in FileMan that were made in PR #2010 to compensate for the error in PR #1905.

This change restores the NewButton backgound color in FileMan, FreqMan, Replay, Remote, and Notepad apps.  The original grey was a better background color because there is more contrast when the button is selected; with the light_grey background it was more difficult to see certain icon colors and not as obvious which button was selected.