### PR TITLE
Use Freq from App Settings unless override is passed from another app

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -175,16 +175,12 @@ void copy_to_radio_model(const AppSettings& settings) {
     // Specifically 'modulation' which requires a running baseband.
 
     if (flags_enabled(settings.mode, Mode::TX)) {
-        if (!flags_enabled(settings.options, Options::UseGlobalTargetFrequency))
-            persistent_memory::set_target_frequency(settings.tx_frequency);
-
+        persistent_memory::set_target_frequency(settings.tx_frequency);
         transmitter_model.configure_from_app_settings(settings);
     }
 
     if (flags_enabled(settings.mode, Mode::RX)) {
-        if (!flags_enabled(settings.options, Options::UseGlobalTargetFrequency))
-            persistent_memory::set_target_frequency(settings.rx_frequency);
-
+        persistent_memory::set_target_frequency(settings.rx_frequency);
         receiver_model.configure_from_app_settings(settings);
         receiver_model.set_configuration_without_update(
             static_cast<ReceiverModel::Mode>(settings.modulation),

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -118,9 +118,6 @@ enum class Mode : uint8_t {
 
 enum class Options {
     None = 0x0000,
-
-    /* Don't use target frequency from app settings. */
-    UseGlobalTargetFrequency = 0x0001,
 };
 
 /* NB: See RX/TX model headers for default values. */

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -208,7 +208,9 @@ AnalogAudioView::AnalogAudioView(
     NavigationView& nav,
     ReceiverModel::settings_t override)
     : AnalogAudioView(nav) {
+    // Settings to override when launched from another app (versus from AppSettings .ini file)
     // TODO: Which other settings make sense to override?
+    field_frequency.set_value(override.frequency_app_override);
     on_frequency_step_changed(override.frequency_step);
     options_modulation.set_by_value(toUType(override.mode));
 }

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -174,7 +174,6 @@ class AnalogAudioView : public View {
     app_settings::SettingsManager settings_{
         "rx_audio",
         app_settings::Mode::RX,
-        app_settings::Options::UseGlobalTargetFrequency,
         {
             {"iq_phase_calibration"sv, &iq_phase_calibration_value},  // we are saving and restoring that CAL from Settings.
         }};

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -104,6 +104,14 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 }
 
+CaptureAppView::CaptureAppView(
+    NavigationView& nav,
+    ReceiverModel::settings_t override)
+    : CaptureAppView(nav) {
+    // Settings to override when launched from another app (versus from AppSettings .ini file)
+    field_frequency.set_value(override.frequency_app_override);
+}
+
 CaptureAppView::~CaptureAppView() {
     receiver_model.disable();
     baseband::shutdown();

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -38,6 +38,7 @@ namespace ui {
 class CaptureAppView : public View {
    public:
     CaptureAppView(NavigationView& nav);
+    CaptureAppView(NavigationView& nav, ReceiverModel::settings_t override);
     ~CaptureAppView();
 
     void focus() override;
@@ -52,8 +53,7 @@ class CaptureAppView : public View {
     NavigationView& nav_;
     RxRadioState radio_state_{ReceiverModel::Mode::Capture};
     app_settings::SettingsManager settings_{
-        "rx_capture", app_settings::Mode::RX,
-        app_settings::Options::UseGlobalTargetFrequency};
+        "rx_capture", app_settings::Mode::RX};
 
     Labels labels{
         {{0 * 8, 1 * 16}, "Rate:", Color::light_grey()},

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -596,6 +596,7 @@ MicTXView::MicTXView(
     NavigationView& nav,
     ReceiverModel::settings_t override)
     : MicTXView(nav) {
+    // Settings to override when launched from another app (versus from AppSettings .ini file)
     // Try to use the modulation/bandwidth from RX settings.
     // TODO: These concepts should be merged so there's only one.
     switch (override.mode) {
@@ -616,6 +617,7 @@ MicTXView::MicTXView(
             break;
     }
 
+    field_frequency.set_value(override.frequency_app_override);
     check_common_freq_tx_rx.set_value(true);  // freq passed from other app is in tx_frequency, so set rx_frequency=tx_frequency
 
     // TODO: bandwidth selection is tied too tightly to the UI

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -118,7 +118,6 @@ class MicTXView : public View {
     app_settings::SettingsManager settings_{
         "tx_mic",
         app_settings::Mode::RX_TX,
-        app_settings::Options::UseGlobalTargetFrequency,
         {
             {"mic_mod_index"sv, &mic_mod_index},
             {"rxbw_index"sv, &rxbw_index},

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -508,7 +508,7 @@ ReconView::ReconView(NavigationView& nav)
         auto settings = receiver_model.settings();
         settings.frequency_step = step_mode.selected_index_value();
         if (field_mode.selected_index_value() == SPEC_MODULATION)
-            nav_.replace<CaptureAppView>();
+            nav_.replace<CaptureAppView>(settings);
         else
             nav_.replace<AnalogAudioView>(settings);
     };
@@ -539,7 +539,7 @@ ReconView::ReconView(NavigationView& nav)
             }
         }
 
-        // MicTX wants Modulation and Bandwidth overrides, but that's only stored on the RX model.
+        // MicTX wants Frequency, Modulation and Bandwidth overrides, but that's only stored on the RX model.
         nav_.replace<MicTXView>(receiver_model.settings());
     };
 

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -413,7 +413,7 @@ ScannerView::ScannerView(
     button_mic_app.on_select = [this](Button&) {
         if (scan_thread)
             scan_thread->stop();
-        // MicTX wants Modulation and Bandwidth overrides, but that's only stored on the RX model.
+        // MicTX wants Frequency, Modulation and Bandwidth overrides, but that's only stored on the RX model.
         nav_.replace<MicTXView>(receiver_model.settings());
     };
 

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -68,6 +68,7 @@ rf::Frequency ReceiverModel::target_frequency() const {
 
 void ReceiverModel::set_target_frequency(rf::Frequency f) {
     persistent_memory::set_target_frequency(f);
+    settings_.frequency_app_override = f;
     update_tuning_frequency();
 }
 

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -48,6 +48,7 @@ class ReceiverModel {
         uint32_t baseband_bandwidth = max283x::filter::bandwidth_minimum;
         uint32_t sampling_rate = 3'072'000;
         rf::Frequency frequency_step = 25'000;
+        rf::Frequency frequency_app_override = 0;
         uint8_t lna_gain_db = 32;
         uint8_t vga_gain_db = 32;
         bool rf_amp = false;


### PR DESCRIPTION
Before this PR:  The Capture, Audio, and Microphone apps always started up using whatever RX frequency was used last by any app.  For example, if you had been using Microphone app for HAM radio, then ran the ADSB RX app, and subsequently came back and ran the Microphone app again, the frequency in the Mic app would now be 1090MHz (ADSB freq) instead of the last frequency used in the Microphone app.

In this PR, the Capture, Audio, and Microphone app will remember and default to the frequency from the corresponding App Settings .ini file (so it'll go back to the HAM radio frequencies in the example above) **UNLESS** the app is launched from another app that passes an override frequency.

NOTE that if Capture, Audio, or Microphone is launched from the Scanner, Recon, or Looking Glass app, the override frequency from the starting app (Scanner, Recon, or Looking Glass) will be used instead of the saved frequencies in the App Settings .ini file.  This preserves the original behavior in the case where the app is "jumped to" from another app.

Resolves #1954 

Test firmware on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1223660759985422426

_NOTE:  There might be some people who prefer that the Capture, Audio, or Microphone app [and perhaps others] use the frequency from whatever app was last exited (not only in the case where the app was jumped to from another app).  I could make this a configuration setting if that is the case (basically the old "Load App Settings" checkbox)..._