### PR TITLE
fixed usb serial not working after reconnect

### DIFF
--- a/firmware/application/usb_serial.cpp
+++ b/firmware/application/usb_serial.cpp
@@ -45,6 +45,7 @@ void USBSerial::dispatch_transfer() {
 }
 
 void USBSerial::on_channel_opened() {
+    reset_transfer_queues();
     connected = true;
 }
 

--- a/firmware/application/usb_serial_host_to_device.cpp
+++ b/firmware/application/usb_serial_host_to_device.cpp
@@ -54,6 +54,14 @@ void init_host_to_device() {
     thread_usb_event = chThdSelf();
 }
 
+void reset_transfer_queues() {
+    while (usb_bulk_buffer_queue.empty() == false)
+        usb_bulk_buffer_queue.pop();
+
+    while (usb_bulk_buffer_spare.empty() == false)
+        usb_bulk_buffer_spare.pop();
+}
+
 void schedule_host_to_device_transfer() {
     if (usb_bulk_buffer_queue.size() >= 8)
         return;

--- a/firmware/application/usb_serial_host_to_device.hpp
+++ b/firmware/application/usb_serial_host_to_device.hpp
@@ -27,6 +27,7 @@
 #define USB_BULK_BUFFER_SIZE 64
 
 void init_host_to_device();
+void reset_transfer_queues();
 void serial_bulk_transfer_complete(void* user_data, unsigned int bytes_transferred);
 void schedule_host_to_device_transfer();
 void complete_host_to_device_transfer();


### PR DESCRIPTION
This pull request fixes a bug that prevented the usb serial from working after reconnecting usb. This was only visible on devices that do not reset when usb is disconnected.