### PR TITLE
prevent long life var for audio app - AM

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -37,8 +37,8 @@ using namespace tonekey;
 
 namespace ui {
 
-int16_t previous_AM_mode_option = 0;  // GUI 5 AM modes :  (0..4 ) (DSB9K, DSB6K, USB,LSB, CW). Used to select proper FIR filter (0..11) AM mode  + offset 0 (zoom+1) or +6 (if zoom+2)
-int16_t previous_zoom = 0;            // GUI ZOOM+1, ZOOM+2 , equivalent to two values offset 0 (zoom+1) or +6 (if zoom+2)
+static int16_t previous_AM_mode_option = 0;  // GUI 5 AM modes :  (0..4 ) (DSB9K, DSB6K, USB,LSB, CW). Used to select proper FIR filter (0..11) AM mode  + offset 0 (zoom+1) or +6 (if zoom+2)
+static int16_t previous_zoom = 0;            // GUI ZOOM+1, ZOOM+2 , equivalent to two values offset 0 (zoom+1) or +6 (if zoom+2)
 
 /* AMOptionsView *********************************************************/
 

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -37,9 +37,6 @@ using namespace tonekey;
 
 namespace ui {
 
-static int16_t previous_AM_mode_option = 0;  // GUI 5 AM modes :  (0..4 ) (DSB9K, DSB6K, USB,LSB, CW). Used to select proper FIR filter (0..11) AM mode  + offset 0 (zoom+1) or +6 (if zoom+2)
-static int16_t previous_zoom = 0;            // GUI ZOOM+1, ZOOM+2 , equivalent to two values offset 0 (zoom+1) or +6 (if zoom+2)
-
 /* AMOptionsView *********************************************************/
 
 AMOptionsView::AMOptionsView(
@@ -55,21 +52,20 @@ AMOptionsView::AMOptionsView(
         &zoom_config,
     });
 
-    zoom_config.on_change = [this, view](size_t, OptionsField::value_t n) {  // n , has two option values. when GUI =zoom+1 => (0), when GUI=zoom+2 (6)
-        receiver_model.set_am_configuration(previous_AM_mode_option + n);    // n (0 or 6)
+    zoom_config.on_change = [this, view](size_t, OptionsField::value_t n) {            // n , has two option values. when GUI =zoom+1 => (0), when GUI=zoom+2 (6)
+        receiver_model.set_am_configuration(view->get_previous_AM_mode_option() + n);  // n (0 or 6)
         view->set_zoom_factor(AM_MODULATION, n);
-        previous_zoom = n;
+        view->set_previous_zoom_option(n);
     };
 
     // restore zoom selection
     zoom_config.set_by_value(view->get_zoom_factor(AM_MODULATION));
-    view->get_zoom_factor(AM_MODULATION);
 
-    freqman_set_bandwidth_option(AM_MODULATION, options_config);                     // freqman.cpp to the options_config, only allowing 5 modes  freqman_bandwidths[AM]  {"DSB 9k", 0},  {"DSB 6k", 1},  {"USB+3k", 2}, {"LSB-3k", 3}, {"CW", 4},
-    options_config.set_by_value(receiver_model.am_configuration() - previous_zoom);  // restore AM GUI option mode ,   AM FIR index filters (0..11) values ,  <baseband::AMConfig, 12> am_configs has 12 fir  index elements.
+    freqman_set_bandwidth_option(AM_MODULATION, options_config);                                        // freqman.cpp to the options_config, only allowing 5 modes  freqman_bandwidths[AM]  {"DSB 9k", 0},  {"DSB 6k", 1},  {"USB+3k", 2}, {"LSB-3k", 3}, {"CW", 4},
+    options_config.set_by_value(receiver_model.am_configuration() - view->get_previous_zoom_option());  // restore AM GUI option mode ,   AM FIR index filters (0..11) values ,  <baseband::AMConfig, 12> am_configs has 12 fir  index elements.
     options_config.on_change = [this, view](size_t, OptionsField::value_t n) {
-        receiver_model.set_am_configuration(n + previous_zoom);  // we select proper FIR AM filter (0..11), = 0..4 GUI AM modes + offset +6 (if zoom+2)
-        previous_AM_mode_option = n;                             // (0..4) allowing 5 AM modes (DSB9K, DSB6K, USB,LSB, CW)
+        receiver_model.set_am_configuration(n + view->get_previous_zoom_option());  // we select proper FIR AM filter (0..11), = 0..4 GUI AM modes + offset +6 (if zoom+2)
+        view->set_previous_AM_mode_option(n);                                       // (0..4) allowing 5 AM modes (DSB9K, DSB6K, USB,LSB, CW)
     };
 }
 
@@ -284,6 +280,22 @@ void AnalogAudioView::set_zoom_factor(uint8_t mode, uint8_t zoom) {  // define a
         zoom_factor_am = zoom;
     else if (mode == AMFM_MODULATION)
         zoom_factor_amfm = zoom;
+}
+
+uint8_t AnalogAudioView::get_previous_AM_mode_option() {
+    return previous_AM_mode_option;
+}
+
+void AnalogAudioView::set_previous_AM_mode_option(uint8_t mode) {
+    previous_AM_mode_option = mode;
+}
+
+uint8_t AnalogAudioView::get_previous_zoom_option() {
+    return previous_zoom;
+}
+
+void AnalogAudioView::set_previous_zoom_option(uint8_t zoom) {
+    previous_zoom = zoom;
 }
 
 uint8_t AnalogAudioView::get_spec_iq_phase_calibration_value() {  // define accessor functions inside AnalogAudioView to read iq_phase_calibration_value

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -199,6 +199,12 @@ class AnalogAudioView : public View {
     uint8_t get_zoom_factor(uint8_t mode);
     void set_zoom_factor(uint8_t mode, uint8_t zoom);
 
+    uint8_t get_previous_AM_mode_option();
+    void set_previous_AM_mode_option(uint8_t mode);
+
+    uint8_t get_previous_zoom_option();
+    void set_previous_zoom_option(uint8_t zoom);
+
    private:
     static constexpr ui::Dim header_height = 3 * 16;
 
@@ -207,6 +213,9 @@ class AnalogAudioView : public View {
     uint8_t iq_phase_calibration_value{15};  // initial default RX IQ phase calibration value , used for both max2837 & max2839
     uint8_t zoom_factor_am{0};               // initial zoom factor in AM mode
     uint8_t zoom_factor_amfm{0};             // initial zoom factor in AMFM mode
+    uint8_t previous_AM_mode_option{0};      // GUI 5 AM modes :  (0..4 ) (DSB9K, DSB6K, USB,LSB, CW). Used to select proper FIR filter (0..11) AM mode  + offset 0 (zoom+1) or +6 (if zoom+2)
+    uint8_t previous_zoom{0};                // GUI ZOOM+1, ZOOM+2 , equivalent to two values offset 0 (zoom+1) or +6 (if zoom+2)
+                                             //
     app_settings::SettingsManager settings_{
         "rx_audio",
         app_settings::Mode::RX,
@@ -214,6 +223,8 @@ class AnalogAudioView : public View {
             {"iq_phase_calibration"sv, &iq_phase_calibration_value},  // we are saving and restoring that CAL from Settings.
             {"zoom_factor_am"sv, &zoom_factor_am},                    // we are saving and restoring AM ZOOM factor from Settings.
             {"zoom_factor_amfm"sv, &zoom_factor_amfm},                // we are saving and restoring AMFM ZOOM factor from Settings.
+            {"previous_AM_mode_option"sv, &previous_AM_mode_option},  // we are saving and restoring AMFM ZOOM factor from Settings.
+            {"previous_zoom"sv, &previous_zoom},                      // we are saving and restoring AMFM ZOOM factor from Settings.
         }};
 
     const Rect options_view_rect{0 * 8, 1 * 16, 30 * 8, 1 * 16};


### PR DESCRIPTION
Just a minor tweak to those two local variables.
Making them static prevents collision with any other cpp files using their name and calling extern.

EDIT: after a talk we are going to make them living in AnalogAudioView if possible, to preserve firmware space (even if it's by only a little)
