### PR TITLE
Add BLE RX filter options

### DIFF
--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -500,7 +500,8 @@ BLERxView::BLERxView(NavigationView& nav)
 
     check_name.on_select = [this](Checkbox&, bool v) {
         name_enable = v;
-        setAllMembersToValue(recent, &BleRecentEntry::include_name, v); // update the include_name instance variable value of each entry in recent entries
+        // update the include_name instance variable value of each entry in recent entries
+        setAllMembersToValue(recent, &BleRecentEntry::include_name, v);
         recent_entries_view.set_dirty();
     };
 

--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -428,6 +428,7 @@ BLERxView::BLERxView(NavigationView& nav)
                   &text_found_count,
                   &check_serial_log,
                   &button_filter,
+                  &options_filter,
                   &button_save_list,
                   &button_clear_list,
                   &button_switch,
@@ -499,7 +500,7 @@ BLERxView::BLERxView(NavigationView& nav)
 
     check_name.on_select = [this](Checkbox&, bool v) {
         name_enable = v;
-        setAllMembersToValue(recent, &BleRecentEntry::include_name, v);
+        setAllMembersToValue(recent, &BleRecentEntry::include_name, v); // update the include_name instance variable value of each entry in recent entries
         recent_entries_view.set_dirty();
     };
 
@@ -525,8 +526,14 @@ BLERxView::BLERxView(NavigationView& nav)
         handle_entries_sort(v);
     };
 
+    options_filter.on_change = [this](size_t index, int32_t v) {
+        filter_index = (uint8_t)index;
+        handle_filter_options(v);
+    };
+
     options_channel.set_selected_index(channel_index, true);
     options_sort.set_selected_index(sort_index, true);
+    options_filter.set_selected_index(filter_index, true);
 
     button_find.on_select = [this](Button&) {
         auto open_view = nav_.push<FileLoadView>(".TXT");
@@ -716,10 +723,11 @@ void BLERxView::on_data(BlePacketData* packet) {
     updateEntry(packet, entry, (ADV_PDU_TYPE)packet->type);
 
     // Add entries if they meet the criteria.
-    auto value = filter;
-    resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
-        return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
-    });
+    // auto value = filter;
+    // resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
+    //     return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
+    // });
+    handle_filter_options(options_filter.selected_index());
 
     handle_entries_sort(options_sort.selected_index());
 
@@ -756,12 +764,13 @@ void BLERxView::on_data(BlePacketData* packet) {
 void BLERxView::on_filter_change(std::string value) {
     // New filter? Reset list from recent entries.
     if (filter != value) {
-        resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
-            return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
-        });
+        // resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
+        //     // return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
+        //     return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos) && (to_string_mac_address(entry.packetData.macAddress, 6, false).find(value) == std::string::npos);
+        // });
+        filter = value;
+        handle_filter_options(options_filter.selected_index());
     }
-
-    filter = value;
 }
 
 void BLERxView::on_file_changed(const std::filesystem::path& new_file_path) {
@@ -852,6 +861,24 @@ void BLERxView::handle_entries_sort(uint8_t index) {
     recent_entries_view.set_dirty();
 }
 
+void BLERxView::handle_filter_options(uint8_t index) {
+    auto value = filter;
+    switch (index) {
+        case 0:  // filter by Data
+            resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
+                return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
+            });
+            break;
+        case 1:  // filter by MAC address (All caps: e.g. AA:BB:CC:DD:EE:FF)
+            resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
+                return (to_string_mac_address(entry.packetData.macAddress, 6, false).find(value) == std::string::npos);
+            });
+            break;
+        default:
+            break;
+    }
+}
+
 void BLERxView::set_parent_rect(const Rect new_parent_rect) {
     View::set_parent_rect(new_parent_rect);
     const Rect content_rect{0, header_height, new_parent_rect.width(), new_parent_rect.height() - header_height - switch_button_height};
@@ -914,6 +941,7 @@ void BLERxView::updateEntry(const BlePacketData* packet, BleRecentEntry& entry, 
 
             // Subtract 1 because type is part of the length.
             for (int i = 0; i < length - 1; i++) {
+                // parse the name of bluetooth device: 0x08->Shortened Local Name; 0x09->Complete Local Name
                 if (type == 0x08 || type == 0x09) {
                     decoded_data += (char)advertiseData->Data[currentByte];
                 }

--- a/firmware/application/apps/ble_rx_app.hpp
+++ b/firmware/application/apps/ble_rx_app.hpp
@@ -186,7 +186,7 @@ class BLERxView : public View {
     ~BLERxView();
 
     void set_parent_rect(const Rect new_parent_rect) override;
-    void paint(Painter&) override{};
+    void paint(Painter&) override {};
 
     void focus() override;
 
@@ -203,6 +203,7 @@ class BLERxView : public View {
     void file_error();
     void on_timer();
     void handle_entries_sort(uint8_t index);
+    void handle_filter_options(uint8_t index);
     void updateEntry(const BlePacketData* packet, BleRecentEntry& entry, ADV_PDU_TYPE pdu_type);
 
     NavigationView& nav_;
@@ -214,6 +215,7 @@ class BLERxView : public View {
 
     uint8_t channel_index{0};
     uint8_t sort_index{0};
+    uint8_t filter_index{0};
     std::string filter{};
     bool logging{false};
     bool serial_logging{false};
@@ -227,6 +229,7 @@ class BLERxView : public View {
             {"sort_index"sv, &sort_index},
             {"filter"sv, &filter},
             {"log"sv, &logging},
+            {"filter_index"sv, &filter_index},
             // disabled to always start without USB serial activated until we can make it non blocking if not connected
             // {"serial_log"sv, &serial_logging},
             {"name"sv, &name_enable},
@@ -255,13 +258,13 @@ class BLERxView : public View {
     std::filesystem::path log_packets_path{blerx_dir / u"Logs/????.TXT"};
     std::filesystem::path packet_save_path{blerx_dir / u"Lists/????.csv"};
 
-    static constexpr auto header_height = 4 * 16;
+    static constexpr auto header_height = 9 * 8;
     static constexpr auto switch_button_height = 3 * 16;
 
     OptionsField options_channel{
         {0 * 8, 0 * 8},
         5,
-        {{"Ch.37 ", 37},
+        {{"Ch.37", 37},
          {"Ch.38", 38},
          {"Ch.39", 39},
          {"Auto", 40}}};
@@ -286,10 +289,10 @@ class BLERxView : public View {
         {24 * 8, 5, 6 * 8, 4}};
 
     Labels label_sort{
-        {{0 * 8, 3 * 8}, "Sort:", Theme::getInstance()->fg_light->foreground}};
+        {{0 * 8, 2 * 8}, "Sort:", Theme::getInstance()->fg_light->foreground}};
 
     OptionsField options_sort{
-        {5 * 8, 3 * 8},
+        {5 * 8, 2 * 8},
         4,
         {{"MAC", 0},
          {"Hits", 1},
@@ -298,40 +301,46 @@ class BLERxView : public View {
          {"Name", 4}}};
 
     Button button_filter{
-        {11 * 8, 3 * 8, 4 * 8, 16},
-        "Filter"};
+        {11 * 8, 2 * 8, 7 * 8, 16},
+        "Filter:"};
+
+    OptionsField options_filter{
+        {18 * 8 + 2, 2 * 8},
+        4,
+        {{"Data", 0},
+         {"MAC", 1}}};
 
     Checkbox check_log{
-        {17 * 8, 3 * 8},
+        {10 * 8, 4 * 8 + 2},
         3,
         "Log",
         true};
 
     Checkbox check_name{
-        {23 * 8, 3 * 8},
+        {0 * 8, 4 * 8 + 2},
         3,
         "Name",
         true};
 
     Button button_find{
-        {0 * 8, 6 * 8, 4 * 8, 16},
+        {0 * 8, 7 * 8 - 2, 4 * 8, 16},
         "Find"};
 
     Labels label_found{
-        {{5 * 8, 6 * 8}, "Found:", Theme::getInstance()->fg_light->foreground}};
+        {{5 * 8, 7 * 8 - 2}, "Found:", Theme::getInstance()->fg_light->foreground}};
 
     Text text_found_count{
-        {11 * 8, 3 * 16, 20 * 8, 16},
+        {11 * 8, 7 * 8 - 2, 20 * 8, 16},
         "0/0"};
 
     Checkbox check_serial_log{
-        {17 * 8, 3 * 16 - 2},
+        {18 * 8 + 2, 4 * 8 + 2},
         7,
         "USB Log",
         true};
 
-    Console console{
-        {0, 4 * 16, 240, 240}};
+    // Console console{
+    //     {0, 10 * 8, 240, 240}};
 
     Button button_clear_list{
         {2 * 8, 320 - (16 + 32), 7 * 8, 32},
@@ -371,7 +380,7 @@ class BLERxView : public View {
         [this](const Message* const) {
             this->on_timer();
         }};
-};
+}; /* BLERxView */
 
 } /* namespace ui */
 

--- a/firmware/application/apps/ble_rx_app.hpp
+++ b/firmware/application/apps/ble_rx_app.hpp
@@ -186,7 +186,7 @@ class BLERxView : public View {
     ~BLERxView();
 
     void set_parent_rect(const Rect new_parent_rect) override;
-    void paint(Painter&) override {};
+    void paint(Painter&) override{};
 
     void focus() override;
 


### PR DESCRIPTION
I'm proposing adding a filter option for BLE RX app. User can choose to look for keyword either in the data string or MAC address, per comments from [#1625](https://github.com/portapack-mayhem/mayhem-firmware/pull/1625).



Filter option: Data, MAC