### PR TITLE
added --print-memory-usage to linker parameters

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -509,6 +509,7 @@ include_directories(. ${INCDIR})
 link_directories(${LLIBDIR})
 target_link_libraries(${PROJECT_NAME}.elf ${LIBS} "-L${CMAKE_CURRENT_LIST_DIR}/external")
 target_link_libraries(${PROJECT_NAME}.elf -Wl,-Map=${PROJECT_NAME}.map)
+target_link_libraries(${PROJECT_NAME}.elf -Wl,--print-memory-usage)
 
 add_custom_command(
 	OUTPUT ${PROJECT_NAME}.bin

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -278,7 +278,9 @@ macro(DeclareTargets chunk_tag name)
 	include_directories(. ${INCDIR} ${MODE_INCDIR})
 	link_directories(${LLIBDIR})
 	target_link_libraries(${PROJECT_NAME}.elf ${LIBS})
+	
 	target_link_libraries(${PROJECT_NAME}.elf -Wl,-Map=${PROJECT_NAME}.map)
+	target_link_libraries(${PROJECT_NAME}.elf -Wl,--print-memory-usage)
 
 	if(add_to_firmware)
 

--- a/firmware/standalone/pacman/CMakeLists.txt
+++ b/firmware/standalone/pacman/CMakeLists.txt
@@ -220,6 +220,7 @@ target_link_libraries(${PROJECT_NAME}.elf -Wl,-Map=${PROJECT_NAME}.map)
 # redirect std lib memory allocations
 target_link_libraries(${PROJECT_NAME}.elf "-Wl,-wrap,_malloc_r")
 target_link_libraries(${PROJECT_NAME}.elf "-Wl,-wrap,_free_r")
+target_link_libraries(${PROJECT_NAME}.elf "-Wl,--print-memory-usage")
 
 add_custom_command(
 	OUTPUT ${PROJECT_NAME}.ppmp


### PR DESCRIPTION
This pull request adds --print-memory-usage to linker parameters. The memory usage output helps to track the size and memory consumption while writing new applications.

Resulting change in compiler output:

![linker_info_baseband](https://github.com/user-attachments/assets/8c49eaba-eab2-4407-ae71-59be6ad722e1)

![linker_info_application](https://github.com/user-attachments/assets/90df4e98-b43b-47ee-9eba-ef33efd7549e)

![grafik](https://github.com/user-attachments/assets/f7987a95-0788-4b95-aa99-3add0d117d68)
