### PR TITLE
Nav fix, fixes #1197

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -722,8 +722,8 @@ void NavigationView::update_view() {
     auto top_view = top.view.get();
 
     add_child(top_view);
-    top_view->set_parent_rect({{0, 0}, size()});
-
+    auto newSize = (is_top()) ? Size{size().width(), size().height() - 16} : size();
+    top_view->set_parent_rect({{0, 0}, newSize});
     focus();
     set_dirty();
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -722,7 +722,7 @@ void NavigationView::update_view() {
     auto top_view = top.view.get();
 
     add_child(top_view);
-    auto newSize = (is_top()) ? Size{size().width(), size().height() - 16} : size();
+    auto newSize = (is_top()) ? Size{size().width(), size().height() - 16} : size();  // if top(), then there is the info bar at the bottom, so leave space for it
     top_view->set_parent_rect({{0, 0}, newSize});
     focus();
     set_dirty();


### PR DESCRIPTION
A bit haxxy, but if we are on the top() we got the info bar on the bottom, so skip the last 16 px for it.