### PR TITLE
zooming_spectrum_AMFM_mode

### DIFF
--- a/firmware/baseband/proc_am_audio.cpp
+++ b/firmware/baseband/proc_am_audio.cpp
@@ -112,9 +112,14 @@ void NarrowbandAMAudio::configure(const AMConfigureMessage& message) {
     channel_filter_low_f = message.channel_filter.low_frequency_normalized * channel_filter_input_fs;
     channel_filter_high_f = message.channel_filter.high_frequency_normalized * channel_filter_input_fs;
     channel_filter_transition = message.channel_filter.transition_normalized * channel_filter_input_fs;
-    channel_spectrum.set_decimation_factor(1.0f);
+
     // modulation_ssb = (message.modulation == AMConfigureMessage::Modulation::SSB);  // originally we had just 2 AM types of demod. (DSB , SSB)
-    modulation_ssb = (int)message.modulation;              // now sending by message , 3 types of AM demod :   enum class Modulation : int32_t {DSB = 0, SSB = 1, SSB_FM = 2}
+    modulation_ssb = (int)message.modulation;  // now sending by message , 3 types of AM demod :   enum class Modulation : int32_t {DSB = 0, SSB = 1, SSB_FM = 2}
+    if (modulation_ssb == (int)(AMConfigureMessage::Modulation::SSB_FM)) {
+        channel_spectrum.set_decimation_factor(6.0f);  // zooming for better tuning {SSB_FM = 2}
+    } else {
+        channel_spectrum.set_decimation_factor(1.0f);  // no zooming .{DSB = 0, SSB = 1,}
+    }
     audio_output.configure(message.audio_hpf_lpf_config);  // hpf in all AM demod modes (AM-6K/9K, USB/LSB,DSB), except Wefax (lpf there).
 
     configured = true;


### PR DESCRIPTION
(MINOR issue )
Simple PR , just to make zooming to the waterfall spectrum in AMFM mode , (inside Audio App)
then it is more easy to follow correct tuning, and identify better a correct Wefax Station, (signal level, saturation , interferences ,.. (I used that zooming to identify better the optimum -freq_offset) . 

Original 
![image](https://github.com/user-attachments/assets/1eba96f0-c530-405e-9ee2-67f3bf109cba)

Zoomed AMFM mode 
![image](https://github.com/user-attachments/assets/84b10bcd-8f08-4f1c-b117-e54b41645a62)


-----------------------------
In our current demodulating AMFM filters, the best optimum Wefax reception is done applying freq = (Published_Wefax_Freq -2.200 Hz offset )  (other public SDR programs like Fldigi, MultiPSK,...  , usually need -1.900 Hz  offset) . 

Then currently in that Audio App , AMFM mode , we need to apply manual freq tuning = (Published Wefax Station  -2.2Khz)  to record correct APT signal files .
 In next PR , to make more user friendly  Wefax Broadcasting station tuning , I will make  internal offset automatic ,   (-offset frequency) in next PR .   (this will communize the same concept that  @htotoo  is applying in his next Wefax receiver App. that  has internal automatic  hidden   -offset tuning of -2,200Hz ) , and we will avoid confusions between both App's.

Cheers, 



