### PR TITLE
Record app: Add GPS icon, fix overwrite bug

### DIFF
--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -144,6 +144,12 @@ class RecordView : public View {
         "",
     };
 
+    Image gps_icon{
+        {2 * 8 + 1, 0 * 16, 2 * 8, 1 * 16},
+        &bitmap_target,
+        Color::white(),
+        Color::black()};
+
     std::unique_ptr<CaptureThread> capture_thread{};
 
     MessageHandlerRegistration message_handler_capture_thread_error{


### PR DESCRIPTION
Added GPS icon to ui_record_view when there is a valid GPS position, since app start.
Also fixes file naming bug, when GEO files could get overwritten. Now GEO and non GEO files has separated counter.
Closes #2051 