### PR TITLE
Explicit_naming_wefax_NOAA_and_small_addition

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -74,7 +74,7 @@ class AMFMAptOptionsView : public View {
 
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        6,  // Max option length chars  "USB+FM"
+        17,  // Max option length chars   "USB+FM(Wefax Apt)"
         {
             // Using common messages from freqman_ui.cpp In HF USB , Here  we only need USB Audio demod, + post-FM demod fsubcarrier FM tone to get APT signal.
         }};
@@ -143,7 +143,7 @@ class WFMAMAptOptionsView : public View {
     };
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        10,  // Max option char length  "FM+AM(DSB)"
+        15,  // Max option char length "FM+AM(NOAA Apt)"
         {
             // Using common messages from freqman_ui.cpp
         }};

--- a/firmware/application/external/wefax_rx/ui_wefax_rx.cpp
+++ b/firmware/application/external/wefax_rx/ui_wefax_rx.cpp
@@ -81,6 +81,8 @@ WeFaxRxView::WeFaxRxView(NavigationView& nav)
     };
     audio::output::start();
     receiver_model.set_hidden_offset(WEFAX_FREQ_OFFSET);
+    receiver_model.set_sampling_rate(3072000);       // set the needed baseband SR.
+    receiver_model.set_baseband_bandwidth(1750000);  // set  the front-end RF BW filter.
     receiver_model.enable();
 
     txt_status.set("Waiting for signal.");

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -104,11 +104,11 @@ options_t freqman_bandwidths[6] = {
     },
     {
         // AMFM for Wefax-
-        {"USB+FM", 5},  // Fixed RX demod. AM config Index 5 : USB+FM for Audio Weather fax (WFAX) tones.
+        {"USB+FM(Wefax Apt)", 5},  // Fixed RX demod. AM config Index 5 : USB+FM for Audio Weather fax (WFAX) tones.
     },
     {
         // WFMAM for NOAA satellites,  137 Mhz band
-        {"FM+AM(DSB)", 1},  // Fixed RX demod- WFM config Index 1 : FM+AM  for Audio NOAA APT ones.
+        {"FM+AM(NOAA Apt)", 1},  // Fixed RX demod- WFM config Index 1 : FM+AM  for Audio NOAA APT ones.
     },
 };
 


### PR DESCRIPTION
This PR has two small changes, 

1-) Although we will have soon separated Stand alone Wefax and NOAA Aplications to extract the .bmp image map file from the APT signal . In the Audio App,  the double demodulation AM+FM ,  FM+AM , might be confused to the user.

@htotoo and myself already got confused several times. 
Better to extend the name inside Audio App , --> AM+FM (Wefax Apt)  ,  FM+AM (NOAA Apt)  
![image](https://github.com/user-attachments/assets/4f312d03-7abd-44a7-a0b1-be2745d01f81)

![image](https://github.com/user-attachments/assets/3f7331f9-1c12-4c15-a7ec-9c470e2e675e)


2-) Set up to  the External Wefax , the specific  baseband SR , and RF bandwith.  (just in case that some other App change them).

 