### PR TITLE
FileMan support for folder Cut & Paste and Timestamp Rename

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -514,7 +514,10 @@ void FileManagerView::on_paste() {
     fs::filesystem_error result;
 
     if (clipboard_mode == ClipboardMode::Cut)
-        result = rename_file(clipboard_path, current_path / new_name);
+        if ((current_path / clipboard_path.filename()) == clipboard_path)
+            result = FR_OK;  // Skip paste to avoid renaming if path is unchanged
+        else
+            result = rename_file(clipboard_path, current_path / new_name);
 
     else if (clipboard_mode == ClipboardMode::Copy)
         result = copy_file(clipboard_path, current_path / new_name);
@@ -639,7 +642,7 @@ FileManagerView::FileManagerView(
     };
 
     button_cut.on_select = [this]() {
-        if (selected_is_valid() && !get_selected_entry().is_directory) {
+        if (selected_is_valid()) {
             clipboard_path = get_selected_full_path();
             clipboard_mode = ClipboardMode::Cut;
         } else
@@ -658,7 +661,7 @@ FileManagerView::FileManagerView(
         if (clipboard_mode != ClipboardMode::None)
             on_paste();
         else
-            nav_.display_modal("Paste", "Cut or copy a file first.");
+            nav_.display_modal("Paste", "  Cut or copy a file,\nor cut a folder, first.");
     };
 
     button_new_dir.on_select = [this]() {
@@ -678,7 +681,7 @@ FileManagerView::FileManagerView(
     };
 
     button_rename_timestamp.on_select = [this]() {
-        if (selected_is_valid() && !get_selected_entry().is_directory) {
+        if (selected_is_valid()) {
             on_rename(::truncate(to_string_timestamp(rtc_time::now()), 8));
         } else
             nav_.display_modal("Timestamp Rename", "Can't rename that.");

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -661,7 +661,7 @@ FileManagerView::FileManagerView(
         if (clipboard_mode != ClipboardMode::None)
             on_paste();
         else
-            nav_.display_modal("Paste", "  Cut or copy a file,\nor cut a folder, first.");
+            nav_.display_modal("Paste", "    Cut or copy a file,\n  or cut a folder, first.");
     };
 
     button_new_dir.on_select = [this]() {


### PR DESCRIPTION
1. Enabled support for Cut & Paste of folders.  Resolves #2052  (note that folder Copy still is not supported)
2. Enabled support for Timestamp Rename of folders (this is a good option for preserving user folders before unpacking a new SDcard image).
3. When Cut & Paste is used in the same directory, don't rename the file/folder by appending "_1".  The Cut & Paste operation now does nothing if the path is unchanged.

Test version:
https://discord.com/channels/719669764804444213/722101917135798312/1223021741140345005