### PR TITLE
Invest limit bw ssb to 3 k

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -269,7 +269,7 @@ void MicTXView::set_rxbw_options(void) {
     }
 }
 
-void MicTXView::set_rxbw_defaults(bool use_app_settings) {
+void MicTXView::set_rxbw_defaults(bool use_app_settings) {      // Initially in that function we set up rxbw, but now also txbw.
     if (use_app_settings) {
         field_bw.set_value(transmitter_model.channel_bandwidth() / 1000);
         field_rxbw.set_by_value(rxbw_index);
@@ -285,7 +285,7 @@ void MicTXView::set_rxbw_defaults(bool use_app_settings) {
         field_rxbw.set_by_value(0);
     } else if ((mic_mod_index == MIC_MOD_USB) | (mic_mod_index == MIC_MOD_LSB)) {
         field_bw.set_value(3);     // In SSB by default let's limit TX_BW to 3kHz.
-        field_bw.set_range(2, 4);  // User range to modify that TX_BW.
+        field_bw.set_range(2, 3);  // User range to modify that TX_BW.  (TODO pending to investigate 4khz).
         field_bw.set_step(1);
     }
     // field_bw is hidden in other modulation cases

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -274,11 +274,19 @@ void MicTXView::set_rxbw_defaults(bool use_app_settings) {
         field_bw.set_value(transmitter_model.channel_bandwidth() / 1000);
         field_rxbw.set_by_value(rxbw_index);
     } else if (mic_mod_index == MIC_MOD_NFM) {
-        field_bw.set_value(10);  // NFM TX bw 10k, RX bw 16k (2) default
+        field_bw.set_value(10);     // NFM TX bw 10k, RX bw 16k (index 2) default
+        field_bw.set_range(1, 60);  // In NFM , FM , we are limitting index modulation range (0.08 ..5) ; (Ex max dev 60khz/12k = 5)
+        field_bw.set_step(1);
         field_rxbw.set_by_value(2);
     } else if (mic_mod_index == MIC_MOD_WFM) {
-        field_bw.set_value(75);  // WFM TX bw 75K, RX bw 200k (0) default
+        field_bw.set_value(75);       // WFM TX bw 75K, RX bw 200k (index 0) default
+        field_bw.set_range(20, 150);  // In our case Mod. Index range (1,67 ...12,5) ; 150k/12k=12,5
+        field_bw.set_step(1);
         field_rxbw.set_by_value(0);
+    } else if ((mic_mod_index == MIC_MOD_USB) | (mic_mod_index == MIC_MOD_LSB)) {
+        field_bw.set_value(3);     // In SSB by default let's limit TX_BW to 3khz.
+        field_bw.set_range(2, 8);  // User range to modify that TX_BW.
+        field_bw.set_step(1);
     }
     // field_bw is hidden in other modulation cases
 }
@@ -482,7 +490,11 @@ MicTXView::MicTXView(
             field_bw.hidden(false);
             options_tone_key.hidden(false);
         } else {
-            field_bw.hidden(true);
+            if ((mic_mod_index == MIC_MOD_USB) || (mic_mod_index == MIC_MOD_LSB)) {
+                field_bw.hidden(false);
+            } else {
+                field_bw.hidden(true);
+            }
             options_tone_key.set_selected_index(0);
             options_tone_key.hidden(true);
         }

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -277,15 +277,15 @@ void MicTXView::set_rxbw_defaults(bool use_app_settings) {
         field_bw.set_value(10);     // NFM TX bw 10k, RX bw 16k (index 2) default
         field_bw.set_range(1, 60);  // In NFM , FM , we are limitting index modulation range (0.08 ..5) ; (Ex max dev 60khz/12k = 5)
         field_bw.set_step(1);
-        field_rxbw.set_by_value(2);
+        field_rxbw.set_by_value(2);  // 16k from the three options (8k5,11k,16k)
     } else if (mic_mod_index == MIC_MOD_WFM) {
-        field_bw.set_value(75);       // WFM TX bw 75K, RX bw 200k (index 0) default
-        field_bw.set_range(20, 150);  // In our case Mod. Index range (1,67 ...12,5) ; 150k/12k=12,5
+        field_bw.set_value(75);      // WFM TX bw 75K, RX bw 200k (index 0) default
+        field_bw.set_range(1, 150);  // In our case Mod. Index range (1,67 ...12,5) ; 150k/12k=12,5
         field_bw.set_step(1);
         field_rxbw.set_by_value(0);
     } else if ((mic_mod_index == MIC_MOD_USB) | (mic_mod_index == MIC_MOD_LSB)) {
-        field_bw.set_value(3);     // In SSB by default let's limit TX_BW to 3khz.
-        field_bw.set_range(2, 8);  // User range to modify that TX_BW.
+        field_bw.set_value(3);     // In SSB by default let's limit TX_BW to 3kHz.
+        field_bw.set_range(2, 4);  // User range to modify that TX_BW.
         field_bw.set_step(1);
     }
     // field_bw is hidden in other modulation cases

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -269,7 +269,7 @@ void MicTXView::set_rxbw_options(void) {
     }
 }
 
-void MicTXView::set_rxbw_defaults(bool use_app_settings) {      // Initially in that function we set up rxbw, but now also txbw.
+void MicTXView::set_rxbw_defaults(bool use_app_settings) {  // Initially in that function we set up rxbw, but now also txbw.
     if (use_app_settings) {
         field_bw.set_value(transmitter_model.channel_bandwidth() / 1000);
         field_rxbw.set_by_value(rxbw_index);

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -148,10 +148,10 @@ class MicTXView : public View {
 
     Labels labels_both{
         {{3 * 8, 1 * 8}, "MIC-GAIN:", Theme::getInstance()->fg_light->foreground},
-        {{3 * 8, 3 * 8}, "F:", Theme::getInstance()->fg_light->foreground},
-        {{15 * 8, 3 * 8}, "FM TXBW:    kHz", Theme::getInstance()->fg_light->foreground},  // to be more symetric and consistent to the below FM RXBW
-        {{18 * 8, (5 * 8)}, "Mode:", Theme::getInstance()->fg_light->foreground},          // now, no need to handle GAIN, Amp here It is handled by ui_transmitter.cpp
-        {{4 * 8, 10 * 8}, "LVL:", Theme::getInstance()->fg_light->foreground},             // we delete  { {11 * 8, 5 * 8 }, "Amp:", Theme::getInstance()->fg_light->foreground },
+        {{3 * 8, 3 * 8}, "F:         MHz", Theme::getInstance()->fg_light->foreground},
+        {{18 * 8, 3 * 8}, "TXBW:    kHz", Theme::getInstance()->fg_light->foreground},  // to be more symetric and consistent to the below FM RXBW
+        {{18 * 8, (5 * 8)}, "Mode:", Theme::getInstance()->fg_light->foreground},       // now, no need to handle GAIN, Amp here It is handled by ui_transmitter.cpp
+        {{4 * 8, 10 * 8}, "LVL:", Theme::getInstance()->fg_light->foreground},          // we delete  { {11 * 8, 5 * 8 }, "Amp:", Theme::getInstance()->fg_light->foreground },
         {{12 * 8, 10 * 8}, "ATT:", Theme::getInstance()->fg_light->foreground},
         {{20 * 8, 10 * 8}, "DEC:", Theme::getInstance()->fg_light->foreground},
         {{3 * 8, (13 * 8) - 5}, "TONE KEY:", Theme::getInstance()->fg_light->foreground},

--- a/firmware/baseband/dsp_hilbert.cpp
+++ b/firmware/baseband/dsp_hilbert.cpp
@@ -27,6 +27,7 @@ namespace dsp {
 HilbertTransform::HilbertTransform() {
     n = 0;
 
+    sos_input.configure(half_band_lpf_config);
     sos_i.configure(half_band_lpf_config);
     sos_q.configure(half_band_lpf_config);
 }
@@ -34,22 +35,26 @@ HilbertTransform::HilbertTransform() {
 void HilbertTransform::execute(float in, float& out_i, float& out_q) {
     float a = 0, b = 0;
 
+    float in_filtered = sos_input.execute(in) * 1.0f;  // Anti-aliasing LPF at fs/4 mic audio filter front-end.
+    // it is exactly matching with the usefull mic BW_cut_off =fs/4 of the following Hilbert Transf. implementation
+    // Ex. to TX SSB  3khz BW (3KHZ =fs/4) ,we need to run Hiblert_Trf fs = 12khz . And our anti-aliasing filter is also fcut =fs/4 when we use a half_band_LPF .
+
     switch (n) {
         case 0:
-            a = in;
+            a = in_filtered;
             b = 0;
             break;
         case 1:
             a = 0;
-            b = -in;
+            b = -in_filtered;
             break;
         case 2:
-            a = -in;
+            a = -in_filtered;
             b = 0;
             break;
         case 3:
             a = 0;
-            b = in;
+            b = in_filtered;
             break;
     }
 

--- a/firmware/baseband/dsp_hilbert.hpp
+++ b/firmware/baseband/dsp_hilbert.hpp
@@ -34,6 +34,7 @@ class HilbertTransform {
 
    private:
     uint8_t n = 0;
+    SOSFilter<5> sos_input = {};
     SOSFilter<5> sos_i = {};
     SOSFilter<5> sos_q = {};
 };

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -82,30 +82,18 @@ SSB::SSB()
 }
 
 void SSB::set_fs_div_factor(float new_bw_ssb) {
-    switch ((int)new_bw_ssb) {
+    switch ((int)new_bw_ssb / 1000) {
         case 2:
-            fs_div_factor = 384;  // BW_ssb = 2khz => 4khz Sample Rate (fs) Hilbert ; The transceiver SR = 1.536.000; 1.536.000 /4000= 384
-            break;                // We need exact division, integer, with zero decimals
+            fs_div_factor = 192;  // TXBW_ssb = 2khz = fs/4 ; fs of Hilbert Transform => 8khz fs Hilbert = 1536.000/8000= 192
+            break;
         case 3:
-            fs_div_factor = 256;  // BW_ssb = 3khz => 6khz fs Hilbert = 1536.000/6000= 256
+            fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
             break;
         case 4:
-            fs_div_factor = 192;  // BW_ssb = 4khz => 8khz fs Hilbert = 1536.000/8000= 192
-            break;
-        case 5:
-            fs_div_factor = 160;  // Exact factor = 153,6 , but we can not use it . We will use closer aprox factor without decimals,
-            break;                // GUI will say BW 5khz, but real  BW_ssb = 4.8khz => 9.6khz fs Hilbert = 1536.000/9600= 160
-        case 6:
-            fs_div_factor = 128;  // BW_ssb = 6khz => 12khz fs Hilbert = 1536.000/12000= 128
-            break;
-        case 7:
-            fs_div_factor = 100;  // Exact factor = 109,71 , but we can not use it . We will use closer aprox factor without decimals,
-            break;                // GUI will say BW 7khz, but real  BW_ssb = 7.6khz => 15.3khz fs Hilbert = 1536.000/15360= 100
-        case 8:
-            fs_div_factor = 96;  // BW_ssb = 8khz => 16khz fs Hilbert = 1536.000/16000= 96
+            fs_div_factor = 96;  // TXBW_ssb = 4khz = fs/4 ; fs of Hilbert Transform => 16khz fs Hilbert = 1536.000/16000= 96
             break;
         default:
-            fs_div_factor = 128;  // BW_ssb = 6khz => 12khz fs Hilbert = 1536.000/12000= 128
+            fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
             break;
     }
 }

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -89,9 +89,11 @@ void SSB::set_fs_div_factor(float new_bw_ssb) {
         case 3:
             fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
             break;
+        /* TODO pending to investigate 4khz, now is making aliasing folding with audio sweep . 
         case 4:
             fs_div_factor = 96;  // TXBW_ssb = 4khz = fs/4 ; fs of Hilbert Transform => 16khz fs Hilbert = 1536.000/16000= 96
             break;
+        */    
         default:
             fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
             break;

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -110,7 +110,7 @@ void SSB::execute(const buffer_s16_t& audio, const buffer_c8_t& buffer, bool& co
     int8_t re = 0, im = 0;
 
     for (size_t counter = 0; counter < buffer.count; counter++) {
-        if (counter % fs_div_factor == 0) {  // Ex. bw_ssb 6khz ,  128 =  1.536.000 hz  / 12.000 hz
+        if (counter % fs_div_factor == 0) {  // Ex. TX bw_ssb 3khz =fs/4 Hilbert Transform sample rate,  128 =  1.536.000 hz  / 12.000 hz (fs H.T.)
             float i = 0.0, q = 0.0;
 
             // over = 1.536.000/24khz = 64 . (Mic audio has fixed SR in audio_p buffer[]  = 24khz), but in tx mode , we are running Transceiver fs @tx = 1.536.000 Hz.

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -89,11 +89,11 @@ void SSB::set_fs_div_factor(float new_bw_ssb) {
         case 3:
             fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
             break;
-        /* TODO pending to investigate 4khz, now is making aliasing folding with audio sweep . 
+        /* TODO pending to investigate 4khz,     now is making aliasing folding with audio sweep .
         case 4:
             fs_div_factor = 96;  // TXBW_ssb = 4khz = fs/4 ; fs of Hilbert Transform => 16khz fs Hilbert = 1536.000/16000= 96
             break;
-        */    
+        */
         default:
             fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
             break;

--- a/firmware/baseband/dsp_modulate.hpp
+++ b/firmware/baseband/dsp_modulate.hpp
@@ -79,9 +79,12 @@ class SSB : public Modulator {
     SSB();
 
     virtual void execute(const buffer_s16_t& audio, const buffer_c8_t& buffer, bool& configured_in, uint32_t& new_beep_index, uint32_t& new_beep_timer, TXProgressMessage& new_txprogress_message, AudioLevelReportMessage& new_level_message, uint32_t& new_power_acc_count, uint32_t& new_divider);
+    void set_fs_div_factor(float new_bw_ssb);
 
    private:
     dsp::HilbertTransform hilbert;
+    float new_bw_ssb{3.0};
+    int fs_div_factor{256};
 };
 
 ///

--- a/firmware/baseband/dsp_modulate.hpp
+++ b/firmware/baseband/dsp_modulate.hpp
@@ -84,7 +84,7 @@ class SSB : public Modulator {
    private:
     dsp::HilbertTransform hilbert;
     float new_bw_ssb{3.0};
-    int fs_div_factor{256};
+    int fs_div_factor{128};
 };
 
 ///

--- a/firmware/baseband/proc_mictx.cpp
+++ b/firmware/baseband/proc_mictx.cpp
@@ -113,13 +113,27 @@ void MicTXProcessor::on_message(const Message* const msg) {
             }
 
             if (usb_enabled) {
-                modulator = new dsp::modulate::SSB();
-                modulator->set_mode(dsp::modulate::Mode::USB);
+                dsp::modulate::SSB* ssb = new dsp::modulate::SSB();
+
+                // Config fs_div_factor  private var inside DSP modulate.cpp
+                ssb->set_fs_div_factor(config_message.deviation_hz);  // we use same FM var deviation_hz , to set up also SSB BW
+                ssb->set_mode(dsp::modulate::Mode::USB);
+                modulator = ssb;
+
+                // modulator = new dsp::modulate::SSB();             // Keeping previous code as ref., when not passing deviation_hz parameter.
+                // modulator->set_mode(dsp::modulate::Mode::USB);
             }
 
             if (lsb_enabled) {
-                modulator = new dsp::modulate::SSB();
-                modulator->set_mode(dsp::modulate::Mode::LSB);
+                dsp::modulate::SSB* ssb = new dsp::modulate::SSB();
+
+                // Config fs_div_factor  private var inside DSP modulate.cpp
+                ssb->set_fs_div_factor(config_message.deviation_hz);  // we use same FM var deviation_hz , to set up also SSB BW
+                ssb->set_mode(dsp::modulate::Mode::LSB);
+                modulator = ssb;
+
+                // modulator = new dsp::modulate::SSB();             // Keeping previous code as ref., when not passing deviation_hz parameter.
+                // modulator->set_mode(dsp::modulate::Mode::LSB);
             }
             if (am_enabled) {
                 modulator = new dsp::modulate::AM();


### PR DESCRIPTION
Second official attemp PR to try to close that issue #2180  (but all this week , we had several  testing trial fw's  between)
Special thanks to [ly2ss](https://github.com/ly2ss) , for his patience and deep checking support  ,and for  finding several bugs. Hopefully this time , all should be OK , 

We are correcting  previous  aliasing  folding  effect , when sending  an audio sweep signal. 
And we are also addressing a proper BW  SSB  limitation.  And moreover, we added the feature to be able to set up that BW , (but that user change settings , should be applied at PTT_OFF time . It is not a hot on the fly change . It will need PTT OFF ,setting change and PTT ON .

Here you can see all the three consecutive freq. limit changes 2k,3k,4khz in USB / LSB  test transmission , saturating the mic with audio air blow noise , at very low local dBm level .
![image](https://github.com/portapack-mayhem/mayhem-firmware/assets/86470699/2c8be3ed-feb5-48dd-9456-3faade8d3a2f)

Let's  wait for final test of  [ly2ss](https://github.com/ly2ss) ,  and thanks in advance. 

Pls. [ly2ss](https://github.com/ly2ss),  you can add the related comments here , after evaluating the latest fw , that I uploaded to the test-drive,

Cheers, 
