### PR TITLE
Disable Back button during Touch Calibration

### DIFF
--- a/firmware/application/apps/ui_touch_calibration.cpp
+++ b/firmware/application/apps/ui_touch_calibration.cpp
@@ -26,6 +26,8 @@
 #include "portapack_persistent_memory.hpp"
 using namespace portapack;
 
+extern ui::SystemView* system_view_ptr;
+
 namespace ui {
 
 TouchCalibrationView::TouchCalibrationView(
@@ -40,6 +42,7 @@ TouchCalibrationView::TouchCalibrationView(
         &image_verify_1,
         &image_verify_2,
         &label_calibrate,
+        &label_calibrate_2,
         &label_verify,
         &label_success,
         &label_failure,
@@ -51,6 +54,12 @@ TouchCalibrationView::TouchCalibrationView(
     button_ok.on_select = [this](Button&) { this->on_ok(); };
 
     set_phase(Phase::Calibrate0);
+
+    system_view_ptr->get_status_view()->set_back_hidden(true);
+}
+
+TouchCalibrationView::~TouchCalibrationView() {
+    system_view_ptr->get_status_view()->set_back_hidden(false);
 }
 
 void TouchCalibrationView::focus() {
@@ -70,6 +79,7 @@ void TouchCalibrationView::update_target() {
     image_verify_2.hidden(phase != Phase::Verify2);
 
     label_calibrate.hidden(!phase_calibrate);
+    label_calibrate_2.hidden(!phase_calibrate && !phase_verify);
     label_verify.hidden(!phase_verify);
     label_success.hidden(phase != Phase::Success);
     label_failure.hidden(phase != Phase::Failure);

--- a/firmware/application/apps/ui_touch_calibration.hpp
+++ b/firmware/application/apps/ui_touch_calibration.hpp
@@ -31,6 +31,7 @@ namespace ui {
 class TouchCalibrationView : public View {
    public:
     TouchCalibrationView(NavigationView& nav);
+    ~TouchCalibrationView();
 
     void focus() override;
 
@@ -110,8 +111,12 @@ class TouchCalibrationView : public View {
         Color::black()};
 
     Text label_calibrate{
-        {16, 5 * 16, 26 * 8, 1 * 16},
+        {2 * 8, 5 * 16, 26 * 8, 1 * 16},
         "Touch targets to calibrate"};
+
+    Text label_calibrate_2{
+        {1 * 8, 6 * 16, 28 * 8, 1 * 16},
+        "(hold position using stylus)"};
 
     Text label_verify{
         {28, 5 * 16, 23 * 8, 1 * 16},

--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -144,12 +144,15 @@ Continuous (Fox-oring)
 
 #include "rffc507x.hpp" /* c/m, avoiding initial short ON Ant_DC_Bias pulse, from cold reset  */
 rffc507x::RFFC507x first_if;
+ui::SystemView* system_view_ptr;
 
 static void event_loop() {
     static ui::Context context;
     static ui::SystemView system_view{
         context,
         portapack::display.screen_rect()};
+
+    system_view_ptr = &system_view;
 
     EventDispatcher event_dispatcher{&system_view, context};
     static MessageHandlerRegistration message_handler_display_sleep{

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -422,6 +422,10 @@ void SystemStatusView::set_back_enabled(bool new_value) {
     }
 }
 
+void SystemStatusView::set_back_hidden(bool new_value) {
+    button_back.hidden(new_value);
+}
+
 void SystemStatusView::set_title_image_enabled(bool new_value) {
     if (new_value) {
         add_child(&button_title);
@@ -895,6 +899,9 @@ Context& SystemView::context() const {
 }
 NavigationView* SystemView::get_navigation_view() {
     return &navigation_view;
+}
+SystemStatusView* SystemView::get_status_view() {
+    return &status_view;
 }
 
 void SystemView::toggle_overlay() {

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -185,6 +185,7 @@ class SystemStatusView : public View {
     SystemStatusView(NavigationView& nav);
 
     void set_back_enabled(bool new_value);
+    void set_back_hidden(bool new_value);
     void set_title_image_enabled(bool new_value);
     void set_title(const std::string new_value);
 
@@ -378,6 +379,7 @@ class SystemView : public View {
     void paint_overlay();
 
     NavigationView* get_navigation_view();
+    SystemStatusView* get_status_view();
 
    private:
     uint8_t overlay_active{0};


### PR DESCRIPTION
Kludge fix for #1976

An inelegant workaround to hide & disable the "back" button when the touchscreen calibration app is running.  This is only necessary because the first calibration position is so close to the back button, and the default touch calibration (based on some old H1) is very different from the latest H2+ screens.

Note that I did not hide/disable any other icons on the status bar because they're so far away from the calibration positions that they shouldn't be an issue.

If you have any better suggestion then feel free to propose an alternate solution...

I also added an extra hint message to the screen during calibration "(hold position using stylus)" as suggested in #1976