### PR TITLE
Fix "standalone pacman" compile errors with gcc >9.2.1

### DIFF
--- a/firmware/standalone/pacman/CMakeLists.txt
+++ b/firmware/standalone/pacman/CMakeLists.txt
@@ -31,7 +31,7 @@ include(CheckCXXCompilerFlag)
 project(pacman_app)
 
 # Compiler options here.
-set(USE_OPT "-Os -g --specs=nano.specs")
+set(USE_OPT "-Os -g --specs=nano.specs --specs=nosys.specs")
 
 # C specific options here (added to USE_OPT).
 set(USE_COPT "-std=gnu99")
@@ -120,7 +120,7 @@ set(TCPPSRC)
 # List ASM source files here
 set(ASMSRC)
 
-set(INCDIR 
+set(INCDIR
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${COMMON}
 	${COMMON}/../application


### PR DESCRIPTION
Since the introduction of standalone pacman app in PR #2145, it's been impossible to build Mayhem firmware with any compiler version above 9.2.1.  (Yes I realize that 9.2.1 is the "official" build version but I prefer the warning message versus strange compiler errors below.)

This command line switch resolves the issue, and is already being used in the cmake file when building applications so there should be no adverse affects.

Thanks to @Brumi-2021 for this fix.

BTW, this is what the errors look like without this fix:
`/opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg_nano.a(lib_a-writer.o): in function `_write_r':
writer.c:(.text._write_r+0x10): undefined reference to `_write'
/opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg_nano.a(lib_a-closer.o): in function `_close_r':
closer.c:(.text._close_r+0xc): undefined reference to `_close'
/opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg_nano.a(lib_a-fstatr.o): in function `_fstat_r':
fstatr.c:(.text._fstat_r+0xe): undefined reference to `_fstat'
/opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg_nano.a(lib_a-isattyr.o): in function `_isatty_r':
isattyr.c:(.text._isatty_r+0xc): undefined reference to `_isatty'
/opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg_nano.a(lib_a-lseekr.o): in function `_lseek_r':
lseekr.c:(.text._lseek_r+0x10): undefined reference to `_lseek'
/opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /opt/build/armbin/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg_nano.a(lib_a-readr.o): in function `_read_r':
readr.c:(.text._read_r+0x10): undefined reference to `_read'
collect2: error: ld returned 1 exit status
make[2]: *** [firmware/standalone/pacman/CMakeFiles/pacman_app.elf.dir/build.make:114: firmware/standalone/pacman/pacman_app.elf] Error 1
make[1]: *** [CMakeFiles/Makefile2:2095: firmware/standalone/pacman/CMakeFiles/pacman_app.elf.dir/all] Error 2
`