### PR TITLE
Adding 8.33KHz spacing

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -46,7 +46,7 @@ using options_db_t = std::vector<option_db_t>;
 
 extern options_db_t freqman_modulations;
 extern options_db_t freqman_bandwidths[5];
-// extern options_db_t freqman_steps; // now included via receiver.hpp
+// extern options_db_t freqman_steps; // now included via ui_receiver.hpp
 extern options_db_t freqman_steps_short;
 
 options_t dboptions_to_options(const options_db_t& dboptions) {

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -46,7 +46,7 @@ using options_db_t = std::vector<option_db_t>;
 
 extern options_db_t freqman_modulations;
 extern options_db_t freqman_bandwidths[5];
-extern options_db_t freqman_steps;
+// extern options_db_t freqman_steps; // now included via receiver.hpp
 extern options_db_t freqman_steps_short;
 
 options_t dboptions_to_options(const options_db_t& dboptions) {

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -29,6 +29,7 @@
 
 #include "irq_controls.hpp"
 #include "rf_path.hpp"
+#include "freqman_db.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -36,6 +37,10 @@
 #include <functional>
 
 #define MAX_UFREQ 7200000000  // maximum usable frequency
+
+using option_db_t = std::pair<std::string_view, int32_t>;
+using options_db_t = std::vector<option_db_t>;
+extern options_db_t freqman_steps;
 
 namespace ui {
 
@@ -263,23 +268,12 @@ class FrequencyStepView : public OptionsField {
         : OptionsField{
               parent_pos,
               5,
-              {
-                  {"   10", 10}, /* Fine tuning SSB voice pitch,in HF and QO-100 sat #669 */
-                  {"   50", 50}, /* added 50Hz/10Hz,but we do not increase GUI digit decimal */
-                  {"  100", 100},
-                  {"  1k ", 1000},
-                  {"  3k ", 3000}, /* Approximate SSB bandwidth */
-                  {"  5k ", 5000},
-                  {"  6k3", 6250},
-                  {"  8k3", 8330}, /* New air band spacing */
-                  {"  9k ", 9000}, /* channel spacing for LF, MF in some regions */
-                  {" 10k ", 10000},
-                  {" 12k5", 12500},
-                  {" 25k ", 25000},
-                  {"100k ", 100000},
-                  {"  1M ", 1000000},
-                  {" 10M ", 10000000},
-              }} {
+              {}} {
+        options_t options;
+        for (const auto& step : freqman_steps) {
+            options.emplace_back(step.first, step.second);
+        }
+        set_options(options);
     }
 };
 

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -271,6 +271,7 @@ class FrequencyStepView : public OptionsField {
                   {"  3k ", 3000}, /* Approximate SSB bandwidth */
                   {"  5k ", 5000},
                   {"  6k3", 6250},
+                  {"  8k3", 8330}, /* New air band spacing */
                   {"  9k ", 9000}, /* channel spacing for LF, MF in some regions */
                   {" 10k ", 10000},
                   {" 12k5", 12500},


### PR DESCRIPTION
8.33KHz is the new Air-band frequency spacing:

>By December 31, 2015, frequencies used by Operations Control (OPC) will need to be converted to 8.33 kHz channel spacing. By January 1, 2018, all aviation radios operating in ICAO European regions must have 8.33 kHz channel spacing capability.

## Checklist
- [x]  Kept changes minimal and limited to necessary files
- [x]  Verified functionality remains intact and code compiles
