### PR TITLE
SSTV TX to ext

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -327,7 +327,7 @@ set(CPPSRC
 	# apps/ui_spectrum_painter_text.cpp
 	# apps/ui_spectrum_painter.cpp
 	apps/ui_ss_viewer.cpp
-	apps/ui_sstvtx.cpp
+	# apps/ui_sstvtx.cpp #moved to ext
 	apps/ui_standalone_view.cpp
 	apps/ui_subghzd.cpp
 	# apps/ui_test.cpp

--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -89,10 +89,13 @@ set(EXTCPPSRC
 	external/adsbtx/main.cpp
 	external/adsbtx/ui_adsb_tx.cpp
 
-	
 	#morse_tx
 	external/morse_tx/main.cpp
 	external/morse_tx/ui_morse.cpp
+
+	#sstvtx
+	external/sstvtx/main.cpp
+	external/sstvtx/ui_sstvtx.cpp
 )
 
 set(EXTAPPLIST
@@ -118,4 +121,5 @@ set(EXTAPPLIST
 	protoview
 	adsbtx
 	morse_tx
+	sstvtx
 )

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -45,6 +45,7 @@ MEMORY
     ram_external_app_protoview(rwx) : org = 0xADC40000, len = 32k
     ram_external_app_adsbtx(rwx) : org = 0xADC50000, len = 32k
     ram_external_app_morse_tx(rwx) : org = 0xADC60000, len = 32k
+    ram_external_app_sstvtx(rwx) : org = 0xADC70000, len = 32k
 }
 
 SECTIONS
@@ -182,6 +183,13 @@ SECTIONS
         KEEP(*(.external_app.app_morse_tx.application_information));
         *(*ui*external_app*morse_tx*);
     } > ram_external_app_morse_tx
+
+   .external_app_sstvtx : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_sstvtx.application_information));
+        *(*ui*external_app*sstvtx*);
+    } > ram_external_app_sstvtx
+
 
 
 }

--- a/firmware/application/external/sstvtx/main.cpp
+++ b/firmware/application/external/sstvtx/main.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui.hpp"
+#include "ui_sstvtx.hpp"
+#include "ui_navigation.hpp"
+#include "external_app.hpp"
+
+namespace ui::external_app::sstvtx {
+void initialize_app(ui::NavigationView& nav) {
+    nav.push<SSTVTXView>();
+}
+}  // namespace ui::external_app::sstvtx
+
+extern "C" {
+
+__attribute__((section(".external_app.app_sstvtx.application_information"), used)) application_information_t _application_information_sstvtx = {
+    /*.memory_location = */ (uint8_t*)0x00000000,
+    /*.externalAppEntry = */ ui::external_app::sstvtx::initialize_app,
+    /*.header_version = */ CURRENT_HEADER_VERSION,
+    /*.app_version = */ VERSION_MD5,
+
+    /*.app_name = */ "SSTV",
+    /*.bitmap_data = */ {
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0xFE,
+        0x7F,
+        0x03,
+        0xC0,
+        0x53,
+        0xD5,
+        0xAB,
+        0xCA,
+        0x53,
+        0xD5,
+        0xAB,
+        0xCA,
+        0x53,
+        0xD5,
+        0xAB,
+        0xCA,
+        0x53,
+        0xD5,
+        0x03,
+        0xC0,
+        0xFF,
+        0xFF,
+        0xFB,
+        0xD7,
+        0xFE,
+        0x7F,
+        0x00,
+        0x00,
+    },
+    /*.icon_color = */ ui::Color::green().v,
+    /*.menu_location = */ app_location_t::TX,
+
+    /*.m4_app_tag = portapack::spi_flash::image_tag_sstvtx */ {'P', 'S', 'T', 'X'},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
+};
+}

--- a/firmware/application/external/sstvtx/ui_sstvtx.cpp
+++ b/firmware/application/external/sstvtx/ui_sstvtx.cpp
@@ -31,7 +31,7 @@
 
 using namespace portapack;
 
-namespace ui {
+namespace ui::external_app::sstvtx {
 
 void SSTVTXView::focus() {
     if (file_error)
@@ -283,4 +283,4 @@ SSTVTXView::SSTVTXView(
     };
 }
 
-} /* namespace ui */
+}  // namespace ui::external_app::sstvtx

--- a/firmware/application/external/sstvtx/ui_sstvtx.hpp
+++ b/firmware/application/external/sstvtx/ui_sstvtx.hpp
@@ -38,7 +38,7 @@
 
 using namespace sstv;
 
-namespace ui {
+namespace ui::external_app::sstvtx {
 
 class SSTVTXView : public View {
    public:
@@ -110,6 +110,6 @@ class SSTVTXView : public View {
         }};
 };
 
-} /* namespace ui */
+} /* namespace ui::external_app::sstvtx */
 
 #endif /*__UI_SSTVTX_H__*/

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -74,7 +74,7 @@
 #include "ui_sonde.hpp"
 // #include "ui_spectrum_painter.hpp" //moved to ext app
 #include "ui_ss_viewer.hpp"
-#include "ui_sstvtx.hpp"
+// #include "ui_sstvtx.hpp" //moved to ext
 // #include "ui_test.hpp"
 #include "ui_text_editor.hpp"
 #include "ui_tone_search.hpp"
@@ -191,7 +191,7 @@ const NavigationView::AppList NavigationView::appList = {
     {"pocsagtx", "POCSAG TX", TX, ui::Color::green(), &bitmap_icon_pocsag, new ViewFactory<POCSAGTXView>()},
     {"rdstx", "RDS", TX, ui::Color::green(), &bitmap_icon_rds, new ViewFactory<RDSView>()},
     {"soundbrd", "Soundbrd", TX, ui::Color::green(), &bitmap_icon_soundboard, new ViewFactory<SoundBoardView>()},
-    {"sstvtx", "SSTV", TX, ui::Color::green(), &bitmap_icon_sstv, new ViewFactory<SSTVTXView>()},
+    //{"sstvtx", "SSTV", TX, ui::Color::green(), &bitmap_icon_sstv, new ViewFactory<SSTVTXView>()}, //moved to ext
     {"touchtune", "TouchTune", TX, ui::Color::green(), &bitmap_icon_touchtunes, new ViewFactory<TouchTunesView>()},
     /* UTILITIES *************************************************************/
     {"antennalength", "Antenna Length", UTILITIES, Color::green(), &bitmap_icon_tools_antenna, new ViewFactory<WhipCalcView>()},

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -480,12 +480,6 @@ set(MODE_CPPSRC
 DeclareTargets(PSIG siggen)
 
 
-### SSTV TX
-
-set(MODE_CPPSRC
-	proc_sstvtx.cpp
-)
-DeclareTargets(PSTX sstvtx)
 
 ### Tones
 
@@ -650,6 +644,12 @@ set(MODE_CPPSRC
 DeclareTargets(PPVW protoview)
 
 
+### SSTV TX
+
+set(MODE_CPPSRC
+	proc_sstvtx.cpp
+)
+DeclareTargets(PSTX sstvtx)
 
 ### TPMS
 


### PR DESCRIPTION
Move SSTV TX app to external app, to save some FW space.