### PR TITLE
Setfreq usb command

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -435,4 +435,7 @@ void AnalogAudioView::handle_coded_squelch(uint32_t value) {
     text_ctcss.set(tone_key_string_by_value(value, text_ctcss.parent_rect().width() / 8));
 }
 
+void AnalogAudioView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
 } /* namespace ui */

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -247,11 +247,20 @@ class AnalogAudioView : public View {
 
     void handle_coded_squelch(uint32_t value);
 
+    void on_freqchg(int64_t freq);
+
     MessageHandlerRegistration message_handler_coded_squelch{
         Message::ID::CodedSquelch,
         [this](const Message* p) {
             const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
             this->handle_coded_squelch(message.value);
+        }};
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
         }};
 };
 

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -128,4 +128,8 @@ void CaptureAppView::focus() {
     record_view.focus();
 }
 
+void CaptureAppView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 } /* namespace ui */

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -108,6 +108,15 @@ class CaptureAppView : public View {
         3};
 
     spectrum::WaterfallView waterfall{};
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -178,4 +178,8 @@ void ERTAppView::on_show_list() {
     recent_entries_view.focus();
 }
 
+void ERTAppView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 } /* namespace ui */

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -119,7 +119,7 @@ class ERTAppView : public View {
 
     // Prevent painting of region covered entirely by a child.
     // TODO: Add flag to View that specifies view does not need to be cleared before painting.
-    void paint(Painter&) override {};
+    void paint(Painter&) override{};
 
     void focus() override;
 

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -119,7 +119,7 @@ class ERTAppView : public View {
 
     // Prevent painting of region covered entirely by a child.
     // TODO: Add flag to View that specifies view does not need to be cleared before painting.
-    void paint(Painter&) override{};
+    void paint(Painter&) override {};
 
     void focus() override;
 
@@ -176,6 +176,14 @@ class ERTAppView : public View {
             this->on_packet(packet);
         }};
 
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
     void on_packet(const ert::Packet& packet);
     void on_show_list();
 };

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -321,6 +321,10 @@ void POCSAGAppView::on_stats(const POCSAGStatsMessage* stats) {
     widget_frames.set_sync(stats->has_sync);
 }
 
+void POCSAGAppView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 void BaudIndicator::paint(Painter& painter) {
     auto p = screen_pos();
     char top = '-';

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -292,6 +292,15 @@ class POCSAGAppView : public View {
     Console console{
         {0, 2 * 16 + 6, screen_width, screen_height - 54}};
 
+    void on_freqchg(int64_t freq);
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
     MessageHandlerRegistration message_handler_packet{
         Message::ID::POCSAGPacket,
         [this](Message* const p) {

--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -122,6 +122,10 @@ APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
     receiver_model.enable();
 }
 
+void APRSRxView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 void APRSRxView::on_packet(const APRSPacketMessage* message) {
     std::string str_console = "\x1B";
 

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -185,6 +185,7 @@ class APRSRxView : public View {
 
     std::string title() const override { return "APRS RX"; };
     void on_packet(const APRSPacketMessage* message);
+    void on_freqchg(int64_t freq);
 
    private:
     void on_data(uint32_t value, bool is_data);
@@ -270,6 +271,13 @@ class APRSRXView : public View {
             const auto message = static_cast<const APRSPacketMessage*>(p);
             this->view_stream.on_packet(message);
             this->view_table.on_pkt(message);
+        }};
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->view_stream.on_freqchg(message->freq);
         }};
 };
 

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -323,4 +323,9 @@ void LevelView::handle_coded_squelch(const uint32_t value) {
         text_ctcss.set("        ");
 }
 
+void LevelView::on_freqchg(int64_t freq) {
+    receiver_model.set_target_frequency(freq);
+    button_frequency.set_text("<" + to_string_short_freq(freq) + " MHz>");
+}
+
 } /* namespace ui */

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -188,6 +188,15 @@ class LevelView : public View {
 
     void handle_coded_squelch(const uint32_t value);
 
+    void on_freqchg(int64_t freq);
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
     MessageHandlerRegistration message_handler_coded_squelch{
         Message::ID::CodedSquelch,
         [this](const Message* const p) {

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -187,4 +187,8 @@ void SondeView::on_packet(const sonde::Packet& packet) {
     }
 }
 
+void SondeView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 } /* namespace ui */

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -195,6 +195,14 @@ class SondeView : public View {
             const auto message = static_cast<const OrientationDataMessage*>(p);
             this->on_orientation(message);
         }};
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 
     void on_gps(const GPSPosDataMessage* msg);
     void on_orientation(const OrientationDataMessage* msg);

--- a/firmware/application/apps/ui_subghzd.cpp
+++ b/firmware/application/apps/ui_subghzd.cpp
@@ -224,6 +224,10 @@ std::string SubGhzDView::pad_string_with_spaces(int snakes) {
     return paddedStr;
 }
 
+void SubGhzDView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 template <>
 void RecentEntriesTable<ui::SubGhzDRecentEntries>::draw(
     const Entry& entry,

--- a/firmware/application/apps/ui_subghzd.hpp
+++ b/firmware/application/apps/ui_subghzd.hpp
@@ -127,6 +127,14 @@ class SubGhzDView : public View {
     }};
     SubGhzDRecentEntriesView recent_entries_view{columns, recent};
 
+    void on_freqchg(int64_t freq);
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
     MessageHandlerRegistration message_handler_packet{
         Message::ID::SubGhzDData,
         [this](Message* const p) {

--- a/firmware/application/apps/ui_weatherstation.cpp
+++ b/firmware/application/apps/ui_weatherstation.cpp
@@ -220,6 +220,10 @@ std::string WeatherView::pad_string_with_spaces(int snakes) {
     return paddedStr;
 }
 
+void WeatherView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 template <>
 void RecentEntriesTable<ui::WeatherRecentEntries>::draw(
     const Entry& entry,

--- a/firmware/application/apps/ui_weatherstation.hpp
+++ b/firmware/application/apps/ui_weatherstation.hpp
@@ -151,6 +151,14 @@ class WeatherView : public View {
     }};
     WeatherRecentEntriesView recent_entries_view{columns, recent};
 
+    void on_freqchg(int64_t freq);
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
     MessageHandlerRegistration message_handler_packet{
         Message::ID::WeatherData,
         [this](Message* const p) {

--- a/firmware/application/external/afsk_rx/ui_afsk_rx.cpp
+++ b/firmware/application/external/afsk_rx/ui_afsk_rx.cpp
@@ -143,6 +143,10 @@ void AFSKRxView::on_data(uint32_t value, bool is_data) {
     }
 }
 
+void AFSKRxView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 AFSKRxView::~AFSKRxView() {
     audio::output::stop();
     receiver_model.disable();

--- a/firmware/application/external/afsk_rx/ui_afsk_rx.hpp
+++ b/firmware/application/external/afsk_rx/ui_afsk_rx.hpp
@@ -117,6 +117,15 @@ class AFSKRxView : public View {
             const auto message = static_cast<const AFSKDataMessage*>(p);
             this->on_data(message->value, message->is_data);
         }};
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 };
 
 }  // namespace ui::external_app::afsk_rx

--- a/firmware/application/external/analogtv/analog_tv_app.cpp
+++ b/firmware/application/external/analogtv/analog_tv_app.cpp
@@ -202,4 +202,8 @@ void AnalogTvView::update_modulation(const ReceiverModel::Mode modulation) {
     receiver_model.enable();
 }
 
+void AnalogTvView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 }  // namespace ui::external_app::analogtv

--- a/firmware/application/external/analogtv/analog_tv_app.hpp
+++ b/firmware/application/external/analogtv/analog_tv_app.hpp
@@ -108,6 +108,15 @@ class AnalogTvView : public View {
     void set_options_widget(std::unique_ptr<Widget> new_widget);
 
     void update_modulation(const ReceiverModel::Mode modulation);
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 };
 
 }  // namespace ui::external_app::analogtv

--- a/firmware/application/external/foxhunt/ui_foxhunt_rx.cpp
+++ b/firmware/application/external/foxhunt/ui_foxhunt_rx.cpp
@@ -103,4 +103,8 @@ void FoxhuntRxView::on_orientation(const OrientationDataMessage* msg) {
     geomap.update_my_orientation(msg->angle, true);
 }
 
+void FoxhuntRxView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 }  // namespace ui::external_app::foxhunt_rx

--- a/firmware/application/external/foxhunt/ui_foxhunt_rx.hpp
+++ b/firmware/application/external/foxhunt/ui_foxhunt_rx.hpp
@@ -103,6 +103,14 @@ class FoxhuntRxView : public View {
         [this](const Message* const p) {
             this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
         }};
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 
     float my_lat = 200;
     float my_lon = 200;

--- a/firmware/application/external/nrf_rx/ui_nrf_rx.cpp
+++ b/firmware/application/external/nrf_rx/ui_nrf_rx.cpp
@@ -125,6 +125,10 @@ void NRFRxView::on_data(uint32_t value, bool is_data) {
     }
 }
 
+void NRFRxView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 NRFRxView::~NRFRxView() {
     audio::output::stop();
     receiver_model.disable();

--- a/firmware/application/external/nrf_rx/ui_nrf_rx.hpp
+++ b/firmware/application/external/nrf_rx/ui_nrf_rx.hpp
@@ -89,6 +89,15 @@ class NRFRxView : public View {
             const auto message = static_cast<const AFSKDataMessage*>(p);
             this->on_data(message->value, message->is_data);
         }};
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 };
 
 } /* namespace ui::external_app::nrf_rx */

--- a/firmware/application/external/protoview/ui_protoview.cpp
+++ b/firmware/application/external/protoview/ui_protoview.cpp
@@ -186,6 +186,10 @@ void ProtoView::on_data(const ProtoViewDataMessage* message) {
     draw2();
 }
 
+void ProtoView::on_freqchg(int64_t freq) {
+    field_frequency.set_value(freq);
+}
+
 ProtoView::~ProtoView() {
     audio::output::stop();
     receiver_model.disable();

--- a/firmware/application/external/protoview/ui_protoview.hpp
+++ b/firmware/application/external/protoview/ui_protoview.hpp
@@ -157,6 +157,15 @@ class ProtoView : public View {
         [this](const Message* const) {
             this->on_timer();
         }};
+
+    MessageHandlerRegistration message_handler_freqchg{
+        Message::ID::FreqChangeCommand,
+        [this](Message* const p) {
+            const auto message = static_cast<const FreqChangeCommandMessage*>(p);
+            this->on_freqchg(message->freq);
+        }};
+
+    void on_freqchg(int64_t freq);
 };
 
 }  // namespace ui::external_app::protoview

--- a/firmware/application/external/tpmsrx/tpms_app.hpp
+++ b/firmware/application/external/tpmsrx/tpms_app.hpp
@@ -99,7 +99,7 @@ class TPMSAppView : public View {
 
     // Prevent painting of region covered entirely by a child.
     // TODO: Add flag to View that specifies view does not need to be cleared before painting.
-    void paint(Painter&) override {};
+    void paint(Painter&) override{};
 
     void focus() override;
 

--- a/firmware/application/external/tpmsrx/tpms_app.hpp
+++ b/firmware/application/external/tpmsrx/tpms_app.hpp
@@ -99,7 +99,7 @@ class TPMSAppView : public View {
 
     // Prevent painting of region covered entirely by a child.
     // TODO: Add flag to View that specifies view does not need to be cleared before painting.
-    void paint(Painter&) override{};
+    void paint(Painter&) override {};
 
     void focus() override;
 

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1147,6 +1147,23 @@ static void cmd_asyncmsg(BaseSequentialStream* chp, int argc, char* argv[]) {
         chprintf(chp, usage);
     }
 }
+static void cmd_setfreq(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: setfreq freq_in_hz\r\n";
+    if (argc != 1) {
+        chprintf(chp, usage);
+        return;
+    }
+    int64_t freq = atol(argv[0]);
+
+    if (freq == 0) {
+        chprintf(chp, usage);
+        return;
+    }
+    // radio::set_tuning_frequency(freq); // sadly this doesn't update any widget, just change the frequency.
+    FreqChangeCommandMessage message{freq};
+    EventDispatcher::send_message(message);
+    chprintf(chp, "ok\r\n");
+}
 
 static const ShellCommand commands[] = {
     {"reboot", cmd_reboot},
@@ -1180,6 +1197,7 @@ static const ShellCommand commands[] = {
     {"settingsreset", cmd_settingsreset},
     {"sendpocsag", cmd_sendpocsag},
     {"asyncmsg", cmd_asyncmsg},
+    {"setfreq", cmd_setfreq},
     {NULL, NULL}};
 
 static const ShellConfig shell_cfg1 = {

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1155,7 +1155,7 @@ static void cmd_setfreq(BaseSequentialStream* chp, int argc, char* argv[]) {
     }
     int64_t freq = atol(argv[0]);
 
-    if (freq == 0) {
+    if (freq <= 0) {
         chprintf(chp, usage);
         return;
     }

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -125,6 +125,7 @@ class Message {
         PocsagTosend = 67,
         BatteryStateData = 68,
         ProtoViewData = 69,
+        FreqChangeCommand = 70,
         MAX
     };
 
@@ -1425,6 +1426,13 @@ class ProtoViewDataMessage : public Message {
     int32_t times[100] = {0};  // positive: high, negative: low
     uint16_t timeptr = 0;
     const uint16_t maxptr = 99;
+};
+
+class FreqChangeCommandMessage : public Message {
+   public:
+    constexpr FreqChangeCommandMessage(int64_t freq)
+        : Message{ID::FreqChangeCommand}, freq{freq} {}
+    int64_t freq = 0;
 };
 
 #endif /*__MESSAGE_H__*/


### PR DESCRIPTION
Provides a new setfreq command where you can set the desired frequency in (some) RX apps (where no range provided, or no jumpings, ..). The freq must be in HZ.

TX apps not covered, since no sense to set them without any other interaction possibility.
But with this, you can listen to FM stations, and change them by computer.