### PR TITLE
Fix cmake_minimum_required to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0005 NEW)
 
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/firmware/toolchain-arm-cortex-m.cmake)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -18,7 +18,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(firmware)
 

--- a/firmware/standalone/CMakeLists.txt
+++ b/firmware/standalone/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(standalone_apps)
 


### PR DESCRIPTION
In order to be aligned with all our other CMakeLists.txt I fixed cmake_minimum_required to 3.16.
It's killing the following warning when calling cmake:
```
  CMake Deprecation Warning at firmware/standalone/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```
Note: all our other CMakeLists are using cmake_minimum_required to 3.16.