### PR TITLE
removed unused field _frequency and associated code

### DIFF
--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -44,29 +44,13 @@ AudioSpectrumView::AudioSpectrumView(
     set_focusable(true);
 
     add_children({&labels,
-                  &field_frequency,
                   &waveform});
-
-    field_frequency.on_change = [this](int32_t) {
-        set_dirty();
-    };
-    field_frequency.set_value(0);
 }
 
 void AudioSpectrumView::paint(Painter& painter) {
     const auto r = screen_rect();
 
     painter.fill_rectangle(r, Color::black());
-
-    // if( !spectrum_sampling_rate ) return;
-
-    // Cursor
-    const Rect r_cursor{
-        field_frequency.value() / (48000 / 240), r.bottom() - 32 - cursor_band_height,
-        1, cursor_band_height};
-    painter.fill_rectangle(
-        r_cursor,
-        Color::red());
 }
 
 void AudioSpectrumView::on_audio_spectrum(const AudioSpectrum* spectrum) {

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -43,8 +43,7 @@ AudioSpectrumView::AudioSpectrumView(
     : View{parent_rect} {
     set_focusable(true);
 
-    add_children({&labels,
-                  &waveform});
+    add_children({&waveform});
 }
 
 void AudioSpectrumView::paint(Painter& painter) {

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -51,13 +51,6 @@ class AudioSpectrumView : public View {
     Labels labels{
         {{6 * 8, 0 * 16}, "Hz", Color::light_grey()}};
 
-    NumberField field_frequency{
-        {0 * 8, 0 * 16},
-        5,
-        {0, 48000},
-        48000 / 240,
-        ' '};
-
     Waveform waveform{
         {0, 1 * 16 + cursor_band_height, 30 * 8, 2 * 16},
         audio_spectrum,

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -44,15 +44,10 @@ class AudioSpectrumView : public View {
     void on_audio_spectrum(const AudioSpectrum* spectrum);
 
    private:
-    static constexpr int cursor_band_height = 4;
-
     int16_t audio_spectrum[128]{0};
 
-    Labels labels{
-        {{6 * 8, 0 * 16}, "Hz", Color::light_grey()}};
-
     Waveform waveform{
-        {0, 1 * 16 + cursor_band_height, 30 * 8, 2 * 16},
+        {0, 0 * 16, 31 * 8, 2 * 16},
         audio_spectrum,
         128,
         0,


### PR DESCRIPTION
- Remove an unused field appearing only in audio WFM under the Rec button
- Removed unused label
- Resized WaveForm to fill the gap

Other spectrum view do not use the field.