### PR TITLE
Jammer app add modes

### DIFF
--- a/firmware/application/external/jammer/ui_jammer.hpp
+++ b/firmware/application/external/jammer/ui_jammer.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2025 RocketGod - Added modes from my Flipper Zero RF Jammer App - https://betaskynet.com
  *
  * This file is part of PortaPack.
  *
@@ -150,12 +151,17 @@ class JammerView : public View {
     OptionsField options_type{
         {7 * 8, 23 * 8},
         8,
-        {
-            {"Rand FSK", 0},
-            {"FM tone", 1},
-            {"CW sweep", 2},
-            {"Rand CW", 3},
-        }};
+        {{"Rand FSK", 0},
+         {"FM tone", 1},
+         {"CW sweep", 2},
+         {"Noise", 3},
+         {"Sine", 4},
+         {"Square", 5},
+         {"Sawtooth", 6},
+         {"Triangle", 7},
+         {"Chirp", 8},
+         {"Gauss", 9},
+         {"Brute", 10}}};
 
     Text text_range_number{
         {16 * 8, 23 * 8, 2 * 8, 16},

--- a/firmware/baseband/proc_jammer.hpp
+++ b/firmware/baseband/proc_jammer.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2025 RocketGod - Added modes from my Flipper Zero RF Jammer App - https://betaskynet.com
  *
  * This file is part of PortaPack.
  *
@@ -27,6 +28,8 @@
 #include "baseband_thread.hpp"
 #include "portapack_shared_memory.hpp"
 #include "jammer.hpp"
+#include <random>
+#include <cmath>
 
 using namespace jammer;
 
@@ -50,9 +53,11 @@ class JammerProcessor : public BasebandProcessor {
     uint32_t aphase{0}, phase{0}, delta{0}, sphase{0};
     int8_t sample{0};
     int8_t re{0}, im{0};
+    uint32_t wave_phase{0};
+    uint32_t wave_index{0};
+    float chirp_freq{0.0f};
     RetuneMessage message{};
 
-    /* NB: Threads should be the last members in the class definition. */
     BasebandThread baseband_thread{3072000, this, baseband::Direction::Transmit};
 };
 

--- a/firmware/common/jammer.hpp
+++ b/firmware/common/jammer.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyright (C) 2025 RocketGod - Added modes from my Flipper Zero RF Jammer App - https://betaskynet.com
  *
  * This file is part of PortaPack.
  *
@@ -20,11 +21,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#define JAMMER_CH_WIDTH 1000000
-#define JAMMER_MAX_CH 24
-
 #ifndef __JAMMER_H__
 #define __JAMMER_H__
+
+#define JAMMER_CH_WIDTH 1000000
+#define JAMMER_MAX_CH 24
 
 namespace jammer {
 
@@ -37,7 +38,15 @@ typedef struct jammer_range {
 enum JammerType : uint32_t {
     TYPE_FSK = 0,
     TYPE_TONE = 1,
-    TYPE_SWEEP = 2
+    TYPE_SWEEP = 2,
+    TYPE_RANDOM = 3,
+    TYPE_SINE = 4,
+    TYPE_SQUARE = 5,
+    TYPE_SAWTOOTH = 6,
+    TYPE_TRIANGLE = 7,
+    TYPE_CHIRP = 8,
+    TYPE_GAUSSIAN = 9,
+    TYPE_BRUTEFORCE = 10
 };
 
 } /* namespace jammer */


### PR DESCRIPTION
### Overview

This PR enhances the PortaPack Jammer app by introducing eight new signal types, ported from my Flipper Zero RF Jammer app (https://github.com/RocketGod-git/flipper-zero-rf-jammer). These modes expand the app's capability to disrupt a wide range of RF communication protocols, from analog radios to modern digital systems. 

### New Modes

The following modes have been added to the options_type in ui_jammer.hpp, with corresponding signal generation in proc_jammer.cpp:

**Noise:** Generates broadband white noise to interfere with analog and digital signals (e.g., Wi-Fi, Bluetooth, key fobs). Highly effective for overwhelming receivers across a frequency range.

**Sine:** Produces a continuous, unmodulated sine wave to jam narrowband receivers, ideal for analog FM/AM radios or telemetry systems.

**Square:** Emits a harmonic-rich square wave, disrupting digital protocols (e.g., OOK, ASK) and systems sensitive to sharp transitions, such as remote keyless entry.

**Sawtooth (Experimental):** Generates a sawtooth wave with a unique harmonic profile, useful for testing interference against PWM-based or niche analog systems.

**Triangle (Experimental):** Creates a triangle wave with minimal harmonics, suitable for exploratory jamming of narrowband systems or receiver linearity testing.

**Chirp:** Outputs a rapid frequency-sweeping chirp signal, effective against frequency-hopping and spread-spectrum systems (e.g., some Wi-Fi, Bluetooth, or military radios).

**Gauss:** Generates Gaussian noise to mimic natural interference, targeting digital systems like GPS or data links by degrading signal-to-noise ratios.

**Brute (Experimental):** Transmits a constant maximum-amplitude signal to saturate simple receiver front-ends, useful for brute-force jamming of basic analog devices.

### Changes

**jammer.hpp:** Added new JammerType enum values (TYPE_RANDOM, TYPE_SINE, ..., TYPE_BRUTEFORCE) to support the new modes, preserving original types.

**proc_jammer.hpp/cpp:** Implemented signal generation for new modes, leveraging efficient algorithms (e.g., LFSR for noise, sine table for waveforms). 

**ui_jammer.hpp:** Updated options_type with new modes
