### PR TITLE
Navigation buttons

### DIFF
--- a/firmware/application/bitmap.hpp
+++ b/firmware/application/bitmap.hpp
@@ -2531,6 +2531,44 @@ static constexpr Bitmap bitmap_icon_batt_icon{
     {16, 16},
     bitmap_icon_batt_icon_data};
 
+static constexpr uint8_t bitmap_icon_temperature_data[] = {
+    0x00,
+    0x01,
+    0x80,
+    0x01,
+    0x80,
+    0x05,
+    0xC0,
+    0x0D,
+    0x40,
+    0x0D,
+    0xD0,
+    0x1F,
+    0x70,
+    0x15,
+    0xB0,
+    0x1A,
+    0x58,
+    0x35,
+    0xB8,
+    0x3A,
+    0x58,
+    0x34,
+    0x28,
+    0x28,
+    0x18,
+    0x30,
+    0x30,
+    0x18,
+    0x60,
+    0x0C,
+    0xC0,
+    0x07,
+};
+static constexpr Bitmap bitmap_icon_temperature{
+    {16, 16},
+    bitmap_icon_temperature_data};
+
 static constexpr uint8_t bitmap_tab_edge_data[] = {
     0x00,
     0x01,
@@ -4789,6 +4827,44 @@ static constexpr Bitmap bitmap_icon_ais{
     {16, 16},
     bitmap_icon_ais_data};
 
+static constexpr uint8_t bitmap_temperature_data[] = {
+    0x00,
+    0x00,
+    0x20,
+    0x00,
+    0x70,
+    0x3E,
+    0x88,
+    0x00,
+    0x88,
+    0x00,
+    0x88,
+    0x3E,
+    0x88,
+    0x00,
+    0x88,
+    0x00,
+    0x88,
+    0x3E,
+    0x88,
+    0x00,
+    0x04,
+    0x01,
+    0x74,
+    0x01,
+    0x04,
+    0x01,
+    0x88,
+    0x00,
+    0x70,
+    0x00,
+    0x00,
+    0x00,
+};
+static constexpr Bitmap bitmap_temperature{
+    {16, 16},
+    bitmap_temperature_data};
+
 static constexpr uint8_t bitmap_titlebar_image_data[] = {
     0x00,
     0x00,
@@ -5701,6 +5777,44 @@ static constexpr Bitmap bitmap_icon_options_datetime{
     {16, 16},
     bitmap_icon_options_datetime_data};
 
+static constexpr uint8_t bitmap_icon_tune_fork_data[] = {
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x22,
+    0x44,
+    0x21,
+    0x84,
+    0x2D,
+    0xB4,
+    0x25,
+    0xA4,
+    0x25,
+    0xA4,
+    0x2D,
+    0xB4,
+    0x61,
+    0x86,
+    0xC2,
+    0x43,
+    0x80,
+    0x01,
+    0x80,
+    0x01,
+    0x80,
+    0x01,
+    0x80,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+};
+static constexpr Bitmap bitmap_icon_tune_fork{
+    {16, 16},
+    bitmap_icon_tune_fork_data};
+
 static constexpr uint8_t bitmap_target_verify_data[] = {
     0x00,
     0xE0,
@@ -6027,4 +6141,4 @@ static constexpr Bitmap bitmap_icon_protoview{
 
 } /* namespace ui */
 
-#endif /*__BITMAP_HPP__*/
+#endif/*__BITMAP_HPP__*/

--- a/firmware/application/bitmap.hpp
+++ b/firmware/application/bitmap.hpp
@@ -6141,4 +6141,4 @@ static constexpr Bitmap bitmap_icon_protoview{
 
 } /* namespace ui */
 
-#endif/*__BITMAP_HPP__*/
+#endif /*__BITMAP_HPP__*/

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -55,6 +55,9 @@ BtnGridView::BtnGridView(
         }
     };
 
+    button_pgup.set_style(Theme::getInstance()->bg_darkest_small);
+    button_pgdown.set_style(Theme::getInstance()->bg_darkest_small);
+
     add_child(&button_pgup);
     add_child(&button_pgdown);
 }

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -38,17 +38,28 @@ BtnGridView::BtnGridView(
     set_parent_rect(new_parent_rect);
     set_focusable(true);
 
-    signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
-        this->on_tick_second();
+    button_pgup.set_focusable(false);
+    button_pgup.on_select = [this](Button&) {
+        if (arrow_up_enabled) {
+            if (((int64_t)highlighted_item - displayed_max) > 0)
+                set_highlighted(highlighted_item - displayed_max);
+            else
+                set_highlighted(0);
+        }
     };
 
-    add_child(&arrow_more);
-    arrow_more.set_focusable(false);
-    arrow_more.set_foreground(Theme::getInstance()->bg_darkest->background);
+    button_pgdown.set_focusable(false);
+    button_pgdown.on_select = [this](Button&) {
+        if (arrow_down_enabled) {
+            set_highlighted(highlighted_item + displayed_max);
+        }
+    };
+
+    add_child(&button_pgup);
+    add_child(&button_pgdown);
 }
 
 BtnGridView::~BtnGridView() {
-    rtc_time::signal_tick_second -= signal_token_tick_second;
 }
 
 void BtnGridView::set_max_rows(int rows) {
@@ -63,7 +74,10 @@ void BtnGridView::set_parent_rect(const Rect new_parent_rect) {
     View::set_parent_rect(new_parent_rect);
 
     displayed_max = (parent_rect().size().height() / button_h);
-    arrow_more.set_parent_rect({228, (Coord)(displayed_max * button_h), 8, 8});
+
+    button_pgup.set_parent_rect({0, (Coord)(displayed_max * button_h), 120, 16});
+    button_pgdown.set_parent_rect({120, (Coord)(displayed_max * button_h), 120, 16});
+
     displayed_max *= rows_;
 
     // Delete any existing buttons.
@@ -84,28 +98,40 @@ void BtnGridView::set_parent_rect(const Rect new_parent_rect) {
 
         menu_item_views.push_back(std::move(item));
     }
-
     update_items();
 }
 
-void BtnGridView::set_arrow_enabled(bool enabled) {
+void BtnGridView::set_arrow_up_enabled(bool enabled) {
+    if (!show_arrows)
+        return;
     if (enabled) {
-        add_child(&arrow_more);
-    } else {
-        remove_child(&arrow_more);
+        if (!arrow_up_enabled) {
+            arrow_up_enabled = true;
+            button_pgup.set_text("PAGE UP");
+        }
+    } else if (!enabled) {
+        if (arrow_up_enabled) {
+            arrow_up_enabled = false;
+            button_pgup.set_text("       ");
+        }
     }
 };
 
-void BtnGridView::on_tick_second() {
-    if (more && blink)
-        arrow_more.set_foreground(Theme::getInstance()->bg_darkest->foreground);
-    else
-        arrow_more.set_foreground(Theme::getInstance()->bg_darkest->background);
-
-    blink = !blink;
-
-    arrow_more.set_dirty();
-}
+void BtnGridView::set_arrow_down_enabled(bool enabled) {
+    if (!show_arrows)
+        return;
+    if (enabled) {
+        if (!arrow_down_enabled) {
+            arrow_down_enabled = true;
+            button_pgdown.set_text("PAGE DOWN");
+        }
+    } else if (!enabled) {
+        if (arrow_down_enabled) {
+            arrow_down_enabled = false;
+            button_pgdown.set_text("         ");
+        }
+    }
+};
 
 void BtnGridView::clear() {
     // clear vector and release memory, not using swap since it's causing capture to glitch/fault
@@ -153,15 +179,23 @@ void BtnGridView::insert_item(const GridItem& new_item, size_t position, bool in
     }
 }
 
+void BtnGridView::show_hide_arrows() {
+    if (highlighted_item == 0) {
+        set_arrow_up_enabled(false);
+    } else {
+        set_arrow_up_enabled(true);
+    }
+    if (highlighted_item == (menu_items.size() - 1)) {
+        set_arrow_down_enabled(false);
+    } else {
+        set_arrow_down_enabled(true);
+    }
+}
+
 void BtnGridView::update_items() {
     size_t i = 0;
-    Color bg_color = portapack::persistent_memory::menu_color();
 
-    if ((menu_items.size()) > (displayed_max + offset)) {
-        more = true;
-        blink = true;
-    } else
-        more = false;
+    Color bg_color = portapack::persistent_memory::menu_color();
 
     for (auto& item : menu_item_views) {
         if ((i + offset) >= menu_items.size()) {
@@ -189,14 +223,19 @@ NewButton* BtnGridView::item_view(size_t index) const {
     return menu_item_views[index].get();
 }
 
+void BtnGridView::set_show_arrows(bool enabled) {
+    show_arrows = enabled;
+}
+
 bool BtnGridView::set_highlighted(int32_t new_value) {
     int32_t item_count = (int32_t)menu_items.size();
 
     if (new_value < 0)
         return false;
 
-    if (new_value >= item_count)
+    if (new_value >= item_count) {
         new_value = item_count - 1;
+    }
 
     if (((uint32_t)new_value > offset) && ((new_value - offset) >= displayed_max)) {
         // Shift BtnGridView up
@@ -222,6 +261,8 @@ bool BtnGridView::set_highlighted(int32_t new_value) {
     if (visible())
         item_view(highlighted_item - offset)->focus();
 
+    show_hide_arrows();
+
     return true;
 }
 
@@ -235,21 +276,22 @@ void BtnGridView::on_focus() {
 
 void BtnGridView::on_blur() {
 #if 0
-    if (!keep_highlight)
-        item_view(highlighted_item - offset)->unhighlight();
+        if (!keep_highlight)
+            item_view(highlighted_item - offset)->unhighlight();
 #endif
 }
 
 void BtnGridView::on_show() {
     on_populate();
-
     View::on_show();
+    set_highlighted(highlighted_item);
 }
 
 void BtnGridView::on_hide() {
     View::on_hide();
-
     clear();
+    set_arrow_up_enabled(false);
+    set_arrow_down_enabled(false);
 }
 
 bool BtnGridView::on_key(const KeyEvent key) {

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -226,7 +226,7 @@ NewButton* BtnGridView::item_view(size_t index) const {
     return menu_item_views[index].get();
 }
 
-void BtnGridView::set_show_arrows(bool enabled) {
+void BtnGridView::show_arrows_enabled(bool enabled) {
     show_arrows = enabled;
 }
 

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -90,8 +90,6 @@ class BtnGridView : public View {
 
     void update_items();
 
-    ui::Painter painter{};
-
    protected:
     virtual void on_populate() = 0;
 

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -69,7 +69,7 @@ class BtnGridView : public View {
     NewButton* item_view(size_t index) const;
 
     bool show_arrows{true};  // flag used to hide arrows in main menu
-    void set_show_arrows(bool enabled);
+    void show_arrows_enabled(bool enabled);
 
     bool set_highlighted(int32_t new_value);
     uint32_t highlighted_index();

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -68,11 +68,18 @@ class BtnGridView : public View {
 
     NewButton* item_view(size_t index) const;
 
+    bool show_arrows{true};  // flag used to hide arrows in main menu
+    void set_show_arrows(bool enabled);
+
     bool set_highlighted(int32_t new_value);
     uint32_t highlighted_index();
 
     void set_parent_rect(const Rect new_parent_rect) override;
-    void set_arrow_enabled(bool enabled);
+    bool arrow_up_enabled{false};
+    bool arrow_down_enabled{false};
+    void set_arrow_up_enabled(bool enabled);
+    void set_arrow_down_enabled(bool enabled);
+    void show_hide_arrows();
     void on_focus() override;
     void on_blur() override;
     void on_show() override;
@@ -83,29 +90,28 @@ class BtnGridView : public View {
 
     void update_items();
 
+    ui::Painter painter{};
+
    protected:
     virtual void on_populate() = 0;
 
    private:
     int rows_{3};
-    void on_tick_second();
-
     bool keep_highlight{false};
 
-    SignalToken signal_token_tick_second{};
     std::vector<GridItem> menu_items{};
     std::vector<std::unique_ptr<NewButton>> menu_item_views{};
 
-    Image arrow_more{
-        {228, 320 - 8, 8, 8},
-        &bitmap_more,
-        Theme::getInstance()->bg_darkest->foreground,
-        Theme::getInstance()->bg_darkest->background};
+    Button button_pgup{
+        {0, 324, 120, 16},
+        "       "};
+
+    Button button_pgdown{
+        {121, 324, 119, 16},
+        "         "};
 
     int button_w = 240 / rows_;
     static constexpr int button_h = 48;
-    bool blink = false;
-    bool more = false;
     size_t displayed_max{0};
     size_t highlighted_item{0};
     size_t offset{0};

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -876,7 +876,7 @@ void SystemMenuView::hackrf_mode(NavigationView& nav) {
 SystemMenuView::SystemMenuView(NavigationView& nav)
     : nav_(nav) {
     set_max_rows(2);  // allow wider buttons
-    set_show_arrows(false);
+    show_arrows_enabled(false);
 }
 
 void SystemMenuView::on_populate() {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -825,9 +825,7 @@ void ReceiversMenuView::on_populate() {
     if (return_icon) {
         add_item({"..", Theme::getInstance()->fg_light->foreground, &bitmap_icon_previous, [this]() { nav_.pop(); }});
     }
-
     add_apps(nav_, *this, RX);
-
     add_external_items(nav_, app_location_t::RX, *this, return_icon ? 1 : 0);
 }
 
@@ -841,9 +839,7 @@ void TransmittersMenuView::on_populate() {
     if (return_icon) {
         add_items({{"..", Theme::getInstance()->fg_light->foreground, &bitmap_icon_previous, [this]() { nav_.pop(); }}});
     }
-
     add_apps(nav_, *this, TX);
-
     add_external_items(nav_, app_location_t::TX, *this, return_icon ? 1 : 0);
 }
 
@@ -859,9 +855,7 @@ void UtilitiesMenuView::on_populate() {
     if (return_icon) {
         add_items({{"..", Theme::getInstance()->fg_light->foreground, &bitmap_icon_previous, [this]() { nav_.pop(); }}});
     }
-
     add_apps(nav_, *this, UTILITIES);
-
     add_external_items(nav_, app_location_t::UTILITIES, *this, return_icon ? 1 : 0);
 }
 
@@ -882,7 +876,7 @@ void SystemMenuView::hackrf_mode(NavigationView& nav) {
 SystemMenuView::SystemMenuView(NavigationView& nav)
     : nav_(nav) {
     set_max_rows(2);  // allow wider buttons
-    set_arrow_enabled(false);
+    set_show_arrows(false);
 }
 
 void SystemMenuView::on_populate() {


### PR DESCRIPTION
That PR is adding pagination buttons in the submenus.

Main menu is not having them as the black stripe on the bottom is used to display hackrf version /date and time.

The only way to make something responsive was to use Buttons with text.

I tried using ImageButtons, but there was no way to make them disappear without clearing the whole screen and make the whole menu flashing.

#### How is it scrolling :
- the code was already computing the maximum number of displayed cells regarding the row number. I use that value to scroll by a whole 'screen', it's the displayed_max value
- you can scroll until you reach a boundary. Then the highlighted item is set on the minimum or maximum position, depending on the direction you touch
- it is displaying the page up / page down as soon as you are not on the minimum or maximum index
- it is hiding page up if you are at minimum position
- it is hiding page down if you are at maximum position

#### Will it need adjustments if we change the number of rows : 
- No

PS: I also updated bitmap.hpp by running the python script to regenerate it.

![image](https://github.com/user-attachments/assets/a19e0372-ef3c-4653-a7bf-8766781c5ad7)

Test bin: https://discord.com/channels/719669764804444213/722101917135798312/1323418884702863360

