### PR TITLE
add ccache option and  transparent color instead of bool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ cmake_policy(SET CMP0005 NEW)
 
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/firmware/toolchain-arm-cortex-m.cmake)
 
+option(USE_CCACHE "Enable ccache, please keep an eye on this because sometimes it's not quite stable and generated unusable binary" OFF)
+
 project(portapack-h1)
 
 set(EXPECTED_GCC_VERSION "9.2.1")
@@ -72,13 +74,24 @@ set(HACKRF_CPLD_XSVF_PATH ${HACKRF_PATH}/firmware/cpld/sgpio_if/${HACKRF_CPLD_XS
 set(HACKRF_FIRMWARE_DFU_IMAGE ${hackrf_usb_BINARY_DIR}/${HACKRF_FIRMWARE_DFU_FILENAME})
 set(HACKRF_FIRMWARE_BIN_IMAGE ${hackrf_usb_BINARY_DIR}/${HACKRF_FIRMWARE_BIN_FILENAME})
 
-# this seems causing some issues (ref. in discord discussions), so temporarily disabled, until figure out the pros and cons and bugs of this tool.
-#find_program(CCACHE "ccache")
-#if(CCACHE)
-#    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE})
-#    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
-#    set(ENV{CCACHE_SLOPPINESS} pch_defines,time_macros)
-#endif(CCACHE)
+# this seems causing some issues (ref. in discord discussions), but it sometimes do helps, so you have your choice to use. it's default disabled,  unless you use such command:
+# cmake -DUSE_CCACHE=ON ..
+# `make` or `make -j` or `make -j10` etc
+# the default behavior `cmake ..` isn't changed (aka don't use ccache)
+message(STATUS "-------v ccache info--------")
+if(USE_CCACHE)
+	find_program(CCACHE_FOUND ccache)
+	if(CCACHE_FOUND)
+		set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})
+		set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
+		message(STATUS "Using ccache, please keep an eye on this because sometimes it's not quite stable and generated unusable binary.\n-- use `cmake -DUSE_CCACHE=OFF ..` to turn off ccache")
+	else()
+		message(WARNING "ccache is enabled but not found on the system.")
+	endif()
+else()
+	message(STATUS "Not using ccache, use `cmake -DUSE_CCACHE=ON ..` to turn on ccache")
+endif()
+message(STATUS "-------^ ccache info--------")
 
 enable_testing()
 add_subdirectory(firmware)

--- a/firmware/application/external/protoview/ui_protoview.cpp
+++ b/firmware/application/external/protoview/ui_protoview.cpp
@@ -224,11 +224,11 @@ void ProtoView::set_pause(bool pause) {
     if (pause) {
         label_shift.hidden(false);
         number_shift.hidden(false);
-        button_pause.set_text("Resume");
+        button_pause.set_text(LanguageHelper::currentMessages[LANG_RESUME]);
     } else {
         label_shift.hidden(true);
         number_shift.hidden(true);
-        button_pause.set_text("Pause");
+        button_pause.set_text(LanguageHelper::currentMessages[LANG_PAUSE]);
     }
     set_dirty();
 }

--- a/firmware/application/external/protoview/ui_protoview.cpp
+++ b/firmware/application/external/protoview/ui_protoview.cpp
@@ -140,7 +140,7 @@ void ProtoView::draw() {
     drawcnt = 0;
     for (uint16_t i = 0; i < MAXDRAWCNT; i++) waveform_buffer[i] = 0;  // reset
 
-    // add empty data for padding (so you can shift left/nagetive)
+    // add empty data for padding (so you can shift left/negative)
     if (waveform_shift < 0) {
         for (int32_t i = 0; (i < -1 * waveform_shift) && drawcnt < MAXDRAWCNT;  // this is for shift negative (move to right)
              ++i) {

--- a/firmware/application/external/protoview/ui_protoview.cpp
+++ b/firmware/application/external/protoview/ui_protoview.cpp
@@ -142,7 +142,7 @@ void ProtoView::draw() {
 
     // add empty data for padding (so you can shift left/nagetive)
     if (waveform_shift < 0) {
-        for (int32_t i = 0; (i < -1 * waveform_shift) && drawcnt < MAXDRAWCNT;  // this is for shift nagetive (move to right)
+        for (int32_t i = 0; (i < -1 * waveform_shift) && drawcnt < MAXDRAWCNT;  // this is for shift negative (move to right)
              ++i) {
             waveform_buffer[drawcnt++] = 0;
         }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -1007,7 +1007,7 @@ BMPView::BMPView(NavigationView& nav)
 
 void BMPView::paint(Painter&) {
     if (!portapack::display.drawBMP2({0, 0}, splash_dot_bmp))
-        portapack::display.drawBMP({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, true);
+        portapack::display.drawBMP({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
 }
 
 bool BMPView::on_touch(const TouchEvent event) {
@@ -1103,7 +1103,7 @@ ModalMessageView::ModalMessageView(
 }
 
 void ModalMessageView::paint(Painter& painter) {
-    if (!compact) portapack::display.drawBMP({100, 48}, modal_warning_bmp, true);
+    if (!compact) portapack::display.drawBMP({100, 48}, modal_warning_bmp, (const uint8_t[]){0, 0, 0});
 
     // Break lines.
     auto lines = split_string(message_, '\n');

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -355,7 +355,7 @@ void ILI9341::render_box(const ui::Point p, const ui::Size s, const ui::Color* l
  * don't draw transparent, pass nullptr as arg, usage
  * portapack::display.drawBMP({100, 100}, foo_bmp, nullptr);
  *
- * ifyour image use RLE as transparency, pass any valid color as arg, it doesn't matter (like the modal bmp. TODO: write RLE transparency generator)
+ * if your image use RLE compress as transparency methods, pass any valid color as arg, it doesn't matter (like the modal bmp. TODO: write RLE transparency generator)
  * */
 void ILI9341::drawBMP(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color) {
     const bmp_header_t* bmp_header = (const bmp_header_t*)bitmap;

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -344,7 +344,20 @@ void ILI9341::render_box(const ui::Point p, const ui::Size s, const ui::Color* l
 }
 
 // RLE_4 BMP loader (delta not implemented)
-void ILI9341::drawBMP(const ui::Point p, const uint8_t* bitmap, const bool transparency) {
+/* draw transparent, pass transparent color as arg, usage inline anonymous obj
+ * portapack::display.drawBMP({100, 100}, foo_bmp, (const uint8_t[]){41, 24, 22}); // dec, out of {255, 255, 255}
+ * portapack::display.drawBMP({100, 100}, foo_bmp, (const uint8_t[]){0x29, 0x18, 0x16}); //hex out of {0xFF, 0xFF, 0xFF}
+ *
+ * draw transparent, pass transparent color as arg, usage pass uint8_t[] obj
+ * const uint8_t c[] = {41, 24, 22}; or const uint8_t c[3] = {0x29, 0x18, 0x16};
+ * portapack::display.drawBMP({100, 100}, foo_bmp, c);
+ *
+ * don't draw transparent, pass nullptr as arg, usage
+ * portapack::display.drawBMP({100, 100}, foo_bmp, nullptr);
+ *
+ * ifyour image use RLE as transparency, pass any valid color as arg, it doesn't matter (like the modal bmp. TODO: write RLE transparency generator)
+ * */
+void ILI9341::drawBMP(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color) {
     const bmp_header_t* bmp_header = (const bmp_header_t*)bitmap;
     uint32_t data_idx;
     uint8_t by, c, count, transp_idx = 0;
@@ -362,12 +375,13 @@ void ILI9341::drawBMP(const ui::Point p, const uint8_t* bitmap, const bool trans
     // Convert palette and find pure magenta index (alpha color key) rgb dec(41,24,22)
     for (c = 0; c < 16; c++) {
         palette[c] = ui::Color(bmp_palette->color[c].R, bmp_palette->color[c].G, bmp_palette->color[c].B);
-        if ((bmp_palette->color[c].R == 0x29) &&
-            (bmp_palette->color[c].G == 0x18) &&
-            (bmp_palette->color[c].B == 0x16)) transp_idx = c;
+        if (transparency_color &&
+            (bmp_palette->color[c].R == transparency_color[0]) &&
+            (bmp_palette->color[c].G == transparency_color[1]) &&
+            (bmp_palette->color[c].B == transparency_color[2])) transp_idx = c;
     }
 
-    if (!transparency) {
+    if (!transparency_color) {
         py = bmp_header->height + 16;
         do {
             by = bitmap[data_idx++];

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -62,7 +62,7 @@ class ILI9341 {
         const ui::Color background);
 
     void draw_pixel(const ui::Point p, const ui::Color color);
-    void drawBMP(const ui::Point p, const uint8_t* bitmap, const bool transparency);
+    void drawBMP(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color);
     bool drawBMP2(const ui::Point p, const std::filesystem::path& file);
     void render_line(const ui::Point p, const uint8_t count, const ui::Color* line_buffer);
     void render_box(const ui::Point p, const ui::Size s, const ui::Color* line_buffer);


### PR DESCRIPTION
# ccache
- previously https://github.com/portapack-mayhem/mayhem-firmware/pull/1832 added ccache
- we on discord found sometimes ccache creates issues, i removed it https://github.com/portapack-mayhem/mayhem-firmware/pull/2153
- but it sometimes useful, so this time add back and optional.
- it's default disabled,  unless you use such command:
 ``cmake -DUSE_CCACHE=ON ..``then
`make` or `make -j` or `make -j10` etc
- the default behavior `cmake ..` then `make` isn't changed (aka don't use ccache), so it’s safe for pipeline

# transparency color for bmp
/* draw transparent, pass transparent color as arg, usage inline anonymous obj
 * portapack::display.drawBMP({100, 100}, foo_bmp, (const uint8_t[]){41, 24, 22}); // dec, out of {255, 255, 255}
 * portapack::display.drawBMP({100, 100}, foo_bmp, (const uint8_t[]){0x29, 0x18, 0x16}); //hex out of {0xFF, 0xFF, 0xFF}
 *
 * draw transparent, pass transparent color as arg, usage pass uint8_t[] obj
 * const uint8_t c[] = {41, 24, 22}; or const uint8_t c[3] = {0x29, 0x18, 0x16};
 * portapack::display.drawBMP({100, 100}, foo_bmp, c);
 *
 * don't draw transparent, pass nullptr as arg, usage
 * portapack::display.drawBMP({100, 100}, foo_bmp, nullptr);
 *
 * ifyour image use RLE as transparency, pass any valid color as arg, it doesn't matter (like the modal bmp. TODO: write RLE transparency generator)
 * */
