### PR TITLE
Fix bug in to_string_decimal

### DIFF
--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -159,6 +159,7 @@ std::string to_string_decimal(float decimal, int8_t precision) {
     double fractional_part;
 
     std::string result;
+    if (precision > 9) precision = 9;  // we will convert to uin32_t, and that is the max it can hold.
 
     fractional_part = modf(decimal, &integer_part) * pow(10, precision);
 


### PR DESCRIPTION
There is a bug in to_string_decimal, when we use too high precision (>9) the result will be invalid, since we will cast the double fraction value to uint32_t.
That can hold 9 digits safely. So limiting precision to 9.
