### PR TITLE
Move ADSBTX to ext

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -282,7 +282,7 @@ set(CPPSRC
 	# apps/tpms_app.cpp
 	apps/ui_about_simple.cpp
 	apps/ui_adsb_rx.cpp
-	apps/ui_adsb_tx.cpp
+	# apps/ui_adsb_tx.cpp #moved to ext
 	apps/ui_aprs_rx.cpp
 	apps/ui_aprs_tx.cpp
 	apps/ui_battinfo.cpp

--- a/firmware/application/external/adsbtx/main.cpp
+++ b/firmware/application/external/adsbtx/main.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui.hpp"
+#include "ui_adsb_tx.hpp"
+#include "ui_navigation.hpp"
+#include "external_app.hpp"
+
+namespace ui::external_app::adsbtx {
+void initialize_app(ui::NavigationView& nav) {
+    nav.push<ADSBTxView>();
+}
+}  // namespace ui::external_app::adsbtx
+
+extern "C" {
+
+__attribute__((section(".external_app.app_adsbtx.application_information"), used)) application_information_t _application_information_adsbtx = {
+    /*.memory_location = */ (uint8_t*)0x00000000,
+    /*.externalAppEntry = */ ui::external_app::adsbtx::initialize_app,
+    /*.header_version = */ CURRENT_HEADER_VERSION,
+    /*.app_version = */ VERSION_MD5,
+
+    /*.app_name = */ "ADSB-TX",
+    /*.bitmap_data = */ {
+        0x80,
+        0x01,
+        0xC0,
+        0x03,
+        0xC0,
+        0x03,
+        0xC0,
+        0x03,
+        0xC0,
+        0x03,
+        0xE0,
+        0x07,
+        0xF8,
+        0x1F,
+        0xFE,
+        0x7F,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xC0,
+        0x03,
+        0xC0,
+        0x03,
+        0xC0,
+        0x03,
+        0xE0,
+        0x07,
+        0xF0,
+        0x0F,
+        0xF8,
+        0x1F,
+    },
+    /*.icon_color = */ ui::Color::green().v,
+    /*.menu_location = */ app_location_t::TX,
+
+    /*.m4_app_tag = portapack::spi_flash::image_tag_adsbtx */ {'P', 'A', 'D', 'T'},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
+};
+}

--- a/firmware/application/external/adsbtx/ui_adsb_tx.cpp
+++ b/firmware/application/external/adsbtx/ui_adsb_tx.cpp
@@ -34,7 +34,7 @@
 using namespace adsb;
 using namespace portapack;
 
-namespace ui {
+namespace ui::external_app::adsbtx {
 
 Compass::Compass(
     const Point parent_pos)
@@ -311,7 +311,8 @@ void ADSBTxView::start_tx() {
 ADSBTxView::ADSBTxView(
     NavigationView& nav)
     : nav_{nav} {
-    baseband::run_image(portapack::spi_flash::image_tag_adsb_tx);
+    // baseband::run_image(portapack::spi_flash::image_tag_adsb_tx);
+    baseband::run_prepared_image(portapack::memory::map::m4_code.base());
 
     add_children({&tab_view,
                   &labels,
@@ -341,4 +342,4 @@ ADSBTxView::ADSBTxView(
     };
 }
 
-} /* namespace ui */
+} /* namespace ui::external_app::adsbtx */

--- a/firmware/application/external/adsbtx/ui_adsb_tx.hpp
+++ b/firmware/application/external/adsbtx/ui_adsb_tx.hpp
@@ -34,7 +34,7 @@
 
 using namespace adsb;
 
-namespace ui {
+namespace ui::external_app::adsbtx {
 
 class Compass : public Widget {
    public:
@@ -251,4 +251,4 @@ class ADSBTxView : public View {
     std::unique_ptr<ADSBTXThread> tx_thread{};
 };
 
-} /* namespace ui */
+}  // namespace ui::external_app::adsbtx

--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -84,6 +84,10 @@ set(EXTCPPSRC
 	#protoview
 	external/protoview/main.cpp
 	external/protoview/ui_protoview.cpp
+
+	#adsbtx
+	external/adsbtx/main.cpp
+	external/adsbtx/ui_adsb_tx.cpp
 )
 
 set(EXTAPPLIST
@@ -107,4 +111,5 @@ set(EXTAPPLIST
 	wardrivemap
 	tpmsrx
 	protoview
+	adsbtx
 )

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -43,6 +43,7 @@ MEMORY
     ram_external_app_wardrivemap(rwx) : org = 0xADC20000, len = 32k
     ram_external_app_tpmsrx(rwx) : org = 0xADC30000, len = 32k
     ram_external_app_protoview(rwx) : org = 0xADC40000, len = 32k
+    ram_external_app_adsbtx(rwx) : org = 0xADC50000, len = 32k
 }
 
 SECTIONS
@@ -167,6 +168,12 @@ SECTIONS
         KEEP(*(.external_app.app_protoview.application_information));
         *(*ui*external_app*protoview*);
     } > ram_external_app_protoview
+
+   .external_app_adsbtx : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_adsbtx.application_information));
+        *(*ui*external_app*adsbtx*);
+    } > ram_external_app_adsbtx
 
 
 }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -35,7 +35,7 @@
 
 #include "ui_about_simple.hpp"
 #include "ui_adsb_rx.hpp"
-#include "ui_adsb_tx.hpp"
+// #include "ui_adsb_tx.hpp" //moved to ext
 #include "ui_aprs_rx.hpp"
 #include "ui_aprs_tx.hpp"
 #include "ui_bht_tx.hpp"
@@ -181,7 +181,7 @@ const NavigationView::AppList NavigationView::appList = {
     //{"sstv", "SSTV", RX, Color::dark_grey(), &bitmap_icon_sstv, new ViewFactory<NotImplementedView>()},
     //{"tetra", "TETRA", RX, Color::dark_grey(), &bitmap_icon_tetra, new ViewFactory<NotImplementedView>()},
     /* TX ********************************************************************/
-    {"adsbtx", "ADS-B TX", TX, ui::Color::green(), &bitmap_icon_adsb, new ViewFactory<ADSBTxView>()},
+    //{"adsbtx", "ADS-B TX", TX, ui::Color::green(), &bitmap_icon_adsb, new ViewFactory<ADSBTxView>()},
     {"aprstx", "APRS TX", TX, ui::Color::green(), &bitmap_icon_aprs, new ViewFactory<APRSTXView>()},
     {"bht", "BHT Xy/EP", TX, ui::Color::green(), &bitmap_icon_bht, new ViewFactory<BHTView>()},
     {"bletx", "BLE Tx", TX, ui::Color::green(), &bitmap_icon_btle, new ViewFactory<BLETxView>()},

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -328,12 +328,6 @@ set(MODE_CPPSRC
 )
 DeclareTargets(PADR adsbrx)
 
-### ADS-B TX
-
-set(MODE_CPPSRC
-	proc_adsbtx.cpp
-)
-DeclareTargets(PADT adsbtx)
 
 ### AFSK TX
 
@@ -663,6 +657,14 @@ set(MODE_CPPSRC
 	proc_tpms.cpp
 )
 DeclareTargets(PTPM tpms)
+
+
+### ADS-B TX
+
+set(MODE_CPPSRC
+	proc_adsbtx.cpp
+)
+DeclareTargets(PADT adsbtx)
 
 
 ### HackRF "factory" firmware


### PR DESCRIPTION
Not so much fw space, but some bytes. Also "dangerous" app, so it can be deleted by user if don't wanna have it on pp.