### PR TITLE
fix build warning in settings

### DIFF
--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -810,8 +810,8 @@ class SetAutostartView : public View {
    private:
     int32_t i = 0;
     std::string autostart_app{""};
-    OptionsField::options_t opts;
-    std::map<int32_t, std::string> full_app_list;  // looking table
+    OptionsField::options_t opts {};
+    std::map<int32_t, std::string> full_app_list {};  // looking table
     int32_t selected = 0;
     SettingsStore nav_setting{
         "nav"sv,

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -810,8 +810,8 @@ class SetAutostartView : public View {
    private:
     int32_t i = 0;
     std::string autostart_app{""};
-    OptionsField::options_t opts {};
-    std::map<int32_t, std::string> full_app_list {};  // looking table
+    OptionsField::options_t opts{};
+    std::map<int32_t, std::string> full_app_list{};  // looking table
     int32_t selected = 0;
     SettingsStore nav_setting{
         "nav"sv,


### PR DESCRIPTION
Fix for : 
- ui::SetAutostartView::opts' should be initialized in the member initialization list

and

- ui::SetAutostartView::full_app_list' should be initialized in the member initialization list