### PR TITLE
Use ifndef instead of pragma

### DIFF
--- a/firmware/application/apps/ui_external_module_view.hpp
+++ b/firmware/application/apps/ui_external_module_view.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __UI_EXTERNAL_MODULE_VIEW_H
+#define __UI_EXTERNAL_MODULE_VIEW_H
 
 #include "ui.hpp"
 #include "ui_widget.hpp"
@@ -92,3 +93,5 @@ class ExternalModuleView : public View {
 };
 
 }  // namespace ui
+
+#endif

--- a/firmware/application/external/spainter/ui_spectrum_painter.hpp
+++ b/firmware/application/external/spainter/ui_spectrum_painter.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __UI_SPECTRUM_PAINTER_H
+#define __UI_SPECTRUM_PAINTER_H
 
 #include "ui.hpp"
 #include "ui_language.hpp"
@@ -165,3 +166,5 @@ class SpectrumPainterView : public View {
 };
 
 }  // namespace ui::external_app::spainter
+
+#endif

--- a/firmware/application/external/spainter/ui_spectrum_painter_image.hpp
+++ b/firmware/application/external/spainter/ui_spectrum_painter_image.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __UI_SPECTRUM_PAINTER_IMAGE_H
+#define __UI_SPECTRUM_PAINTER_IMAGE_H
 
 #include "ui.hpp"
 #include "ui_widget.hpp"
@@ -64,3 +65,5 @@ class SpectrumInputImageView : public View {
 };
 
 }  // namespace ui::external_app::spainter
+
+#endif

--- a/firmware/application/external/spainter/ui_spectrum_painter_text.hpp
+++ b/firmware/application/external/spainter/ui_spectrum_painter_text.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __UI_SPECTRUM_PAINTER_TEXT_H
+#define __UI_SPECTRUM_PAINTER_TEXT_H
 
 #include "ui.hpp"
 #include "ui_widget.hpp"
@@ -110,3 +111,5 @@ class SpectrumInputTextView : public View {
 };
 
 }  // namespace ui::external_app::spainter
+
+#endif

--- a/firmware/application/io.hpp
+++ b/firmware/application/io.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __IO_H
+#define __IO_H
 
 #include "file.hpp"
 
@@ -38,3 +39,5 @@ class Writer {
 };
 
 } /* namespace stream */
+
+#endif

--- a/firmware/application/io_convert.hpp
+++ b/firmware/application/io_convert.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __IO_CONVERT_H
+#define __IO_CONVERT_H
 
 #include "io_file.hpp"
 
@@ -77,3 +78,5 @@ class FileConvertWriter : public stream::Writer {
     File file_{};
     uint64_t bytes_written_{0};
 };
+
+#endif

--- a/firmware/application/io_file.hpp
+++ b/firmware/application/io_file.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __IO_FILE_H
+#define __IO_FILE_H
 
 #include "io.hpp"
 
@@ -71,3 +72,5 @@ class FileWriter : public stream::Writer {
 };
 
 using RawFileWriter = FileWriter;
+
+#endif

--- a/firmware/application/io_wave.hpp
+++ b/firmware/application/io_wave.hpp
@@ -20,7 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __IO_WAVE_H
+#define __IO_WAVE_H
 
 #include "io_file.hpp"
 
@@ -181,3 +182,5 @@ class WAVFileWriter : public FileWriter {
     Optional<File::Error> update_header();
     Optional<File::Error> write_tags();
 };
+
+#endif

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __PORTAPACK_H
+#define __PORTAPACK_H
 
 #include "portapack_io.hpp"
 
@@ -85,3 +86,5 @@ Backlight* backlight();
 extern bool async_tx_enabled;  // this is for serial tx things, globally
 
 } /* namespace portapack */
+
+#endif

--- a/firmware/application/usb_serial.hpp
+++ b/firmware/application/usb_serial.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_H
+#define __USB_SERIAL_H
 
 #include "ch.h"
 #include "hal.h"
@@ -54,3 +55,5 @@ class USBSerial {
 };
 
 }  // namespace portapack
+
+#endif

--- a/firmware/application/usb_serial_cdc.h
+++ b/firmware/application/usb_serial_cdc.h
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_CDC_H
+#define __USB_SERIAL_CDC_H
 
 #include "ch.h"
 #include "hal.h"
@@ -44,3 +45,5 @@ usb_request_status_t usb_set_line_coding_request(usb_endpoint_t* const endpoint,
 #endif
 
 void setup_usb_serial_controller(void);
+
+#endif

--- a/firmware/application/usb_serial_descriptor.h
+++ b/firmware/application/usb_serial_descriptor.h
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_DESCRIPTOR_H
+#define __USB_SERIAL_DESCRIPTOR_H
 
 #include "ch.h"
 #include "hal.h"
@@ -42,3 +43,5 @@ extern uint8_t* usb_descriptor_strings[];
 #define USB_WCID_VENDOR_REQ 0x19
 extern uint8_t wcid_string_descriptor[];
 extern uint8_t wcid_feature_descriptor[];
+
+#endif

--- a/firmware/application/usb_serial_device_to_host.h
+++ b/firmware/application/usb_serial_device_to_host.h
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_DEVICE_TO_HOST_H
+#define __USB_SERIAL_DEVICE_TO_HOST_H
 
 #include "ch.h"
 #include "hal.h"
@@ -55,4 +56,6 @@ extern "C" {
 size_t fillOBuffer(OutputQueue* oqp, const uint8_t* bp, size_t n);
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/firmware/application/usb_serial_endpoints.h
+++ b/firmware/application/usb_serial_endpoints.h
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_ENDPOINTS_H
+#define __USB_SERIAL_ENDPOINTS_H
 
 #include "ch.h"
 #include "hal.h"
@@ -49,3 +50,5 @@ extern USB_DECLARE_QUEUE(usb_endpoint_bulk_in);
 
 extern usb_endpoint_t usb_endpoint_bulk_out;
 extern USB_DECLARE_QUEUE(usb_endpoint_bulk_out);
+
+#endif

--- a/firmware/application/usb_serial_event.hpp
+++ b/firmware/application/usb_serial_event.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_EVENT_H
+#define __USB_SERIAL_EVENT_H
 
 #include "ch.h"
 #include "hal.h"
@@ -31,4 +32,6 @@ void on_channel_opened(void);
 void on_channel_closed(void);
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/firmware/application/usb_serial_host_to_device.hpp
+++ b/firmware/application/usb_serial_host_to_device.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_HOST_TO_DEVICE_H
+#define __USB_SERIAL_HOST_TO_DEVICE_H
 
 #include "ch.h"
 #include "hal.h"
@@ -31,3 +32,5 @@ void reset_transfer_queues();
 void serial_bulk_transfer_complete(void* user_data, unsigned int bytes_transferred);
 void schedule_host_to_device_transfer();
 void complete_host_to_device_transfer();
+
+#endif

--- a/firmware/application/usb_serial_shell.hpp
+++ b/firmware/application/usb_serial_shell.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __USB_SERIAL_SHELL_H
+#define __USB_SERIAL_SHELL_H
 
 #include "ch.h"
 #include "hal.h"
@@ -29,3 +30,5 @@
 class EventDispatcher;
 
 void create_shell(EventDispatcher* evtd);
+
+#endif

--- a/firmware/baseband/proc_spectrum_painter.hpp
+++ b/firmware/baseband/proc_spectrum_painter.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __PROC_SPECTRUM_PAINTER_H
+#define __PROC_SPECTRUM_PAINTER_H
 
 #include "portapack_shared_memory.hpp"
 #include "baseband_processor.hpp"
@@ -46,3 +47,5 @@ class SpectrumPainterProcessor : public BasebandProcessor {
         return 0;
     }
 };
+
+#endif

--- a/firmware/common/backlight.hpp
+++ b/firmware/common/backlight.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __BACKLIGHT_H
+#define __BACKLIGHT_H
 
 #include <cstdint>
 
@@ -118,3 +119,5 @@ class BacklightCAT4004 : public BacklightBase {
 };
 
 } /* namespace portapack */
+
+#endif

--- a/firmware/common/buffer_exchange.hpp
+++ b/firmware/common/buffer_exchange.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __BUFFER_EXCHANGE_H
+#define __BUFFER_EXCHANGE_H
 
 #include "ch.h"
 
@@ -110,3 +111,5 @@ class BufferExchange {
 
     StreamBuffer* get_prefill(FIFO<StreamBuffer*>* fifo);
 };
+
+#endif

--- a/firmware/common/i2cdev_ppmod.hpp
+++ b/firmware/common/i2cdev_ppmod.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __I2CDEV_PPMOD_H
+#define __I2CDEV_PPMOD_H
 
 #include <cstdint>
 #include <array>
@@ -71,3 +72,5 @@ class I2cDev_PPmod : public I2cDev {
 };
 
 } /* namespace i2cdev */
+
+#endif

--- a/firmware/common/random.hpp
+++ b/firmware/common/random.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __RANDOM_H
+#define __RANDOM_H
 
 /* Period parameters */
 #define N 624
@@ -33,3 +34,5 @@
 /* initializes state[N] with a seed */
 extern void init_genrand(unsigned long s);
 extern long genrand_int31(void);
+
+#endif

--- a/firmware/test/application/mock_file.hpp
+++ b/firmware/test/application/mock_file.hpp
@@ -19,7 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#pragma once
+#ifndef __MOCK_FILE_H
+#define __MOCK_FILE_H
 
 #include "file.hpp"
 #include <cstring>
@@ -87,3 +88,5 @@ class MockFile {
     std::string data_;
     uint32_t offset_{0};
 };
+
+#endif


### PR DESCRIPTION
For codebase consistency and portability, it's better to use #ifndef HEADERS than pragmas.

That PR is doing the switch for all the concerned code.

More informations about #ifndef vs prama in the following PR comment : https://github.com/portapack-mayhem/mayhem-firmware/pull/2290#issuecomment-2410606441 
