### PR TITLE
fix gui glitch on beep squelch

### DIFF
--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -127,7 +127,7 @@ class LevelView : public View {
 
     NumberField field_beep_squelch{
         {25 * 8, 3 * 16 + 4},
-        3,
+        4,
         {-120, 12},
         1,
         ' ',


### PR DESCRIPTION
All is in the title.

Missed one character when the number is negative...