### PR TITLE
Looking glass beep

### DIFF
--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -197,7 +197,7 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     }
 
     if (beep && statistics.max_db > beep_squelch) {
-        baseband::request_audio_beep(map(statistics.max_db, -100, 20, 400, 2600), 24000, 250);
+        baseband::request_audio_beep(map(statistics.max_db, -100, 20, 400, 2600), 24000, 150);
     }
 
     // refresh sat

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -35,6 +35,11 @@ using portapack::memory::map::backup_ram;
 
 namespace ui {
 
+// Function to map the value from one range to another
+int32_t LevelView::map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
+    return toLow + (value - fromLow) * (toHigh - toLow) / (fromHigh - fromLow);
+}
+
 void LevelView::m4_manage_stat_update() {
     if (audio_mode) {
         if (radio_mode == WFM_MODULATION || radio_mode == SPEC_MODULATION) {
@@ -192,7 +197,7 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     }
 
     if (beep && statistics.max_db > beep_squelch) {
-        baseband::request_audio_beep(((132 + statistics.max_db) * 2000) / 120, 24000, 250);
+        baseband::request_audio_beep(map(statistics.max_db, -100, 20, 400, 2600), 24000, 250);
     }
 
     // refresh sat

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -56,6 +56,7 @@ class LevelView : public View {
 
     RxRadioState radio_state_{};
 
+    int32_t map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh);
     size_t change_mode(freqman_index_t mod_type);
     void on_statistics_update(const ChannelStatistics& statistics);
     void set_display_freq(int64_t freq);
@@ -128,7 +129,7 @@ class LevelView : public View {
     NumberField field_beep_squelch{
         {25 * 8, 3 * 16 + 4},
         4,
-        {-120, 12},
+        {-100, 20},
         1,
         ' ',
     };

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -45,7 +45,7 @@ void GlassView::update_display_beep() {
        if( beep_enabled ) {
             button_beep_squelch.set_style( &Styles::green );
             //                            <bip:-XXXdb>
-            button_beep_squelch.set_text("<bip:"+to_string_dec_int(beep_squelch,4) + "db>");
+            button_beep_squelch.set_text("<bip:>"+to_string_dec_int(beep_squelch,4) + "%>");
             receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // WM8731 hack.
       } else {
             button_beep_squelch.set_style( &Styles::white );
@@ -213,7 +213,9 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
         // process actual bin
         if( process_bins(&max_power) )
         {
-            if( range_max_power >= beep_squelch )
+            uint8_t real_beep_squelch = beep_squelch * 255 / 100 ;
+
+            if( range_max_power >= real_beep_squelch )
             {
                 baseband::request_audio_beep( 400 + (((256-range_max_power) * 2600)/255), 24000, 500);
             }
@@ -548,8 +550,8 @@ GlassView::GlassView(
             int new_beep_squelch = beep_squelch + button_beep_squelch.get_encoder_delta();
             if( new_beep_squelch < 0 )
                 new_beep_squelch = 0 ;
-            if( new_beep_squelch > 255 )
-                new_beep_squelch = 255 ;
+            if( new_beep_squelch > 100 )
+                new_beep_squelch = 100 ;
             beep_squelch = new_beep_squelch ;
         button_beep_squelch.set_encoder_delta(0);
         update_display_beep();

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -25,6 +25,7 @@
 #include "convert.hpp"
 #include "file_reader.hpp"
 #include "string_format.hpp"
+#include "audio.hpp"
 
 using namespace portapack;
 
@@ -34,10 +35,34 @@ void GlassView::focus() {
 }
 
 GlassView::~GlassView() {
+    audio::output::stop();
     receiver_model.set_sampling_rate(3072000);  // Just a hack to avoid hanging other apps
     receiver_model.disable();
     baseband::shutdown();
 }
+
+void GlassView::update_display_beep() {
+       if( beep_enabled ) {
+            button_beep_squelch.set_style( &Styles::green );
+            //                            <bip:-XXXdb>
+            button_beep_squelch.set_text("<bip:"+to_string_dec_int(beep_squelch,4) + "db>");
+            receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // WM8731 hack.
+      } else {
+            button_beep_squelch.set_style( &Styles::white );
+            button_beep_squelch.set_text( "< beep OFF >" ); 
+        }
+}
+
+void GlassView::manage_beep_audio() {
+     if( beep_enabled ) {
+            audio::set_rate(audio::Rate::Hz_48000);
+            audio::output::start();
+        } else {
+            baseband::request_beep_stop();
+            audio::output::stop();
+        }
+}
+
 
 void GlassView::get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power) {
     if (mode == LOOKING_GLASS_SINGLEPASS) {
@@ -173,6 +198,8 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
     // we actually need SCREEN_W (240) of those bins
     for (uint8_t bin = 0; bin < bin_length; bin++) {
         get_max_power(spectrum, bin, max_power);
+        if( max_power > range_max_power )
+            range_max_power = max_power ;
         // process dc spike if enable
         if (bin == 119) {
             uint8_t next_max_power = 0;
@@ -184,14 +211,22 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
             }
         }
         // process actual bin
-        if (process_bins(&max_power) == true)
+        if( process_bins(&max_power) )
+        {
+            if( range_max_power >= beep_squelch )
+            {
+                baseband::request_audio_beep( 400 + (((256-range_max_power) * 2600)/255), 24000, 500);
+            }
+            range_max_power = 0 ;
             return;  // new line signaled, return
+        }
     }
     if (mode != LOOKING_GLASS_SINGLEPASS) {
         f_center += looking_glass_step;
         retune();
-    } else
+    } else {
         baseband::spectrum_streaming_start();
+    }
 }
 
 void GlassView::on_hide() {
@@ -319,6 +354,7 @@ void GlassView::update_range_field() {
 GlassView::GlassView(
     NavigationView& nav)
     : nav_(nav) {
+
     baseband::run_image(portapack::spi_flash::image_tag_wideband_spectrum);
 
     add_children({&labels,
@@ -331,9 +367,11 @@ GlassView::GlassView(
                   &scan_type,
                   &view_config,
                   &level_integration,
+                  &field_volume,
                   &filter_config,
                   &field_rf_amp,
                   &range_presets,
+                  &button_beep_squelch,
                   &field_marker,
                   &field_trigger,
                   &button_jump,
@@ -497,6 +535,28 @@ GlassView::GlassView(
     receiver_model.set_baseband_bandwidth(looking_glass_bandwidth);  // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
     receiver_model.set_squelch_level(0);
     receiver_model.enable();
+
+     
+    button_beep_squelch.on_select = [this](ButtonWithEncoder& button) {
+        (void)button;
+        beep_enabled = 1 - beep_enabled ;
+        manage_beep_audio();
+        update_display_beep();
+    };
+
+    button_beep_squelch.on_change = [this]() {
+            int new_beep_squelch = beep_squelch + button_beep_squelch.get_encoder_delta();
+            if( new_beep_squelch < 0 )
+                new_beep_squelch = 0 ;
+            if( new_beep_squelch > 255 )
+                new_beep_squelch = 255 ;
+            beep_squelch = new_beep_squelch ;
+        button_beep_squelch.set_encoder_delta(0);
+        update_display_beep();
+    };
+
+    manage_beep_audio();
+    update_display_beep();
 }
 
 uint8_t GlassView::get_spec_iq_phase_calibration_value() {  // define accessor functions inside AnalogAudioView to read & write real iq_phase_calibration_value

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -42,27 +42,26 @@ GlassView::~GlassView() {
 }
 
 void GlassView::update_display_beep() {
-       if( beep_enabled ) {
-            button_beep_squelch.set_style( &Styles::green );
-            //                            <bip:-XXXdb>
-            button_beep_squelch.set_text("<bip:>"+to_string_dec_int(beep_squelch,4) + "%>");
-            receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // WM8731 hack.
-      } else {
-            button_beep_squelch.set_style( &Styles::white );
-            button_beep_squelch.set_text( "< beep OFF >" ); 
-        }
+    if (beep_enabled) {
+        button_beep_squelch.set_style(&Styles::green);
+        // <bip:-XXXdb>
+        button_beep_squelch.set_text("<bip:>" + to_string_dec_int(beep_squelch, 4) + "%>");
+        receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // WM8731 hack.
+    } else {
+        button_beep_squelch.set_style(&Styles::white);
+        button_beep_squelch.set_text("< beep OFF >");
+    }
 }
 
 void GlassView::manage_beep_audio() {
-     if( beep_enabled ) {
-            audio::set_rate(audio::Rate::Hz_48000);
-            audio::output::start();
-        } else {
-            baseband::request_beep_stop();
-            audio::output::stop();
-        }
+    if (beep_enabled) {
+        audio::set_rate(audio::Rate::Hz_48000);
+        audio::output::start();
+    } else {
+        baseband::request_beep_stop();
+        audio::output::stop();
+    }
 }
-
 
 void GlassView::get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power) {
     if (mode == LOOKING_GLASS_SINGLEPASS) {
@@ -198,8 +197,8 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
     // we actually need SCREEN_W (240) of those bins
     for (uint8_t bin = 0; bin < bin_length; bin++) {
         get_max_power(spectrum, bin, max_power);
-        if( max_power > range_max_power )
-            range_max_power = max_power ;
+        if (max_power > range_max_power)
+            range_max_power = max_power;
         // process dc spike if enable
         if (bin == 119) {
             uint8_t next_max_power = 0;
@@ -211,15 +210,13 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
             }
         }
         // process actual bin
-        if( process_bins(&max_power) )
-        {
-            uint8_t real_beep_squelch = beep_squelch * 255 / 100 ;
+        if (process_bins(&max_power)) {
+            uint8_t real_beep_squelch = beep_squelch * 255 / 100;
 
-            if( range_max_power >= real_beep_squelch )
-            {
-                baseband::request_audio_beep( 400 + (((256-range_max_power) * 2600)/255), 24000, 500);
+            if (range_max_power >= real_beep_squelch) {
+                baseband::request_audio_beep(400 + (((256 - range_max_power) * 2600) / 255), 24000, 500);
             }
-            range_max_power = 0 ;
+            range_max_power = 0;
             return;  // new line signaled, return
         }
     }
@@ -356,7 +353,6 @@ void GlassView::update_range_field() {
 GlassView::GlassView(
     NavigationView& nav)
     : nav_(nav) {
-
     baseband::run_image(portapack::spi_flash::image_tag_wideband_spectrum);
 
     add_children({&labels,
@@ -365,7 +361,7 @@ GlassView::GlassView(
                   &field_lna,
                   &field_vga,
                   &field_range,
-                  &steps_config,
+                  //&steps_config,
                   &scan_type,
                   &view_config,
                   &level_integration,
@@ -410,12 +406,12 @@ GlassView::GlassView(
         };
     };
 
-    steps_config.on_change = [this](size_t, OptionsField::value_t v) {
+    /*steps_config.on_change = [this](size_t, OptionsField::value_t v) {
         field_frequency_min.set_step(v);
         field_frequency_max.set_step(v);
         steps = v;
     };
-    steps_config.set_selected_index(0);  // 1 Mhz step.
+    steps_config.set_selected_index(0);  // 1 Mhz step.*/
 
     scan_type.on_change = [this](size_t, OptionsField::value_t v) {
         mode = v;
@@ -538,21 +534,20 @@ GlassView::GlassView(
     receiver_model.set_squelch_level(0);
     receiver_model.enable();
 
-     
     button_beep_squelch.on_select = [this](ButtonWithEncoder& button) {
         (void)button;
-        beep_enabled = 1 - beep_enabled ;
+        beep_enabled = 1 - beep_enabled;
         manage_beep_audio();
         update_display_beep();
     };
 
     button_beep_squelch.on_change = [this]() {
-            int new_beep_squelch = beep_squelch + button_beep_squelch.get_encoder_delta();
-            if( new_beep_squelch < 0 )
-                new_beep_squelch = 0 ;
-            if( new_beep_squelch > 100 )
-                new_beep_squelch = 100 ;
-            beep_squelch = new_beep_squelch ;
+        int new_beep_squelch = beep_squelch + button_beep_squelch.get_encoder_delta();
+        if (new_beep_squelch < 0)
+            new_beep_squelch = 0;
+        if (new_beep_squelch > 100)
+            new_beep_squelch = 100;
+        beep_squelch = new_beep_squelch;
         button_beep_squelch.set_encoder_delta(0);
         update_display_beep();
     };

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -60,7 +60,7 @@ void GlassView::update_display_beep() {
 
 void GlassView::manage_beep_audio() {
     if (beep_enabled) {
-        audio::set_rate(audio::Rate::Hz_48000);
+        audio::set_rate(audio::Rate::Hz_24000);
         audio::output::start();
     } else {
         baseband::request_beep_stop();
@@ -218,7 +218,7 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
         if (process_bins(&max_power)) {
             int8_t power = map(range_max_power, 0, 255, -100, 20);
             if (power >= beep_squelch) {
-                baseband::request_audio_beep(map(range_max_power, 0, 256, 400, 2600), 24000, 500);
+                baseband::request_audio_beep(map(range_max_power, 0, 256, 400, 2600), 24000, 250);
             }
             range_max_power = 0;
             return;  // new line signaled, return

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -45,7 +45,7 @@ void GlassView::update_display_beep() {
     if (beep_enabled) {
         button_beep_squelch.set_style(&Styles::green);
         // <bip:-XXXdb>
-        button_beep_squelch.set_text("<bip:>" + to_string_dec_int(beep_squelch, 4) + "%>");
+        button_beep_squelch.set_text("<bip: >" + to_string_dec_int(beep_squelch, 3) + "%>");
         receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // WM8731 hack.
     } else {
         button_beep_squelch.set_style(&Styles::white);

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -85,8 +85,8 @@ class GlassView : public View {
     uint8_t live_frequency_view = 0;         // Spectrum
     uint8_t live_frequency_integrate = 3;    // Default (3 * old value + new_value) / 4
     uint8_t iq_phase_calibration_value{15};  // initial default RX IQ phase calibration value , used for both max2837 & max2839
-    int32_t beep_squelch = 20 ;                // range from -100 to +20, >=20 disabled
-    bool beep_enabled = false ;              // activate on bip button click
+    int32_t beep_squelch = 20;               // range from -100 to +20, >=20 disabled
+    bool beep_enabled = false;               // activate on bip button click
     app_settings::SettingsManager settings_{
         "rx_glass"sv,
         app_settings::Mode::RX,
@@ -169,15 +169,13 @@ class GlassView : public View {
     uint8_t offset = 0;
     uint8_t ignore_dc = 0;
 
-    AudioVolumeField field_volume{
-        {24 * 8, 0 * 16}};
-
     Labels labels{
         {{0, 0 * 16}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
         {{0, 1 * 16}, "RANGE:       FILTER:     AMP:", Color::light_grey()},
         {{0, 2 * 16}, "PRESET:", Color::light_grey()},
         {{0, 3 * 16}, "MARKER:          MHz RXIQCAL", Color::light_grey()},
-        {{0, 4 * 16}, "RES:    STEP:", Color::light_grey()}};
+        //{{0, 4 * 16}, "RES:    STEPS:", Color::light_grey()}};
+        {{0, 4 * 16}, "RES:     VOL:", Color::light_grey()}};
 
     NumberField field_frequency_min{
         {4 * 8, 0 * 16},
@@ -220,8 +218,8 @@ class GlassView : public View {
         10,
         {}};
 
-    ButtonWithEncoder button_beep_squelch {
-      {18 * 8, 2 * 16 + 4, 12 * 8, 1 * 8},
+    ButtonWithEncoder button_beep_squelch{
+        {18 * 8, 2 * 16 + 4, 12 * 8, 1 * 8},
         ""};
 
     TextField field_marker{
@@ -243,7 +241,10 @@ class GlassView : public View {
         2,
         ' '};
 
-    OptionsField steps_config{
+    AudioVolumeField field_volume{
+        {13 * 8, 4 * 16}};
+
+    /*OptionsField steps_config{
         {13 * 8, 4 * 16},
         3,
         {
@@ -253,7 +254,7 @@ class GlassView : public View {
             {"100", 100},
             {"250", 250},
             {"500", 500},
-        }};
+        }};*/
 
     OptionsField scan_type{
         {17 * 8, 4 * 16},

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -110,6 +110,7 @@ class GlassView : public View {
         std::string label{};
     };
 
+    int32_t map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh);
     std::vector<preset_entry> presets_db{};
     void manage_beep_audio();
     void update_display_beep();

--- a/firmware/baseband/proc_wideband_spectrum.cpp
+++ b/firmware/baseband/proc_wideband_spectrum.cpp
@@ -60,7 +60,32 @@ void WidebandSpectrum::execute(const buffer_c8_t& buffer) {
     }
 }
 
+
+void WidebandSpectrum::on_signal_message(const RequestSignalMessage& message) {
+    if (message.signal == RequestSignalMessage::Signal::BeepStopRequest) {
+        audio::dma::beep_stop();
+    }
+}
+
+void WidebandSpectrum::on_beep_message(const AudioBeepMessage& message) {
+    audio::dma::beep_start(message.freq, message.sample_rate, message.duration_ms);
+}
+
 void WidebandSpectrum::on_message(const Message* const msg) {
+    
+    switch (msg->id) {
+        case Message::ID::RequestSignal:
+            on_signal_message(*reinterpret_cast<const RequestSignalMessage*>(msg));
+            return;
+
+        case Message::ID::AudioBeep:
+            on_beep_message(*reinterpret_cast<const AudioBeepMessage*>(msg));
+            return;
+
+        default:
+            break;
+    }
+
     const WidebandSpectrumConfigMessage message = *reinterpret_cast<const WidebandSpectrumConfigMessage*>(msg);
 
     switch (msg->id) {
@@ -77,6 +102,7 @@ void WidebandSpectrum::on_message(const Message* const msg) {
             configured = true;
             break;
 
+        
         default:
             break;
     }
@@ -84,7 +110,6 @@ void WidebandSpectrum::on_message(const Message* const msg) {
 
 int main() {
     audio::dma::init_audio_out();  // for AudioRX app (enables audio output while this baseband image is running)
-
     EventDispatcher event_dispatcher{std::make_unique<WidebandSpectrum>()};
     event_dispatcher.run();
     return 0;

--- a/firmware/baseband/proc_wideband_spectrum.cpp
+++ b/firmware/baseband/proc_wideband_spectrum.cpp
@@ -60,7 +60,6 @@ void WidebandSpectrum::execute(const buffer_c8_t& buffer) {
     }
 }
 
-
 void WidebandSpectrum::on_signal_message(const RequestSignalMessage& message) {
     if (message.signal == RequestSignalMessage::Signal::BeepStopRequest) {
         audio::dma::beep_stop();
@@ -72,7 +71,6 @@ void WidebandSpectrum::on_beep_message(const AudioBeepMessage& message) {
 }
 
 void WidebandSpectrum::on_message(const Message* const msg) {
-    
     switch (msg->id) {
         case Message::ID::RequestSignal:
             on_signal_message(*reinterpret_cast<const RequestSignalMessage*>(msg));
@@ -102,7 +100,6 @@ void WidebandSpectrum::on_message(const Message* const msg) {
             configured = true;
             break;
 
-        
         default:
             break;
     }

--- a/firmware/baseband/proc_wideband_spectrum.hpp
+++ b/firmware/baseband/proc_wideband_spectrum.hpp
@@ -42,6 +42,9 @@ class WidebandSpectrum : public BasebandProcessor {
    private:
     bool configured = false;
     size_t baseband_fs = 20000000;
+   
+    void on_beep_message(const AudioBeepMessage& message);
+    void on_signal_message(const RequestSignalMessage& message);
 
     SpectrumCollector channel_spectrum{};
 

--- a/firmware/baseband/proc_wideband_spectrum.hpp
+++ b/firmware/baseband/proc_wideband_spectrum.hpp
@@ -42,7 +42,7 @@ class WidebandSpectrum : public BasebandProcessor {
    private:
     bool configured = false;
     size_t baseband_fs = 20000000;
-   
+
     void on_beep_message(const AudioBeepMessage& message);
     void on_signal_message(const RequestSignalMessage& message);
 


### PR DESCRIPTION
This add a squelch based beep option on Looking Glass:

- It can be enabled/disabled 
- Squelch level before activating beep is adjustable
- Detection use the whole range
- In order to add the necessary volume field, I took out the (IMHO) not useful 'STEPS'

Can be seen here:
https://discord.com/channels/719669764804444213/738371118204846131/1221545809179578418

Test bin here:
https://discord.com/channels/719669764804444213/722101917135798312/1221552584704135219