### PR TITLE
Back to WFM as base baseband for Level, Scanner, GFXeq

### DIFF
--- a/firmware/application/external/gfxeq/main.cpp
+++ b/firmware/application/external/gfxeq/main.cpp
@@ -29,7 +29,7 @@ __attribute__((section(".external_app.app_gfxeq.application_information"), used)
     ui::Color::green().v,
     app_location_t::RX,
     -1,
-    {'P', 'N', 'F', 'M'},
+    {'P', 'W', 'F', 'M'},
     0x00000000,
 };
 

--- a/firmware/application/external/level/main.cpp
+++ b/firmware/application/external/level/main.cpp
@@ -77,8 +77,8 @@ __attribute__((section(".external_app.app_level.application_information"), used)
     /*.menu_location = */ app_location_t::RX,
     /*.desired_menu_position = */ -1,
 
-    // this has to be the biggest baseband used by the app. Level is using AM,WFM,NFM,AMFM,SPEC and NFM is the biggest
-    /*.m4_app_tag = portapack::spi_flash::image_tag_nfm */ {'P', 'N', 'F', 'M'},
+    // this has to be the biggest baseband used by the app. Level is using AM,WFM,NFM,AMFM,SPEC and WFM is the biggest
+    /*.m4_app_tag = portapack::spi_flash::image_tag_nfm */ {'P', 'W', 'F', 'M'},
     /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
 };
 }

--- a/firmware/application/external/scanner/main.cpp
+++ b/firmware/application/external/scanner/main.cpp
@@ -44,8 +44,8 @@ __attribute__((section(".external_app.app_scanner.application_information"), use
     /*.menu_location = */ app_location_t::RX,
     /*.desired_menu_position = */ -1,
 
-    // this has to be the biggest baseband used by the app. Scanner is using AM,WFM,NFM and NFM is the biggest
-    /*.m4_app_tag = portapack::spi_flash::image_tag_scanner */ {'P', 'N', 'F', 'M'},
+    // this has to be the biggest baseband used by the app. Scanner is using AM,WFM,NFM and WFM is the biggest
+    /*.m4_app_tag = portapack::spi_flash::image_tag_scanner */ {'P', 'W', 'F', 'M'},
     /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
 };
 }


### PR DESCRIPTION
After the last WFM FMAM PR (https://github.com/portapack-mayhem/mayhem-firmware/pull/2644) the Level, Scanner, GFXeq apps were crashing.

It appears that using NFM as basic baseband in main.cpp was not anymore good.

Going back to WFM as base baseband for these 3 apps solved it.

Fix issue https://github.com/portapack-mayhem/mayhem-firmware/issues/2645