### PR TITLE
RSSI draw/ Level app opt

### DIFF
--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -184,6 +184,8 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     rssi_graph.add_values(rssi.get_min(), rssi.get_avg(), rssi.get_max(), statistics.max_db);
 
     // refresh db
+    rssi.set_db(statistics.max_db);
+
     if (last_max_db != statistics.max_db) {
         last_max_db = statistics.max_db;
         freq_stats_db.set("Power: " + to_string_dec_int(statistics.max_db) + " db");

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -184,11 +184,10 @@ void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
     rssi_graph.add_values(rssi.get_min(), rssi.get_avg(), rssi.get_max(), statistics.max_db);
 
     // refresh db
-    rssi.set_db(statistics.max_db);
-
     if (last_max_db != statistics.max_db) {
         last_max_db = statistics.max_db;
         freq_stats_db.set("Power: " + to_string_dec_int(statistics.max_db) + " db");
+        rssi.set_db(statistics.max_db);
     }
     // refresh rssi
     if (last_min_rssi != rssi_graph.get_graph_min() || last_avg_rssi != rssi_graph.get_graph_avg() || last_max_rssi != rssi_graph.get_graph_max()) {

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -103,7 +103,7 @@ void RSSI::paint(Painter& painter) {
                 Theme::getInstance()->fg_orange->foreground);
         }
 
-        // dB - x 
+        // dB - x
         constexpr int db_min = -80;
         constexpr int db_max = 10;
         constexpr int db_delta = db_max - db_min;
@@ -126,7 +126,7 @@ void RSSI::paint(Painter& painter) {
 
         // y_min
         const Rect r0{r.left(), r.bottom() - y_min, r.width(), y_min};
-        painter.fill_rectangle( // TODO: the blue plot is broken in vertical bars, not from the dB PR
+        painter.fill_rectangle(  // TODO: the blue plot is broken in vertical bars, not from the dB PR
             r0,
             Color::blue());
 
@@ -180,7 +180,7 @@ void RSSI::paint(Painter& painter) {
         const Rect r6{r.left(), r.top(), r.width(), r.height()};
         painter.draw_rectangle(
             r6,
-            Color::white()); //TODO this and all the following Color struct call should satisfy the new "theme" system ref
+            Color::white());  // TODO this and all the following Color struct call should satisfy the new "theme" system ref
     }
 }
 

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -102,6 +102,17 @@ void RSSI::paint(Painter& painter) {
                 r5,
                 Theme::getInstance()->fg_orange->foreground);
         }
+
+        // dB - x 
+        constexpr int db_min = -80;
+        constexpr int db_max = 10;
+        constexpr int db_delta = db_max - db_min;
+        const range_t<int> x_db_range{0, r.width() - 1};
+        const int16_t x_db = x_db_range.clip((db_ - db_min) * r.width() / db_delta);
+
+        const Rect r_db{r.left() + x_db, r.top(), 1, r.height()};
+
+        if (db_) painter.fill_rectangle(r_db, Color::green());
     } else {
         // vertical bottom to top level meters
         const range_t<int> y_avg_range{0, r.height() - 1};
@@ -115,7 +126,7 @@ void RSSI::paint(Painter& painter) {
 
         // y_min
         const Rect r0{r.left(), r.bottom() - y_min, r.width(), y_min};
-        painter.fill_rectangle(
+        painter.fill_rectangle( // TODO: the blue plot is broken in vertical bars, not from the dB PR
             r0,
             Color::blue());
 
@@ -151,6 +162,16 @@ void RSSI::paint(Painter& painter) {
                 r5,
                 Color::orange());
         }
+
+        // dB - y
+        constexpr int db_min = -80;
+        constexpr int db_max = 10;
+        constexpr int db_delta = db_max - db_min;
+        const range_t<int> y_db_range{0, r.height() - 1};
+        const int16_t y_db = y_db_range.clip((db_ - db_min) * r.height() / db_delta);
+
+        const Rect r_db{r.left(), r.bottom() - y_db, r.width(), 3};
+        if (db_) painter.fill_rectangle(r_db, Color::green());
     }
     if (pitch_rssi_enabled) {
         baseband::set_pitch_rssi((avg_ - raw_min) * 2000 / raw_delta, true);
@@ -159,7 +180,7 @@ void RSSI::paint(Painter& painter) {
         const Rect r6{r.left(), r.top(), r.width(), r.height()};
         painter.draw_rectangle(
             r6,
-            Color::white());
+            Color::white()); //TODO this and all the following Color struct call should satisfy the new "theme" system ref
     }
 }
 
@@ -499,5 +520,10 @@ bool RSSI::on_touch(const TouchEvent event) {
         default:
             return false;
     }
+}
+
+void RSSI::set_db(int16_t db) {
+    db_ = db;
+    set_dirty();
 }
 } /* namespace ui */

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -100,7 +100,7 @@ void RSSI::paint(Painter& painter) {
             const Rect r5{r.left() + peak - 3, r.top(), 3, r.height()};
             painter.fill_rectangle(
                 r5,
-                Theme::getInstance()->fg_green->foreground);
+                Theme::getInstance()->fg_orange->foreground);
         }
     } else {
         // vertical bottom to top level meters
@@ -149,7 +149,7 @@ void RSSI::paint(Painter& painter) {
             const Rect r5{r.left(), r.bottom() - peak - 3, r.width(), 3};
             painter.fill_rectangle(
                 r5,
-                Color::green());
+                Color::orange());
         }
     }
     if (pitch_rssi_enabled) {

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -126,7 +126,7 @@ void RSSI::paint(Painter& painter) {
 
         // y_min
         const Rect r0{r.left(), r.bottom() - y_min, r.width(), y_min};
-        painter.fill_rectangle(  // TODO: the blue plot is broken in vertical bars, not from the dB PR
+        painter.fill_rectangle(  // TODO: the blue plot is broken in vertical bars, not from the dB PR (#2403)
             r0,
             Color::blue());
 

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -524,6 +524,5 @@ bool RSSI::on_touch(const TouchEvent event) {
 
 void RSSI::set_db(int16_t db) {
     db_ = db;
-    set_dirty();
 }
 } /* namespace ui */

--- a/firmware/application/ui/ui_rssi.hpp
+++ b/firmware/application/ui/ui_rssi.hpp
@@ -61,6 +61,7 @@ class RSSI : public Widget {
     void on_focus() override;
     bool on_key(const KeyEvent key) override;
     bool on_touch(const TouchEvent event) override;
+    void set_db(int16_t db);
 
    private:
     int8_t min_ = 0;
@@ -68,6 +69,7 @@ class RSSI : public Widget {
     int8_t max_ = 0;
     int8_t peak_ = 0;
     size_t peak_duration_ = 0;
+    int16_t db_ = 0;
     bool instant_exec_{false};
 
     bool pitch_rssi_enabled = false;


### PR DESCRIPTION
- make the peak of RSSI max val into orange color (it's the peak of RSSI max AKA red color), so should be similar color
- make the dB from RSSIGraph has RSSI too (Level app parallel them, so need to have both on them)
- after the Theme system, some remain Color call here should be satisfied to theme system, but won't do that in this PR.
- the blue paint is broken somewhere but not here.