### PR TITLE
ff.c : fix fallthrough warning

### DIFF
--- a/firmware/chibios-portapack/ext/fatfs/src/ff.c
+++ b/firmware/chibios-portapack/ext/fatfs/src/ff.c
@@ -1060,6 +1060,7 @@ DWORD get_fat (	/* 0xFFFFFFFF:Disk error, 1:Internal error, 2..0x7FFFFFFF:Cluste
 				}
 			}
 			/* go to default */
+            __attribute__ ((fallthrough));
 #endif
 		default:
 			val = 1;	/* Internal error */


### PR DESCRIPTION
That PR fix the following warning introduced when enabling EXFAT :

portapack-mayhem/firmware/chibios-portapack/ext/fatfs/src/ff.c: In function 'get_fat':
portapack-mayhem/firmware/chibios-portapack/ext/fatfs/src/ff.c:1038:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
 1038 |    if (obj->objsize) {
      |       ^
portapack-mayhem/firmware/chibios-portapack/ext/fatfs/src/ff.c:1064:3: note: here
 1064 |   default:
      |   ^~~~~~~
