### PR TITLE
APRS: add frequency settings for Brazil

### DIFF
--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -99,15 +99,21 @@ APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
             field_frequency.set_value(aprs_rx_freq);
         } else if (i == 1) {  // NA - North America - is also the default
             field_frequency.set_value(144390000);
-        } else if (i == 2) {  // EUR
-            field_frequency.set_value(144800000);
-        } else if (i == 3) {  // AUS
-            field_frequency.set_value(145175000);
-        } else if (i == 4) {  // NZ
+        } else if (i == 2) {  // NZ
             field_frequency.set_value(144575000);
-        } else if (i == 5) {  // BR
+        } else if (i == 3) {  // JAP
+            field_frequency.set_value(144640000);
+        } else if (i == 4) {  // PHI
+            field_frequency.set_value(144740000);
+        } else if (i == 5) {  // EUR
+            field_frequency.set_value(144800000);
+        } else if (i == 6) {  // THA
+            field_frequency.set_value(144900000);
+        } else if (i == 7) {  // AUS
+            field_frequency.set_value(145175000);
+        } else if (i == 8) {  // BR
             field_frequency.set_value(145570000);
-        } else if (i == 6) {  // ISS
+        } else if (i == 9) {  // ISS
             field_frequency.set_value(145825000);
         }
         options_region_id = i;

--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -105,7 +105,9 @@ APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
             field_frequency.set_value(145175000);
         } else if (i == 4) {  // NZ
             field_frequency.set_value(144575000);
-        } else if (i == 5) {  // ISS
+        } else if (i == 5) {  // BR
+            field_frequency.set_value(145570000);
+        } else if (i == 6) {  // ISS
             field_frequency.set_value(145825000);
         }
         options_region_id = i;

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -227,11 +227,14 @@ class APRSRxView : public View {
         3,
         {{"MAN", 0},
          {"NA ", 1},
-         {"EUR", 2},
-         {"AUS", 3},
-         {"NZ ", 4},
-         {"BR ", 5},
-         {"ISS", 6}}};
+         {"NZ ", 2},
+         {"JAP", 3},
+         {"PHI", 4},
+         {"EUR", 5},
+         {"THA", 6},
+         {"AUS", 7},
+         {"BR ", 8},
+         {"ISS", 9}}};
 
     FrequencyField field_frequency{
         {3 * 8, 0 * 16}};

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -230,7 +230,8 @@ class APRSRxView : public View {
          {"EUR", 2},
          {"AUS", 3},
          {"NZ ", 4},
-         {"ISS", 5}}};
+         {"BR ", 5},
+         {"ISS", 6}}};
 
     FrequencyField field_frequency{
         {3 * 8, 0 * 16}};


### PR DESCRIPTION
Include a new entry named 'BR' that tunes to 145.570 MHz.