### PR TITLE
solving_Audio_App_AM_GUI_Problem_issue_2604

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -40,7 +40,6 @@ class AnalogAudioView;
 class AMOptionsView : public View {
    public:
     AMOptionsView(AnalogAudioView* view, Rect parent_rect, const Style* style);
-    int16_t previous_filter_array_index = 0;
 
    private:
     Text label_config{
@@ -59,7 +58,7 @@ class AMOptionsView : public View {
         {23 * 8, 0 * 16},
         7,
         {{"ZOOM x1", 0},
-         {"ZOOM x2", 6}}  // offset index array filters.
+         {"ZOOM x2", 6}}  // offset index AM modes array FIR filters.
     };
 };
 


### PR DESCRIPTION
Hi, 
From the ZOOM +1 / ZOOM+2  introduction in the Audio App ,   AM modes ,  sometimes we found an incorrect 
GUI matching with the real AM mode . 
This bug was pointed in the issue #2604 

That PR ,  solves that problem .   It was two hidden bugs there . I added several comments on it.

@gullradriel ,  
I externalize two public vars (previous_AM_mode_option, previous_zoom , both init = 0.
Feel free to tidy up ,  the code it is not well applied.  But now it works well  !

