### PR TITLE
Mic audio ak4951 fix + SSTV description

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -523,21 +523,6 @@ MicTXView::MicTXView(
     };
     check_mic_to_HP.set_value(mic_to_HP_enabled);
 
-    check_rxactive.on_select = [this](Checkbox&, bool v) {
-        //		vumeter.set_value(0);	//Start with a clean vumeter
-        rx_enabled = v;
-        check_mic_to_HP.hidden(rx_enabled);  // Toggle Hide / show "Hear Mic" checkbox depending if we activate or not the receiver. (if RX on => no visible "Mic Hear" option)
-        if ((rx_enabled) && (transmitting))
-            check_mic_to_HP.set_value(transmitting);  // Once we activate the "Rx audio" in reception time we disable "Hear Mic", but we allow it again in TX time.
-
-        if (rx_enabled)
-            check_va.set_value(false);  // Disallow voice activation during RX audio (for now) - Future TODO: Should allow VOX during RX audio
-
-        rxaudio(v);   // Activate-Deactivate audio RX (receiver) accordingly
-        set_dirty();  // Refresh interface
-    };
-    check_rxactive.set_value(rx_enabled);
-
     tx_button.on_select = [this](Button&) {
         if (!transmitting) {
             set_tx(true);
@@ -590,6 +575,21 @@ MicTXView::MicTXView(
     // Trigger receiver to update modulation.
     if (rx_enabled)
         receiver_model.set_squelch_level(receiver_model.squelch_level());
+
+    check_rxactive.on_select = [this](Checkbox&, bool v) {
+        //		vumeter.set_value(0);	//Start with a clean vumeter
+        rx_enabled = v;
+        check_mic_to_HP.hidden(rx_enabled);  // Toggle Hide / show "Hear Mic" checkbox depending if we activate or not the receiver. (if RX on => no visible "Mic Hear" option)
+        if ((rx_enabled) && (transmitting))
+            check_mic_to_HP.set_value(transmitting);  // Once we activate the "Rx audio" in reception time we disable "Hear Mic", but we allow it again in TX time.
+
+        if (rx_enabled)
+            check_va.set_value(false);  // Disallow voice activation during RX audio (for now) - Future TODO: Should allow VOX during RX audio
+
+        rxaudio(v);   // Activate-Deactivate audio RX (receiver) accordingly
+        set_dirty();  // Refresh interface
+    };
+    check_rxactive.set_value(rx_enabled);
 }
 
 MicTXView::MicTXView(

--- a/sdcard/FREQMAN/SSTV.TXT
+++ b/sdcard/FREQMAN/SSTV.TXT
@@ -1,5 +1,5 @@
 # Common SSTV frequencies
-# frequencies marked Active have more frequent transmissions 
+# 'Active' => most used
 f=3640000,d=SSTV 80M
 f=7043000,d=SSTV 40M - Active
 f=7170000,d=SSTV 40M - Active


### PR DESCRIPTION
Mic app audio was not working when enabled on startup, only for my AK4951 (H1)

After digging in the code, I found a simple fix, which was initialize the audio at the very end of the constructor. 

It's working, and tested against WM8731 too.

I also did a minor comment fix in SSTV.TXT 