### PR TITLE
Fix encoder setting p.mem issue

### DIFF
--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -23,7 +23,6 @@
 #include "ui_flash_utility.hpp"
 #include "portapack_shared_memory.hpp"
 #include "file_path.hpp"
-#include "usb_serial_asyncmsg.hpp"
 
 namespace ui {
 
@@ -82,10 +81,6 @@ FlashUtilityView::FlashUtilityView(NavigationView& nav)
                   &menu_view});
 
     menu_view.set_parent_rect({0, 3 * 8, 240, 33 * 8});
-
-    portapack::async_tx_enabled = true;
-    uint32_t a = sizeof(bool);
-    UsbSerialAsyncmsg::asyncmsg(a);
 
     ensure_directory(apps_dir);
     ensure_directory(firmware_dir);

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -23,6 +23,7 @@
 #include "ui_flash_utility.hpp"
 #include "portapack_shared_memory.hpp"
 #include "file_path.hpp"
+#include "usb_serial_asyncmsg.hpp"
 
 namespace ui {
 
@@ -81,6 +82,10 @@ FlashUtilityView::FlashUtilityView(NavigationView& nav)
                   &menu_view});
 
     menu_view.set_parent_rect({0, 3 * 8, 240, 33 * 8});
+
+    portapack::async_tx_enabled = true;
+    uint32_t a = sizeof(bool);
+    UsbSerialAsyncmsg::asyncmsg(a);
 
     ensure_directory(apps_dir);
     ensure_directory(firmware_dir);

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -615,8 +615,8 @@ class SetEncoderDialView : public View {
     OptionsField field_encoder_dial_direction{
         {18 * 8, 14 * 16},
         7,
-        {{"NORMAL", encoder_dial_direction::DIAL_DIRECTION_NORMAL},
-         {"REVERSE", encoder_dial_direction::DIAL_DIRECTION_REVERSE}}};
+        {{"NORMAL", false},
+         {"REVERSE", true}}};
 
     Button button_dial_sensitivity_plus{
         {20 * 8, 2 * 16, 16, 16},

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -67,8 +67,8 @@ int_fast8_t Encoder::update(const uint_fast8_t phase_bits) {
         if ((sensitivity_map[portapack::persistent_memory::encoder_dial_sensitivity()] & (1 << state)) == 0)
             return 0;
 
-        // true: normal, false: reverse
-        if (!portapack::persistent_memory::encoder_dial_direction())
+        // false: normal, true: reverse
+        if (portapack::persistent_memory::encoder_dial_direction())
             direction = -direction;
 
         return direction;

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -212,7 +212,7 @@ struct data_t {
     bool updown_frequency_rx_correction;
     bool updown_frequency_tx_correction;
     bool lcd_inverted_mode : 1;
-    bool encoder_dial_direction : 1;  // true = normal, false = reverse
+    bool encoder_dial_direction : 1;  // false = normal, true = reverse
     bool UNUSED_6 : 1;
     bool UNUSED_7 : 1;
 
@@ -417,8 +417,8 @@ void defaults() {
     set_config_splash(true);
     set_config_disable_external_tcxo(false);
     set_encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL);
-    set_encoder_dial_direction(true);
-    set_config_speaker_disable(true);  // Disable AK4951 speaker by default (in case of OpenSourceSDRLab H2)
+    set_encoder_dial_direction(false);  // false = normal, true = reverse
+    set_config_speaker_disable(true);   // Disable AK4951 speaker by default (in case of OpenSourceSDRLab H2)
     set_menu_color(Color::grey());
     set_ui_hide_numeric_battery(true);  // hide the numeric battery by default - no space to display it
 
@@ -1254,7 +1254,7 @@ bool debug_dump() {
     pmem_dump_file.write_line("frequency_tx_correction: " + to_string_dec_uint(data->frequency_tx_correction));
     pmem_dump_file.write_line("encoder_dial_sensitivity: " + to_string_dec_uint(data->encoder_dial_sensitivity));
     pmem_dump_file.write_line("encoder_rate_multiplier: " + to_string_dec_uint(data->encoder_rate_multiplier));
-    pmem_dump_file.write_line("encoder_dial_direction: " + to_string_dec_uint(data->encoder_dial_direction));
+    pmem_dump_file.write_line("encoder_dial_direction: " + to_string_dec_uint(data->encoder_dial_direction));  // 0 = normal, 1 = reverse
     pmem_dump_file.write_line("headphone_volume_cb: " + to_string_dec_int(data->headphone_volume_cb));
     pmem_dump_file.write_line("config_mode_storage: 0x" + to_string_hex(data->config_mode_storage, 8));
     pmem_dump_file.write_line("dst_config: 0x" + to_string_hex((uint32_t)data->dst_config.v, 8));

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -120,11 +120,6 @@ enum encoder_dial_sensitivity {
     NUM_DIAL_SENSITIVITY
 };
 
-enum encoder_dial_direction {
-    DIAL_DIRECTION_NORMAL = true,
-    DIAL_DIRECTION_REVERSE = false,
-};
-
 typedef union {
     uint32_t v;
     struct {


### PR DESCRIPTION
- Previously I misunderstood how p.mem works and it seems the default should be false.
- removed useless enum and use bool, and use comment everywhere to indicate, because with enum there would be too many useless implicit cast and misleading people (I guess).