### PR TITLE
rename rand pwd app

### DIFF
--- a/firmware/application/external/random_password/main.cpp
+++ b/firmware/application/external/random_password/main.cpp
@@ -38,7 +38,7 @@ __attribute__((section(".external_app.app_random_password.application_informatio
     /*.header_version = */ CURRENT_HEADER_VERSION,
     /*.app_version = */ VERSION_MD5,
 
-    /*.app_name = */ "Random passwd",
+    /*.app_name = */ "Rand Pwd",
     /*.bitmap_data = */ {
         0xC0,
         0x03,


### PR DESCRIPTION
Sorry that I forgot this when I move the app.
Thanks for @NotherNgineer to pointing this out.
ref. https://github.com/portapack-mayhem/mayhem-firmware/pull/2540#issuecomment-2708467628