### PR TITLE
add real gcc ver chk

### DIFF
--- a/firmware/tools/bitmap_arr_reverse_decode.py
+++ b/firmware/tools/bitmap_arr_reverse_decode.py
@@ -1,3 +1,7 @@
+#
+# created by zxkmm on ArchHaseeHome - 2024/01/xx
+#
+
 from PIL import Image
 import numpy as np
 

--- a/firmware/tools/check_gcc_version_from_elf.py
+++ b/firmware/tools/check_gcc_version_from_elf.py
@@ -1,0 +1,41 @@
+#
+# Created by zxkmm on ArchHaseeHome - 2024/04/22
+#
+
+import subprocess
+import sys
+
+if_succeed = False
+
+
+def get_gcc_version(elf_file):
+    global if_succeed
+
+    output = subprocess.check_output(['readelf', '-p', '.comment', elf_file])
+    output = output.decode('utf-8')
+    lines = output.split('\n')
+
+    for line in lines:
+        if 'GCC:' in line:
+            version_info = line.split('GCC:')[1].strip()
+            if_succeed = True
+            return version_info
+
+    if not if_succeed:  # didn't use try except here cuz don't need to break compile if this is bad result anyway
+        return None
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        current_dir = subprocess.check_output(['pwd'])
+        print(f"current dir: {current_dir}")
+        print("usage python check_gcc_version_from_elf.py xxx.elf")
+        sys.exit(1)
+
+    elf_file = sys.argv[1]
+    version_info = get_gcc_version(elf_file)
+
+if version_info is not None:
+    print(f"real gcc version readed from elf: {version_info}")
+else:
+    print("something went wrong when checking gcc version don't worry tho, it's not deadly issue. skip.")

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
 # Copyright (C) 2024 Mark Thompson
+# Copyleft (ɔ) 2024 zxkmm with the GPL license
 #
 # This file is part of PortaPack.
 #
@@ -23,9 +24,11 @@
 #
 
 import sys
+import os
 from external_app_info import maximum_application_size
 from external_app_info import external_apps_address_start
 from external_app_info import external_apps_address_end
+import subprocess
 
 usage_message = """
 PortaPack SPI flash image generator
@@ -34,20 +37,59 @@ Usage: <command> <application_path> <baseband_path> <output_path>
        Where paths refer to the .bin files for each component project.
 """
 
+
 def read_image(path):
-	f = open(path, 'rb')
-	data = f.read()
-	f.close()
-	return data
+    f = open(path, 'rb')
+    data = f.read()
+    f.close()
+    return data
+
 
 def write_image(data, path):
-	f = open(path, 'wb')
-	f.write(data)
-	f.close()
+    f = open(path, 'wb')
+    f.write(data)
+    f.close()
+
+
+def get_gcc_version_from_elf(elf_file):
+    succeed = False
+
+    output = subprocess.check_output(['readelf', '-p', '.comment', elf_file])
+    output = output.decode('utf-8')
+    lines = output.split('\n')
+
+    for line in lines:
+        if 'GCC:' in line:
+            version_info = line.split('GCC:')[1].strip()
+            succeed = True
+            return version_info
+
+    if not succeed:  # didn't use try except here cuz don't need to break compile if this is bad result anyway
+        return None
+
+
+def get_gcc_version_from_elf_files_in_giving_path_or_filename_s_path(path):
+    elf_files = []
+    if os.path.isdir(path):
+        elf_files = [os.path.join(path, f) for f in os.listdir(path) if f.endswith(".elf")]
+    elif os.path.isfile(path):
+        elf_files = [os.path.join(os.path.dirname(path), f) for f in os.listdir(os.path.dirname(path)) if
+                     f.endswith(".elf")]
+    else:
+        print("gave path or filename is not valid")  # didn't use except nor exit here cuz don't need to break compile if this is bad result anyway
+
+    gcc_versions = []
+    for elf_file in elf_files:
+        version_info = get_gcc_version_from_elf(elf_file)
+        if version_info is not None:
+            extract_elf_file_name = os.path.basename(elf_file)
+            gcc_versions.append("gcc version of " + extract_elf_file_name + " is " + version_info)
+    return gcc_versions
+
 
 if len(sys.argv) != 4:
-	print(usage_message)
-	sys.exit(-1)
+    print(usage_message)
+    sys.exit(-1)
 
 application_image = read_image(sys.argv[1])
 baseband_image = read_image(sys.argv[2])
@@ -56,43 +98,47 @@ output_path = sys.argv[3]
 spi_size = 1048576
 
 images = (
-	{
-		'name': 'application',
-		'data': application_image,
-		'size': len(application_image),
-	},
-	{
-		'name': 'baseband',
-		'data': baseband_image,
-		'size': len(baseband_image),
-	},
+    {
+        'name': 'application',
+        'data': application_image,
+        'size': len(application_image),
+    },
+    {
+        'name': 'baseband',
+        'data': baseband_image,
+        'size': len(baseband_image),
+    },
 )
 
 spi_image = bytearray()
 spi_image_default_byte = bytearray((255,))
 
 for image in images:
-	if len(image['data']) > image['size']:
-		raise RuntimeError('data for image "%(name)s" is longer than 0x%(size)x bytes 0x%(sz)x' % {'name':image['name'], 'size':image['size'], 'sz':len(image['data'])})
-	pad_size = image['size'] - len(image['data'])
-	padded_data = image['data'] + (spi_image_default_byte * pad_size)
-	spi_image += padded_data
+    if len(image['data']) > image['size']:
+        raise RuntimeError(
+            'data for image "%(name)s" is longer than 0x%(size)x bytes 0x%(sz)x' % {'name': image['name'],
+                                                                                    'size': image['size'],
+                                                                                    'sz': len(image['data'])})
+    pad_size = image['size'] - len(image['data'])
+    padded_data = image['data'] + (spi_image_default_byte * pad_size)
+    spi_image += padded_data
 
 if len(spi_image) > spi_size - 4:
-	raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
+    raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
 
 pad_size = spi_size - 4 - len(spi_image)
 for i in range(pad_size):
-	spi_image += spi_image_default_byte
+    spi_image += spi_image_default_byte
 
 # quick "add up the words" checksum, and check for possible references to code in external apps
 checksum = 0
 for i in range(0, len(spi_image), 4):
-	snippet = spi_image[i:i+4]
-	val = int.from_bytes(snippet, byteorder='little')
-	checksum += val
-	if (val >= external_apps_address_start) and (val < external_apps_address_end) and ((val & 0xFFFF) < maximum_application_size):
-		print ("WARNING: Possible external code address", hex(val), "at offset", hex(i), "in", sys.argv[3])
+    snippet = spi_image[i:i + 4]
+    val = int.from_bytes(snippet, byteorder='little')
+    checksum += val
+    if (val >= external_apps_address_start) and (val < external_apps_address_end) and (
+            (val & 0xFFFF) < maximum_application_size):
+        print("WARNING: Possible external code address", hex(val), "at offset", hex(i), "in", sys.argv[3])
 
 final_checksum = 0
 checksum = (final_checksum - checksum) & 0xFFFFFFFF
@@ -102,4 +148,14 @@ spi_image += checksum.to_bytes(4, 'little')
 write_image(spi_image, output_path)
 
 percent_remaining = round(1000 * pad_size / spi_size) / 10;
-print ("Space remaining in flash ROM:", pad_size, "bytes (", percent_remaining, "%)")
+print("Space remaining in flash ROM:", pad_size, "bytes (", percent_remaining, "%)")
+
+print("check gcc versions from all elf target")
+application_gcc_versions = get_gcc_version_from_elf_files_in_giving_path_or_filename_s_path(sys.argv[1])
+baseband_gcc_versions = get_gcc_version_from_elf_files_in_giving_path_or_filename_s_path(sys.argv[2])
+
+for itap in application_gcc_versions:
+    print(itap)
+
+for itbb in baseband_gcc_versions:
+    print(itbb)


### PR DESCRIPTION
it's because it happend on me and gull that the current check gcc ver isn't that reliable.
This is read from elf target which were compiled, which should be accurate

~~NOTE that i'm not sure if this will break pipeline. i need to check on my fork HOWEVER~~ even after it passed from my side it's still need a nightly release to check work

readelf cmd is from binutils. ~~which idk if it's included in pipeline.~~ （edit： pipeline compile passed)


https://github.com/zxkmm/mayhem-firmware/actions/runs/8778357213