### PR TITLE
disabling button on main menu, change labels and add 'icons'

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -110,7 +110,7 @@ void BtnGridView::set_arrow_up_enabled(bool enabled) {
     if (enabled) {
         if (!arrow_up_enabled) {
             arrow_up_enabled = true;
-            button_pgup.set_text("NEXT >");
+            button_pgup.set_text("< PREV");
         }
     } else if (!enabled) {
         if (arrow_up_enabled) {
@@ -126,7 +126,7 @@ void BtnGridView::set_arrow_down_enabled(bool enabled) {
     if (enabled) {
         if (!arrow_down_enabled) {
             arrow_down_enabled = true;
-            button_pgdown.set_text("< PREV");
+            button_pgdown.set_text("NEXT >");
         }
     } else if (!enabled) {
         if (arrow_down_enabled) {

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -110,12 +110,12 @@ void BtnGridView::set_arrow_up_enabled(bool enabled) {
     if (enabled) {
         if (!arrow_up_enabled) {
             arrow_up_enabled = true;
-            button_pgup.set_text("PAGE UP");
+            button_pgup.set_text("NEXT >");
         }
     } else if (!enabled) {
         if (arrow_up_enabled) {
             arrow_up_enabled = false;
-            button_pgup.set_text("       ");
+            button_pgup.set_text("      ");
         }
     }
 };
@@ -126,12 +126,12 @@ void BtnGridView::set_arrow_down_enabled(bool enabled) {
     if (enabled) {
         if (!arrow_down_enabled) {
             arrow_down_enabled = true;
-            button_pgdown.set_text("PAGE DOWN");
+            button_pgdown.set_text("< PREV");
         }
     } else if (!enabled) {
         if (arrow_down_enabled) {
             arrow_down_enabled = false;
-            button_pgdown.set_text("         ");
+            button_pgdown.set_text("      ");
         }
     }
 };
@@ -228,6 +228,10 @@ NewButton* BtnGridView::item_view(size_t index) const {
 
 void BtnGridView::show_arrows_enabled(bool enabled) {
     show_arrows = enabled;
+    if (!enabled) {
+        remove_child(&button_pgup);
+        remove_child(&button_pgdown);
+    }
 }
 
 bool BtnGridView::set_highlighted(int32_t new_value) {


### PR DESCRIPTION
That PR is killing the main menu touch navigation button glitch

It's also using the labels mentioned by @eried in the previous PR (https://github.com/portapack-mayhem/mayhem-firmware/pull/2458)

Preview:
![image](https://github.com/user-attachments/assets/52841103-d884-4ecd-b483-d3cb1e83154c)


