### PR TITLE
APRS RX: better region/frequency controls

### DIFF
--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -94,21 +94,39 @@ APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
     record_view.set_sampling_rate(24000);
 
     options_region.on_change = [this](size_t, int32_t i) {
-        if (i == 0) {
+        field_frequency.on_change = [this](rf::Frequency f) { (void)f; };
+        if (i == 0) {  // MAN Manual setting
+            field_frequency.set_value(aprs_rx_freq);
+        } else if (i == 1) {  // NA - North America - is also the default
             field_frequency.set_value(144390000);
-        } else if (i == 1) {
+        } else if (i == 2) {  // EUR
             field_frequency.set_value(144800000);
-        } else if (i == 2) {
+        } else if (i == 3) {  // AUS
             field_frequency.set_value(145175000);
-        } else if (i == 3) {
+        } else if (i == 4) {  // NZ
             field_frequency.set_value(144575000);
-        } else if (i == 4) {
+        } else if (i == 5) {  // ISS
             field_frequency.set_value(145825000);
         }
+        options_region_id = i;
+        receiver_model.set_target_frequency(field_frequency.value());  // Retune
+        field_frequency.on_change = [this](rf::Frequency f) {
+            aprs_rx_freq = f;
+            options_region.set_selected_index(0, true);
+        };
     };
 
     field_frequency.set_step(100);
-    options_region.set_selected_index(0, true);
+    field_frequency.on_edit = [this]() {
+        auto freq_view = nav_.push<FrequencyKeypadView>(field_frequency.value());
+        freq_view->on_changed = [this](rf::Frequency f) {
+            aprs_rx_freq = f;
+            field_frequency.set_value(f);
+        };
+    };
+
+    // Note: setting the region is also going to sef field_frequency.on_change
+    options_region.set_selected_index(options_region_id, true);
 
     logger = std::make_unique<APRSLogger>();
     if (logger)
@@ -124,6 +142,8 @@ APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
 
 void APRSRxView::on_freqchg(int64_t freq) {
     field_frequency.set_value(freq);
+    aprs_rx_freq = freq;
+    options_region.set_selected_index(0, true);
 }
 
 void APRSRxView::on_packet(const APRSPacketMessage* message) {

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -190,6 +190,8 @@ class APRSRxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
     bool reset_console = false;
+    uint8_t options_region_id = 1;          // default to North America
+    rf::Frequency aprs_rx_freq{144390000};  // default to North America frequency
 
     NavigationView& nav_;
     RxRadioState radio_state_{
@@ -198,7 +200,10 @@ class APRSRxView : public View {
         3072000 /* sampling rate */
     };
     app_settings::SettingsManager settings_{
-        "rx_aprs", app_settings::Mode::RX};
+        "rx_aprs",
+        app_settings::Mode::RX,
+        {{"options_region_id"sv, &options_region_id},
+         {"aprs_rx_freq"sv, &aprs_rx_freq}}};
 
     uint8_t console_color{0};
     std::string str_log{""};
@@ -220,15 +225,15 @@ class APRSRxView : public View {
     OptionsField options_region{
         {0 * 8, 0 * 8},
         3,
-        {{"NA ", 0},
-         {"EUR", 1},
-         {"AUS", 2},
-         {"NZ ", 3},
-         {"ISS", 4}}};
+        {{"MAN", 0},
+         {"NA ", 1},
+         {"EUR", 2},
+         {"AUS", 3},
+         {"NZ ", 4},
+         {"ISS", 5}}};
 
-    RxFrequencyField field_frequency{
-        {3 * 8, 0 * 16},
-        nav_};
+    FrequencyField field_frequency{
+        {3 * 8, 0 * 16}};
 
     // DEBUG
     RecordView record_view{


### PR DESCRIPTION
Fix for APRS-RX settings not retained ( https://github.com/portapack-mayhem/mayhem-firmware/issues/2339  )
- added MAN for manual
- added region and manual frequency as app settings 
- added manual frequency input view (press middle button on frequency open the keypad)
- set default region to North America with default corresponding frequency (in case it was never set, which will be the case on first app launch or on portapacks without sdcards)