### PR TITLE
Enable exFAT feature

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -798,7 +798,7 @@ void add_external_items(NavigationView& nav, app_location_t location, BtnGridVie
 
 bool verify_sdcard_format() {
     FATFS* fs = &sd_card::fs;
-    return (fs->fs_type == FS_FAT32) || !(sd_card::status() == sd_card::Status::Mounted);
+    return (fs->fs_type == FS_FAT32 || fs->fs_type == FS_EXFAT) || !(sd_card::status() == sd_card::Status::Mounted);
     /*                                   ^ to satisfy those users that not use an sd*/
 }
 
@@ -875,7 +875,7 @@ SystemMenuView::SystemMenuView(NavigationView& nav)
 void SystemMenuView::on_populate() {
     if (!verify_sdcard_format()) {
         add_item({"SDCard Error", Theme::getInstance()->error_dark->foreground, nullptr, [this]() {
-                      nav_.display_modal("Error", "SD Card is not FAT32,\nformat to FAT32 on PC");
+                      nav_.display_modal("Error", "SD Card is not exFAT/FAT32,\nformat to exFAT or FAT32 on PC");
                   }});
     }
     add_apps(nav_, *this, HOME);

--- a/firmware/application/ui_sd_card_debug.cpp
+++ b/firmware/application/ui_sd_card_debug.cpp
@@ -473,7 +473,7 @@ std::string SDCardDebugView::fetch_sdcard_format() {
         case FS_FAT32:
             resault = "FAT32";
             break;
-        case FS_EXFAT:  // TODO: a bug from filesystem can't detect exfat, issue not from here
+        case FS_EXFAT:
             resault = "ExFAT";
             break;
         default:

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -271,6 +271,7 @@ macro(DeclareTargets chunk_tag name)
 	project("baseband_${name}")
 
 	include(${RULESPATH}/rules.cmake)
+	set_source_files_properties(${MODE_CPPSRC} PROPERTIES COMPILE_FLAGS "${MODE_FLAGS}")
 	add_executable(${PROJECT_NAME}.elf $<TARGET_OBJECTS:baseband_shared> ${MODE_CPPSRC} ${HALSRC} ${PLATFORMSRC})
 	set_target_properties(${PROJECT_NAME}.elf PROPERTIES LINK_DEPENDS ${LDSCRIPT})
 	add_definitions(${DEFS})
@@ -313,6 +314,7 @@ macro(DeclareTargets chunk_tag name)
 endmacro()
 
 set(add_to_firmware TRUE)
+set(MODE_FLAGS "-O3")
 
 
 ### ADS-B RX
@@ -498,6 +500,7 @@ set(MODE_CPPSRC
 )
 DeclareTargets(PWTH weather)
 
+set(MODE_FLAGS "-Os")
 
 ### Flash Utility
 
@@ -559,7 +562,7 @@ DeclareTargets(PUSB sd_over_usb)
 
 ### Place external app and disabled images below so they don't get added to the firmware
 set(add_to_firmware FALSE)
-
+set(MODE_FLAGS "-O3")
 
 ### ACARS RX
 

--- a/firmware/common/ffconf.h
+++ b/firmware/common/ffconf.h
@@ -90,7 +90,7 @@
 /   950 - Traditional Chinese (DBCS)
 */
 
-#define _USE_LFN 2
+#define _USE_LFN 3
 #define _MAX_LFN 255
 /* The _USE_LFN switches the support of long file name (LFN).
 /
@@ -189,7 +189,7 @@
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the file system object (FATFS) is used for the file data transfer. */
 
-#define _FS_EXFAT 0
+#define _FS_EXFAT 1
 /* This option switches support of exFAT file system. (0:Disable or 1:Enable)
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */


### PR DESCRIPTION
Since so many have problems with FAT32 I'd like to enable the exFAT feature flag.

I had to change the compilation of Flash Utility and SD over USB with -Os (optimize for size) so everything fits. They don't have any requirement for speed, so that should be fine.