### PR TITLE
OokBrute app opt

### DIFF
--- a/firmware/application/external/ookbrute/ui_ookbrute.cpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 HTotoo
+ * copyleft Whiterose of the Dark Army
  *
  * This file is part of PortaPack.
  *
@@ -25,6 +26,7 @@
 #include "baseband_api.hpp"
 #include "string_format.hpp"
 #include "portapack_persistent_memory.hpp"
+#include "ui_textentry.hpp"
 
 using namespace portapack;
 using namespace ui;
@@ -39,6 +41,9 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
     : nav_{nav} {
     add_children({
         &button_startstop,
+        &button_input_stop_position,
+        &button_input_start_position,
+        &labels,
         &field_frequency,
         &tx_view,
         &options_atkmode,
@@ -65,6 +70,40 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
     };
     field_stop.on_change = [this](int32_t) {
         validate_start_stop();
+    };
+    button_input_start_position.on_select = [this](Button&) {
+        stop();  // prevent mess count var up
+
+        text_input_buffer = to_string_dec_uint(field_start.value());
+        if (text_input_buffer == "0") {
+            text_input_buffer = "";
+        }
+
+        text_prompt(
+            nav_,
+            text_input_buffer,
+            8,  // currently longest is princeton
+            [this](std::string& buffer) {
+                field_start.set_value(atoi(buffer.c_str()));
+                validate_start_stop();
+            });
+    };
+    button_input_stop_position.on_select = [this](Button&) {
+        stop();  // prevent mess count var up
+
+        text_input_buffer = to_string_dec_uint(field_stop.value());
+        if (text_input_buffer == "0") {
+            text_input_buffer = "";
+        }
+
+        text_prompt(
+            nav_,
+            text_input_buffer,
+            8,  // currently longest is princeton
+            [this](std::string& buffer) {
+                field_stop.set_value(atoi(buffer.c_str()));
+                validate_start_stop();
+            });
     };
     update_start_stop(0);
 }

--- a/firmware/application/external/ookbrute/ui_ookbrute.hpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.hpp
@@ -55,7 +55,7 @@ class OOKBruteView : public View {
 
     Labels labels{
         {{0 * 8, 2 * 16}, "Start Position:", Theme::getInstance()->fg_light->foreground},
-        {{11 * 8, 7 * 16}, "Stop Position:", Theme::getInstance()->fg_light->foreground},
+        {{0 * 8, 7 * 16}, "Stop Position:", Theme::getInstance()->fg_light->foreground},
         {{0 * 8, 13 * 16}, "Encoder Type:", Theme::getInstance()->fg_light->foreground}};
 
     Button button_startstop{

--- a/firmware/application/external/ookbrute/ui_ookbrute.hpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 HTotoo
+ * copyleft Whiterose of the Dark Army
  *
  * This file is part of PortaPack.
  *
@@ -52,12 +53,25 @@ class OOKBruteView : public View {
     app_settings::SettingsManager settings_{
         "tx_ookbrute", app_settings::Mode::TX};
 
+    Labels labels{
+        {{0 * 8, 2 * 16}, "Start Position:", Theme::getInstance()->fg_light->foreground},
+        {{11 * 8, 7 * 16}, "Stop Position:", Theme::getInstance()->fg_light->foreground},
+        {{0 * 8, 13 * 16}, "Encoder Type:", Theme::getInstance()->fg_light->foreground}};
+
     Button button_startstop{
-        {0, 3 * 16, 96, 24},
+        {8, screen_height - 48 - 16, screen_width - 2 * 8, 48},
         LanguageHelper::currentMessages[LANG_START]};
 
+    Button button_input_start_position{
+        {8, 4 * 16, screen_width - 2 * 8, 24},
+        "Input Start Pos"};
+
+    Button button_input_stop_position{
+        {8, 9 * 16, screen_width - 2 * 8, 24},
+        "Input Stop Pos"};
+
     NumberField field_start{
-        {0 * 8, 1 * 16},
+        {0 * 8, 3 * 16},
         8,
         {0, 2500},
         1,
@@ -65,15 +79,16 @@ class OOKBruteView : public View {
         true};
 
     NumberField field_stop{
-        {11 * 8, 1 * 16},
+        {0, 8 * 16},
         9,
         {0, 2500},
         1,
         ' ',
         true};
 
+    // NB: when add new encoder here you should also change the char count limit for input range buttons by it's digits in DEC
     OptionsField options_atkmode{
-        {0 * 8, 2 * 16},
+        {0, 14 * 16},
         12,
         {{"Came12", 0},
          {"Came24", 1},
@@ -85,6 +100,8 @@ class OOKBruteView : public View {
     bool is_running{false};
 
     uint32_t counter = 0;  // for packet change
+
+    std::string text_input_buffer{};  // this is needed by the text_prompt func
 
     void start();
     void stop();


### PR DESCRIPTION
Basically UI tune and also user request here: https://github.com/portapack-mayhem/mayhem-firmware/issues/2560

Q: 
Why not make NumberField can response input ev?

A:
I'm thinking of this too.
It's easy to have this single app to have input support, but I'm thinking that make the NumberField widget has input support, which is tricky, because current text_prompt (or similar name I forgot) need you to have a living var at the full lifetime that enter until exit the input scene.
So it's needed to re-design that function, which is hard, because it's not copying is the reason that notepad can handle big files in this device.

Q: Why not use helper / lambda to reduce repeating code

A: They are slightly difference, and it's not worth to have much param just to make them into helper/lambda, t made code hard to read.