### PR TITLE
Moved games to new game menu

### DIFF
--- a/firmware/application/apps/ui_external_module_view.cpp
+++ b/firmware/application/apps/ui_external_module_view.cpp
@@ -101,7 +101,7 @@ void ExternalModuleView::on_tick_second() {
             case app_location_t::HOME:
                 btnText += " (Home)";
                 break;
-            case app_location_t::GAMES:  
+            case app_location_t::GAMES:
                 btnText += " (Games)";
                 break;
         }

--- a/firmware/application/apps/ui_external_module_view.cpp
+++ b/firmware/application/apps/ui_external_module_view.cpp
@@ -101,6 +101,9 @@ void ExternalModuleView::on_tick_second() {
             case app_location_t::HOME:
                 btnText += " (Home)";
                 break;
+            case app_location_t::GAMES:  
+                btnText += " (Games)";
+                break;
         }
 
         switch (i) {
@@ -122,4 +125,5 @@ void ExternalModuleView::on_tick_second() {
         }
     }
 }
+
 }  // namespace ui

--- a/firmware/application/bitmap.hpp
+++ b/firmware/application/bitmap.hpp
@@ -141,8 +141,8 @@ static constexpr uint8_t bitmap_icon_games_data[] = {
 };
 static constexpr Bitmap bitmap_icon_games{
     {16, 16},
-    bitmap_icon_games_data};    
-    
+    bitmap_icon_games_data};
+
 static constexpr uint8_t bitmap_stripes_data[] = {
     0xFF,
     0x03,

--- a/firmware/application/bitmap.hpp
+++ b/firmware/application/bitmap.hpp
@@ -105,6 +105,44 @@ static constexpr Bitmap bitmap_icon_utilities{
     {16, 16},
     bitmap_icon_utilities_data};
 
+static constexpr uint8_t bitmap_icon_games_data[] = {
+    0x0C,
+    0x0C,
+    0x0C,
+    0x0C,
+    0x3F,
+    0x3C,
+    0xFF,
+    0x7E,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xCC,
+    0xCC,
+    0xCC,
+    0xCC,
+    0xFF,
+    0xFF,
+    0xE7,
+    0x73,
+    0xE7,
+    0x73,
+    0x33,
+    0x33,
+    0x03,
+    0x30,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+};
+static constexpr Bitmap bitmap_icon_games{
+    {16, 16},
+    bitmap_icon_games_data};    
+    
 static constexpr uint8_t bitmap_stripes_data[] = {
     0xFF,
     0x03,

--- a/firmware/application/external/breakout/main.cpp
+++ b/firmware/application/external/breakout/main.cpp
@@ -61,7 +61,7 @@ __attribute__((section(".external_app.app_breakout.application_information"), us
         0x80,
     },
     /*.icon_color = */ ui::Color::green().v,
-    /*.menu_location = */ app_location_t::UTILITIES,
+    /*.menu_location = */ app_location_t::GAMES,
     /*.desired_menu_position = */ -1,
 
     /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},

--- a/firmware/application/external/tetris/main.cpp
+++ b/firmware/application/external/tetris/main.cpp
@@ -74,7 +74,7 @@ __attribute__((section(".external_app.app_tetris.application_information"), used
         0xF1,
     },
     /*.icon_color = */ ui::Color::orange().v,
-    /*.menu_location = */ app_location_t::UTILITIES,
+    /*.menu_location = */ app_location_t::GAMES,
     /*.desired_menu_position = */ -1,
 
     /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -126,6 +126,7 @@ const NavigationView::AppList NavigationView::appList = {
     {"microphone", "Microphone", HOME, Color::green(), &bitmap_icon_microphone, new ViewFactory<MicTXView>()},
     {"lookingglass", "Looking Glass", HOME, Color::green(), &bitmap_icon_looking, new ViewFactory<GlassView>()},
     {nullptr, "Utilities", HOME, Color::cyan(), &bitmap_icon_utilities, new ViewFactory<UtilitiesMenuView>()},
+    {nullptr, "Games", HOME, Color::purple(), &bitmap_icon_games, new ViewFactory<GamesMenuView>()},
     {nullptr, "Settings", HOME, Color::cyan(), &bitmap_icon_setup, new ViewFactory<SettingsMenuView>()},
     {nullptr, "Debug", HOME, Color::light_grey(), &bitmap_icon_debug, new ViewFactory<DebugMenuView>()},
     /* RX ********************************************************************/
@@ -866,6 +867,22 @@ void UtilitiesMenuView::on_populate() {
     }
     add_apps(nav_, *this, UTILITIES);
     add_external_items(nav_, app_location_t::UTILITIES, *this, return_icon ? 1 : 0);
+}
+
+/* GamesMenuView ********************************************************/
+
+GamesMenuView::GamesMenuView(NavigationView& nav)
+    : nav_(nav) {
+    set_max_rows(2);
+}
+
+void GamesMenuView::on_populate() {
+    bool return_icon = pmem::show_gui_return_icon();
+    if (return_icon) {
+        add_item({"..", Theme::getInstance()->fg_light->foreground, &bitmap_icon_previous, [this]() { nav_.pop(); }});
+    }
+    add_apps(nav_, *this, GAMES);
+    add_external_items(nav_, app_location_t::GAMES, *this, return_icon ? 1 : 0);
 }
 
 /* SystemMenuView ********************************************************/

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -390,14 +390,14 @@ class UtilitiesMenuView : public BtnGridView {
 };
 
 class GamesMenuView : public BtnGridView {
-    public:
-     GamesMenuView(NavigationView& nav);
-     std::string title() const override { return "Games"; };
- 
-    private:
-     NavigationView& nav_;
-     void on_populate() override;
- };
+   public:
+    GamesMenuView(NavigationView& nav);
+    std::string title() const override { return "Games"; };
+
+   private:
+    NavigationView& nav_;
+    void on_populate() override;
+};
 
 class SystemMenuView : public BtnGridView {
    public:

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -389,6 +389,16 @@ class UtilitiesMenuView : public BtnGridView {
     void on_populate() override;
 };
 
+class GamesMenuView : public BtnGridView {
+    public:
+     GamesMenuView(NavigationView& nav);
+     std::string title() const override { return "Games"; };
+ 
+    private:
+     NavigationView& nav_;
+     void on_populate() override;
+ };
+
 class SystemMenuView : public BtnGridView {
    public:
     SystemMenuView(NavigationView& nav);

--- a/firmware/common/standalone_app.hpp
+++ b/firmware/common/standalone_app.hpp
@@ -72,7 +72,8 @@ enum app_location_t : uint32_t {
     TX,
     DEBUG,
     HOME,
-    SETTINGS
+    SETTINGS,
+    GAMES
 };
 
 struct standalone_application_information_t {

--- a/firmware/standalone/pacman/main.cpp
+++ b/firmware/standalone/pacman/main.cpp
@@ -65,7 +65,7 @@ __attribute__((section(".standalone_application_information"), used)) standalone
         0x00,
     },
     /*.icon_color = 16 bit: 5R 6G 5B*/ 0x0000FFE0,
-    /*.menu_location = */ app_location_t::UTILITIES,
+    /*.menu_location = */ app_location_t::GAMES,
 
     /*.initialize_app = */ initialize,
     /*.on_event = */ on_event,


### PR DESCRIPTION
There's enough games to have a menu now and I plan to make more. Having them in "Utilities" made no sense.
Created the game menu and bitmap and integrated external and standalone apps.
Updated all games to change location to GAMES.