### PR TITLE
Pacman warning fix

### DIFF
--- a/firmware/application/apps/ui_standalone_view.cpp
+++ b/firmware/application/apps/ui_standalone_view.cpp
@@ -177,7 +177,7 @@ bool StandaloneView::on_touch(const TouchEvent event) {
 
 bool StandaloneView::on_keyboard(const KeyboardEvent event) {
     if (get_application_information()->header_version > 1) {
-        return get_application_information()->OnKeyboad((uint8_t)event);
+        return get_application_information()->OnKeyboard((uint8_t)event);
     }
     return false;
 }

--- a/firmware/common/standalone_app.hpp
+++ b/firmware/common/standalone_app.hpp
@@ -98,7 +98,7 @@ struct standalone_application_information_t {
     void (*OnFocus)();
     bool (*OnKeyEvent)(uint8_t key);
     bool (*OnEncoder)(int32_t delta);
-    bool (*OnKeyboad)(uint8_t key);
+    bool (*OnKeyboard)(uint8_t key);
 };
 
 #endif /*__UI_STANDALONE_APP_H__*/

--- a/firmware/standalone/pacman/main.cpp
+++ b/firmware/standalone/pacman/main.cpp
@@ -27,7 +27,7 @@ const standalone_application_api_t* _api;
 
 extern "C" {
 __attribute__((section(".standalone_application_information"), used)) standalone_application_information_t _standalone_application_information = {
-    /*.header_version = */ CURRENT_STANDALONE_APPLICATION_API_VERSION,
+    /*.header_version = */ 1,
 
     /*.app_name = */ "Pac-Man",
     /*.bitmap_data = */ {

--- a/firmware/standalone/pacman/main.cpp
+++ b/firmware/standalone/pacman/main.cpp
@@ -75,13 +75,13 @@ __attribute__((section(".standalone_application_information"), used)) standalone
     /*OnFocus */ NULL,
     /*OnKeyEvent */ NULL,
     /*OnEncoder */ NULL,
-    /*OnKeyboard */ NULL
-};
+    /*OnKeyboard */ NULL};
 }
 
 /* Implementing abort() eliminates requirement for _getpid(), _kill(), _exit(). */
 extern "C" void abort() {
-    while (true);
+    while (true)
+        ;
 }
 
 // replace memory allocations to use heap from chibios

--- a/firmware/standalone/pacman/main.cpp
+++ b/firmware/standalone/pacman/main.cpp
@@ -70,6 +70,12 @@ __attribute__((section(".standalone_application_information"), used)) standalone
     /*.initialize_app = */ initialize,
     /*.on_event = */ on_event,
     /*.shutdown = */ shutdown,
+    /*PaintViewMirror */ NULL,
+    /*OnTouchEvent */ NULL,
+    /*OnFocus */ NULL,
+    /*OnKeyEvent */ NULL,
+    /*OnEncoder */ NULL,
+    /*OnKeyboard */ NULL
 };
 }
 


### PR DESCRIPTION
Add missing inits in pacman app to avoid compilation warnings 
Rename OnKeyboad to OnKeyboard in ui_standalone apps
Fix standalone app header version to 1 for Pacman