### PR TITLE
refactor the serial log logic of BLE Rx

### DIFF
--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -33,6 +33,7 @@
 #include "portapack_persistent_memory.hpp"
 #include "ui_fileman.hpp"
 #include "ui_textentry.hpp"
+#include "usb_serial_asyncmsg.hpp"
 
 using namespace portapack;
 using namespace modems;
@@ -453,9 +454,9 @@ BLERxView::BLERxView(NavigationView& nav)
     check_serial_log.on_select = [this](Checkbox&, bool v) {
         serial_logging = v;
         if (v) {
-            usb_serial_thread = std::make_unique<UsbSerialThread>();
+            portapack::async_tx_enabled = true;
         } else {
-            usb_serial_thread.reset();
+            portapack::async_tx_enabled = false;
         }
     };
     check_serial_log.set_value(serial_logging);
@@ -755,8 +756,7 @@ void BLERxView::on_data(BlePacketData* packet) {
     }
 
     if (serial_logging) {
-        usb_serial_thread->serial_str = str_console + "\r\n";
-        usb_serial_thread->str_ready = true;
+        UsbSerialAsyncmsg::asyncmsg(str_console);  // new line handled there, no need here.
     }
     str_console = "";
 
@@ -916,6 +916,7 @@ void BLERxView::set_parent_rect(const Rect new_parent_rect) {
 }
 
 BLERxView::~BLERxView() {
+    portapack::async_tx_enabled = false;
     receiver_model.disable();
     baseband::shutdown();
 }

--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -447,6 +447,8 @@ BLERxView::BLERxView(NavigationView& nav)
                   &button_switch,
                   &recent_entries_view});
 
+    async_tx_states_when_entered = portapack::async_tx_enabled;
+
     recent_entries_view.on_select = [this](const BleRecentEntry& entry) {
         nav_.push<BleRecentEntryDetailView>(entry);
     };
@@ -916,7 +918,7 @@ void BLERxView::set_parent_rect(const Rect new_parent_rect) {
 }
 
 BLERxView::~BLERxView() {
-    portapack::async_tx_enabled = false;
+    portapack::async_tx_enabled = async_tx_states_when_entered;
     receiver_model.disable();
     baseband::shutdown();
 }

--- a/firmware/application/apps/ble_rx_app.hpp
+++ b/firmware/application/apps/ble_rx_app.hpp
@@ -219,6 +219,7 @@ class BLERxView : public View {
     std::string filter{};
     bool logging{false};
     bool serial_logging{false};
+    bool async_tx_states_when_entered{false};
 
     bool name_enable{true};
     app_settings::SettingsManager settings_{


### PR DESCRIPTION
1. this logger feat come with the nice BLE Rx app
2. we found that the log would halt the sys when no serial master device, so it was protected by checkbox in #1664 
3. after i introduced asyncmsg, this protection is not needed, and the log logic can be done by func call. so i impl the logic here too
