### PR TITLE
Selectable 314.9 vs 315MHz TPMS RX freq

### DIFF
--- a/firmware/application/external/tpmsrx/tpms_app.hpp
+++ b/firmware/application/external/tpmsrx/tpms_app.hpp
@@ -107,7 +107,7 @@ class TPMSAppView : public View {
 
    private:
     RxRadioState radio_state_{
-        314950000 /* frequency*/
+        314900000 /* frequency*/
         ,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */
@@ -147,20 +147,21 @@ class TPMSAppView : public View {
     // "315 MHz" TPMS sensors transmit at either 314.9 or 315 MHz but we should pick up either
     OptionsField options_band{
         {0 * 8, 0 * 16},
-        3,
+        5,
         {
-            {"315", 314950000},
-            {"434", 433920000},
+            {"314.9", 314900000},
+            {"315.0", 315000000},
+            {"433.9", 433920000},
         }};
 
     OptionsField options_pressure{
-        {5 * 8, 0 * 16},
+        {6 * 8, 0 * 16},
         3,
         {{"kPa", 0},
          {"PSI", 1}}};
 
     OptionsField options_temperature{
-        {9 * 8, 0 * 16},
+        {10 * 8, 0 * 16},
         2,
         {{STR_DEGREES_C, 0},
          {STR_DEGREES_F, 1}}};


### PR DESCRIPTION
Allow selection between 314.9 vs 315.0 MHz TPMS receive frequency, per suggestion in issue #2242 

I don't know why this should be necessary since the bandwidth is set to 1.75MHz, but it doesn't hurt.  In my own testing a 314.9 MHz pressure sensor shows up regardless whether RX frequency is set to 314.9 or 315.0.

This PR also helps with a past concern whether we should display "433" vs "434" for 433.92 MHz; now the display will show "433.9" vs "434".  (Sorry there isn't room for the full 433.92)

(A test version is attached to issue #2242)