### PR TITLE
Auto switch C16/C8 default  REC format in both BW directions.

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -87,9 +87,12 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         auto anti_alias_filter_bandwidth = filter_bandwidth_for_sampling_rate(actual_sample_rate);
         receiver_model.set_baseband_bandwidth(anti_alias_filter_bandwidth);
 
-        // Automatically switch default capture format to C8 when bandwidth setting is increased to >=1.5MHz
+        // Automatically switch default capture format to C8 when bandwidth setting is increased to >=1.5MHz anb back to C16 for <=1,25Mhz
         if ((bandwidth >= 1500000) && (previous_bandwidth < 1500000)) {
-            option_format.set_selected_index(1);
+            option_format.set_selected_index(1); // Default C8 format for REC, 1500K ... 5500k
+        }
+        if ((bandwidth <= 1250000) && (previous_bandwidth > 1250000)) {
+            option_format.set_selected_index(0); // Default C16 format for REC , 12k5 ... 1250K
         }
         previous_bandwidth = bandwidth;
 

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -89,10 +89,10 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
 
         // Automatically switch default capture format to C8 when bandwidth setting is increased to >=1.5MHz anb back to C16 for <=1,25Mhz
         if ((bandwidth >= 1500000) && (previous_bandwidth < 1500000)) {
-            option_format.set_selected_index(1); // Default C8 format for REC, 1500K ... 5500k
+            option_format.set_selected_index(1);  // Default C8 format for REC, 1500K ... 5500k
         }
         if ((bandwidth <= 1250000) && (previous_bandwidth > 1250000)) {
-            option_format.set_selected_index(0); // Default C16 format for REC , 12k5 ... 1250K
+            option_format.set_selected_index(0);  // Default C16 format for REC , 12k5 ... 1250K
         }
         previous_bandwidth = bandwidth;
 


### PR DESCRIPTION
Very Minor issue , (but better for usability ) .

Before that PR,  the default REC  format change just  happended in one direction , when increasing , 
now in both directions  (increasing / decreasing ). 

1-)  default  C16 --> C8   REC format  change , happens when increasing   BW : 1250k ---> 1500k
2-)  default  C8   --> C16 REC format  change , happens when decreasing  BW : 1500k ---> 1250k

Cheers, 
