### PR TITLE
Needed_changes_to_compile_with_gcc_13.2.1

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -281,6 +281,7 @@ void EventDispatcher::emulateTouch(ui::TouchEvent event) {
     while (injected_touch_event != nullptr) {
         chThdSleepMilliseconds(5);
     }
+    injected_touch_event = nullptr;  // to clean event_mo.cpp, compile warning error : "storing the address of local variable 'event' in 'this_4(D)->injected_touch_event' [-Wdangling-pointer=]"
 }
 
 void EventDispatcher::emulateKeyboard(ui::KeyboardEvent event) {
@@ -288,6 +289,7 @@ void EventDispatcher::emulateKeyboard(ui::KeyboardEvent event) {
     while (injected_keyboard_event != nullptr) {
         chThdSleepMilliseconds(5);
     }
+    injected_keyboard_event = nullptr;  // to clean event_mo.cpp, compile warning error : "storing the address of local variable 'event' in 'this_4(D)->injected_keyboard_event' [-Wdangling-pointer=]"
 }
 
 void EventDispatcher::on_keyboard_event(ui::KeyboardEvent event) {

--- a/firmware/standalone/pacman/CMakeLists.txt
+++ b/firmware/standalone/pacman/CMakeLists.txt
@@ -31,7 +31,7 @@ include(CheckCXXCompilerFlag)
 project(pacman_app)
 
 # Compiler options here.
-set(USE_OPT "-Os -g --specs=nano.specs")
+set(USE_OPT "-Os -g --specs=nano.specs --specs=nosys.specs")
 
 # C specific options here (added to USE_OPT).
 set(USE_COPT "-std=gnu99")

--- a/firmware/tools/export_external_apps.py
+++ b/firmware/tools/export_external_apps.py
@@ -55,8 +55,12 @@ def write_image(data, path):
 
 def patch_image(path, image_data, search_address, replace_address):
 	if (len(image_data) % 4) != 0:
-		print("file size not divideable by 4")
-		sys.exit(-1)
+		#sys.exit(-1)
+		print("\n External App image file:", path, ", size not divideable by 4 :", len(image_data))
+		j=0
+		while (len(image_data) % 4) != 0:
+			image_data += b'\x00' ; j+=1
+		print("file size:", len(image_data)," after padded:",j, "bytes")
 
 	external_application_image = bytearray()
 

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -135,8 +135,8 @@ for image in images:
     padded_data = image['data'] + (spi_image_default_byte * pad_size)
     spi_image += padded_data
 
-# if len(spi_image) > spi_size - 4:
-  #  raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
+if len(spi_image) > spi_size - 4:
+    raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
 
 pad_size = spi_size - 4 - len(spi_image)
 for i in range(pad_size):

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -135,8 +135,8 @@ for image in images:
     padded_data = image['data'] + (spi_image_default_byte * pad_size)
     spi_image += padded_data
 
-if len(spi_image) > spi_size - 4:
-    raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
+# if len(spi_image) > spi_size - 4:
+  #  raise RuntimeError('SPI flash image size of %d exceeds device size of %d bytes' % (len(spi_image) + 4, spi_size))
 
 pad_size = spi_size - 4 - len(spi_image)
 for i in range(pad_size):


### PR DESCRIPTION
Hi ,  to not forget the current investigation,   (and thanks specially to @bernd-herzog , @u-foka , and  @NotherNgineer ...) 

Please find attached the changes that I need to apply , for been able to compile with the new version  gcc 13.2.1 arm-none-eabi.
Till now I was using the version gcc 10.3.1,  but  recently pentoo linux updated it to the new  gcc 13.2.1 

Notes : 
1-) Clearly , using  the compiler  gcc 13.2.1  (same as with the previous gcc 10.3.1) , those upgraded  gcc versions produced with the same source code ,  a slighly bigger binary size , than the binary produced with the current  official upstream 9.2.1.
(therefore in my compile test,  following @NotherNgineer advices , I usually delete temporary some application to reduce the binary size  , in ui_navigation.cpp )
Ex . 
    // {"sstvtx", "SSTV", TX, ui::Color::green(), &bitmap_icon_sstv, new ViewFactory<SSTVTXView>()},
    //{"touchtune", "TouchTune", TX, ui::Color::green(), &bitmap_icon_touchtunes, new ViewFactory<TouchTunesView>()},


2-) I could compile all from vscode , using embeded CMake tool  ,  (same as I was doing with 10.3.1 , thanks to  @bernd-herzog help ) 
Now no problem, even it gives me that msg : 
"[build] WARNING: Compiler version mismatch, please use the official compiler version 9.2.1 when sharing builds! Current compiler version: 13.2.1"

3-) Once reflashed the new compiled binary (created with gcc. 13.2.1) , 
I could confirm that using our Portapack , we can generate  DEBUG_DUMP_XXX.TXT ,
and confirm with it , that the generated bin , comes from gcc a real  13.2.1  (just a double check of the used compiler version)
![image](https://github.com/user-attachments/assets/d3676eaa-10bf-4062-b591-147fa2c7f9e4)


4-) Recently,  I was getting some GURU mediation errors ,  just at power up with my binary compiled with gcc 13.2.1, 
but all those problems have been dissappeared after re-sync my cloned github repo with latest  today's next .  
 (I  still do not know why , but now it works well , no more GURU errors) 
https://github.com/user-attachments/assets/7bad6661-5196-4710-bc0c-6da2d782aa24

![image](https://github.com/user-attachments/assets/e4a28dab-762f-4781-8661-0154e4efdf3c)

5-) Regarding  the event_m0.cpp  file changes , those two changes are not related to this gcc compatibility issue, 
but trying to solve the above (4) , I added two lines ,  to delete two more warnings. And now all seems ok ,  
But I will need your approval about them . 
I could delete from 28 compile warnings (actual)  --> 26 compile warnings (after this PR) .
Now all remaining  26 warnings , seems to be related to USB 
![image](https://github.com/user-attachments/assets/4938b989-2b5c-4997-adde-ba5aca9190a0)

6-) The applied changes in the file : /opt/portapack-mayhem/firmware/tools/make_spi_image.py
![image](https://github.com/user-attachments/assets/0ebd8d3c-d083-455d-8016-d5aaeb130730)

Are not strictly necessary .But due to the point (1) ,  initially I was getting so many uncompleted compilations with exit code(1) ,  and it was so annoying and I could not test the full compile and link process.  
Then , in my set up investigation , I decided to comment those two below lines , 
It is true that now when excedding  1MB binary flash size , we will not get the usual error message : 
Example, 
![image](https://github.com/user-attachments/assets/f77adbc1-9686-4e23-9ae6-28c89673ad7f)


But anyway , we still could always check that other output  line .
 And if the room margin is negative  (-) , means that we are exceding the 1MB flash size. (we do not have positive (+) room margin)
![image](https://github.com/user-attachments/assets/cbd22310-4af0-439d-bb4e-d2f66fd52a3c)

Post-note about (6) , 
based on above revision comments,  I have re-activated that Binary limit size protection check with a second commit inside that PR, (as it was originally) 

-----------------
There is no rush to be merged that PR  . 
But soon or later gcc version   9.2.1  might be obsolete ... 
But before merging it , we need to be completely sure that this PR  is fully compatible with current  upstream 9.2.1 compilation , without breaking anything .  (Hopefully it should be compatible and transparent) .

Waiting for your testing  support and comments . 

@u-foka  ,  in the past , I know that you were also using  gcc version 12,x.x...or even 13.x.x   ,
 so maybe you can also have a chance to test those changes ...

Thanks in advance for your test ,  comment reviews ,  and feedbacks 
Cheers. 



 