### PR TITLE
Externalize level

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -293,7 +293,6 @@ set(CPPSRC
 	apps/ui_flash_utility.cpp
 	apps/ui_freqman.cpp
 	apps/ui_iq_trim.cpp
-	apps/ui_level.cpp
 	apps/ui_looking_glass_app.cpp
 	apps/ui_mictx.cpp
 	apps/ui_modemsetup.cpp
@@ -302,7 +301,6 @@ set(CPPSRC
 	apps/ui_rds.cpp
 	apps/ui_recon_settings.cpp
 	apps/ui_recon.cpp
-#	apps/ui_scanner.cpp
 	apps/ui_sd_over_usb.cpp
 	apps/ui_search.cpp
 	apps/ui_settings.cpp

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -517,11 +517,7 @@ ReconView::ReconView(NavigationView& nav)
     };
     set_loop_config(continuous);
 
-    rssi.set_focusable(true);
     rssi.set_peak(true, 500);
-    rssi.on_select = [this](RSSI&) {
-        nav_.replace<LevelView>();
-    };
 
     // TODO: *BUG* Both transmitter_model and receiver_model share the same pmem setting for target_frequency.
     button_mic_app.on_select = [this](Button&) {

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -31,7 +31,6 @@
 #include "analog_audio_app.hpp"
 #include "audio.hpp"
 #include "ui_mictx.hpp"
-#include "ui_level.hpp"
 #include "ui_looking_glass_app.hpp"
 #include "portapack_persistent_memory.hpp"
 #include "baseband_api.hpp"

--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -192,15 +192,15 @@ set(EXTCPPSRC
 	external/doom/main.cpp
 	external/doom/ui_doom.cpp
 
-    #debug_pmem
+	#debug_pmem
 	external/debug_pmem/main.cpp
 	external/debug_pmem/ui_debug_pmem.cpp
 
-    #scanner 
+	#scanner
 	external/scanner/main.cpp
 	external/scanner/ui_scanner.cpp
 
-    #level 
+	#level
 	external/level/main.cpp
 	external/level/ui_level.cpp
 )
@@ -252,7 +252,7 @@ set(EXTAPPLIST
 	stopwatch
 	breakout
 	doom
-    debug_pmem
+	debug_pmem
 	scanner
 	level
 )

--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -192,14 +192,17 @@ set(EXTCPPSRC
 	external/doom/main.cpp
 	external/doom/ui_doom.cpp
 
+    #debug_pmem
+	external/debug_pmem/main.cpp
+	external/debug_pmem/ui_debug_pmem.cpp
+
     #scanner 
 	external/scanner/main.cpp
 	external/scanner/ui_scanner.cpp
 
-	#debug_pmem
-	external/debug_pmem/main.cpp
-	external/debug_pmem/ui_debug_pmem.cpp
-
+    #level 
+	external/level/main.cpp
+	external/level/ui_level.cpp
 )
 
 set(EXTAPPLIST
@@ -251,4 +254,5 @@ set(EXTAPPLIST
 	doom
     debug_pmem
 	scanner
+	level
 )

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -71,6 +71,7 @@ MEMORY
     ram_external_app_doom       (rwx) : org = 0xADDE0000, len = 32k
     ram_external_app_debug_pmem (rwx) : org = 0xADDF0000, len = 32k
     ram_external_app_scanner    (rwx) : org = 0xADE00000, len = 32k
+    ram_external_app_level      (rwx) : org = 0xADE10000, len = 32k
 }
 
 SECTIONS
@@ -362,4 +363,9 @@ SECTIONS
         *(*ui*external_app*scanner*);
     } > ram_external_app_scanner    
 
+    .external_app_level : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_level.application_information));
+        *(*ui*external_app*level*);
+    } > ram_external_app_level
 }

--- a/firmware/application/external/level/main.cpp
+++ b/firmware/application/external/level/main.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui.hpp"
+#include "ui_level.hpp"
+#include "ui_navigation.hpp"
+#include "external_app.hpp"
+
+namespace ui::external_app::level {
+void initialize_app(ui::NavigationView& nav) {
+    nav.push<LevelView>();
+}
+}  // namespace ui::external_app::level
+
+extern "C" {
+
+__attribute__((section(".external_app.app_level.application_information"), used)) application_information_t _application_information_level = {
+    /*.memory_location = */ (uint8_t*)0x00000000,
+    /*.externalAppEntry = */ ui::external_app::level::initialize_app,
+    /*.header_version = */ CURRENT_HEADER_VERSION,
+    /*.app_version = */ VERSION_MD5,
+
+    /*.app_name = */ "Level",
+    /*.bitmap_data = */
+    {
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x04,
+        0x20,
+        0x12,
+        0x48,
+        0x8A,
+        0x51,
+        0xCA,
+        0x53,
+        0xCA,
+        0x53,
+        0x8A,
+        0x51,
+        0x12,
+        0x48,
+        0x84,
+        0x21,
+        0xC0,
+        0x03,
+        0x40,
+        0x02,
+        0x60,
+        0x06,
+        0x20,
+        0x04,
+        0x30,
+        0x0C,
+        0xF0,
+        0x0F},
+    /*.icon_color = */ ui::Color::green().v,
+    /*.menu_location = */ app_location_t::RX,
+    /*.desired_menu_position = */ -1,
+
+    // this has to be the biggest baseband used by the app. Level is using AM,WFM,NFM,AMFM,SPEC and NFM is the biggest
+    /*.m4_app_tag = portapack::spi_flash::image_tag_nfm */ {'P', 'N', 'F', 'M'},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
+};
+}

--- a/firmware/application/external/level/ui_level.cpp
+++ b/firmware/application/external/level/ui_level.cpp
@@ -33,7 +33,7 @@ using namespace portapack;
 using namespace tonekey;
 using portapack::memory::map::backup_ram;
 
-namespace ui {
+namespace ui::external_app::level {
 
 // Function to map the value from one range to another
 int32_t LevelView::map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
@@ -338,4 +338,4 @@ void LevelView::on_freqchg(int64_t freq) {
     button_frequency.set_text("<" + to_string_short_freq(freq) + " MHz>");
 }
 
-} /* namespace ui */
+}  // namespace ui::external_app::level

--- a/firmware/application/external/level/ui_level.hpp
+++ b/firmware/application/external/level/ui_level.hpp
@@ -39,7 +39,7 @@
 #include "ui_receiver.hpp"
 #include "ui_spectrum.hpp"
 
-namespace ui {
+namespace ui::external_app::level {
 
 class LevelView : public View {
    public:
@@ -211,6 +211,6 @@ class LevelView : public View {
         }};
 };
 
-} /* namespace ui */
+}  // namespace ui::external_app::level
 
 #endif

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -42,7 +42,6 @@
 #include "ui_font_fixed_8x16.hpp"
 #include "ui_freqman.hpp"
 #include "ui_iq_trim.hpp"
-#include "ui_level.hpp"
 #include "ui_looking_glass_app.hpp"
 #include "ui_mictx.hpp"
 
@@ -131,22 +130,13 @@ const NavigationView::AppList NavigationView::appList = {
     {"ais", "AIS Boats", RX, Color::green(), &bitmap_icon_ais, new ViewFactory<AISAppView>()},
     {"aprsrx", "APRS", RX, Color::green(), &bitmap_icon_aprs, new ViewFactory<APRSRXView>()},
     {"audio", "Audio", RX, Color::green(), &bitmap_icon_speaker, new ViewFactory<AnalogAudioView>()},
-    //{"blecomm", "BLE Comm", RX, ui::Color::orange(), &bitmap_icon_btle, new ViewFactory<BLECommView>()},
     {"blerx", "BLE Rx", RX, Color::green(), &bitmap_icon_btle, new ViewFactory<BLERxView>()},
     {"ert", "ERT Meter", RX, Color::green(), &bitmap_icon_ert, new ViewFactory<ERTAppView>()},
-    {"level", "Level", RX, Color::green(), &bitmap_icon_options_radio, new ViewFactory<LevelView>()},
     {"pocsag", "POCSAG", RX, Color::green(), &bitmap_icon_pocsag, new ViewFactory<POCSAGAppView>()},
     {"radiosonde", "Radiosnde", RX, Color::green(), &bitmap_icon_sonde, new ViewFactory<SondeView>()},
-    // {"scanner", "Scanner", RX, Color::green(), &bitmap_icon_scanner, new ViewFactory<ScannerView>()},
     {"search", "Search", RX, Color::yellow(), &bitmap_icon_search, new ViewFactory<SearchView>()},
     {"subghzd", "SubGhzD", RX, Color::yellow(), &bitmap_icon_remote, new ViewFactory<SubGhzDView>()},
     {"weather", "Weather", RX, Color::green(), &bitmap_icon_thermometer, new ViewFactory<WeatherView>()},
-    //{"fskrx", "FSK RX", RX, Color::yellow(), &bitmap_icon_remote, new ViewFactory<FskxRxMainView>()}, //for JT
-    //{"dmr", "DMR", RX, Color::dark_grey(), &bitmap_icon_dmr, new ViewFactory<NotImplementedView>()},
-    //{"sigfox", "SIGFOX", RX, Color::dark_grey(), &bitmap_icon_fox, new ViewFactory<NotImplementedView>()},
-    //{"lora", "LoRa", RX, Color::dark_grey(), &bitmap_icon_lora, new ViewFactory<NotImplementedView>()},
-    //{"sstv", "SSTV", RX, Color::dark_grey(), &bitmap_icon_sstv, new ViewFactory<NotImplementedView>()},
-    //{"tetra", "TETRA", RX, Color::dark_grey(), &bitmap_icon_tetra, new ViewFactory<NotImplementedView>()},
     /* TX ********************************************************************/
     {"aprstx", "APRS TX", TX, ui::Color::green(), &bitmap_icon_aprs, new ViewFactory<APRSTXView>()},
     {"bht", "BHT Xy/EP", TX, ui::Color::green(), &bitmap_icon_bht, new ViewFactory<BHTView>()},


### PR DESCRIPTION
That PR is externalizing the Level app.

It's also disabling the possibility to focus on the RSSI bars in Recon and launch Level when clicking on it, until one is giving a way to launch external apps from internal ones.