### PR TITLE
Fix Cancel button in Settings->Autostart app

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -840,7 +840,8 @@ void SetMenuColorView::focus() {
     button_save.focus();
 }
 
-/* SetAutostartView*/
+/* SetAutoStartView ************************************/
+
 SetAutostartView::SetAutostartView(NavigationView& nav) {
     add_children({&labels,
                   &button_save,
@@ -848,7 +849,12 @@ SetAutostartView::SetAutostartView(NavigationView& nav) {
                   &options});
 
     button_save.on_select = [&nav, this](Button&) {
-        nav_setting.save();
+        autostart_app = "";
+        if (selected != 0) {
+            auto it = full_app_list.find(selected);
+            if (it != full_app_list.end())
+                autostart_app = it->second;
+        }
         nav.pop();
     };
 
@@ -879,14 +885,7 @@ SetAutostartView::SetAutostartView(NavigationView& nav) {
 
     options.set_options(opts);
     options.on_change = [this](size_t, OptionsField::value_t v) {
-        if (v == 0) {
-            autostart_app = "";
-            return;
-        }
-        auto it = full_app_list.find(v);
-        if (it != full_app_list.end()) {
-            autostart_app = it->second;
-        }
+        selected = v;
     };
     options.set_selected_index(selected);
 }

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -817,14 +817,15 @@ class SetAutostartView : public View {
         "nav"sv,
         {{"autostart_app"sv, &autostart_app}}};
     Labels labels{
-        {{1 * 8, 1 * 16}, "Select app to start on boot", Color::light_grey()}};
+        {{1 * 8, 1 * 16}, "Select app to start on boot", Color::light_grey()},
+        {{2 * 8, 2 * 16}, "(an SD Card is required)", Color::light_grey()}};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},
         "Save"};
 
     OptionsField options{
-        {0 * 8, 3 * 16},
+        {8 * 8, 4 * 16},
         30,
         {}};
 


### PR DESCRIPTION
1.  Fixed Cancel button (the destructor automatically saves app settings, so we shouldn't change "autostart_app" until Save is pressed.)

2. Added a note to the screen that an SD card is required (otherwise there's nowhere to save the nav.ini file).
