### PR TITLE
Storing_selected_NOAA_filter_in_settings_file

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -188,6 +188,7 @@ void copy_to_radio_model(const AppSettings& settings) {
             settings.am_config_index,
             settings.nbfm_config_index,
             settings.wfm_config_index,
+            settings.wfmam_config_index,
             settings.squelch);
     }
 
@@ -218,6 +219,7 @@ void copy_from_radio_model(AppSettings& settings) {
         settings.am_config_index = receiver_model.am_configuration();
         settings.nbfm_config_index = receiver_model.nbfm_configuration();
         settings.wfm_config_index = receiver_model.wfm_configuration();
+        settings.wfmam_config_index = receiver_model.wfmam_configuration();
     }
 
     settings.step = receiver_model.frequency_step();
@@ -271,6 +273,7 @@ SettingsManager::SettingsManager(
         bindings_.emplace_back("am_config_index"sv, &settings_.am_config_index);
         bindings_.emplace_back("nbfm_config_index"sv, &settings_.nbfm_config_index);
         bindings_.emplace_back("wfm_config_index"sv, &settings_.wfm_config_index);
+        bindings_.emplace_back("wfmam_config_index"sv, &settings_.wfmam_config_index);
         bindings_.emplace_back("squelch"sv, &settings_.squelch);
     }
 

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -139,7 +139,7 @@ struct AppSettings {
     uint8_t am_config_index = 0;
     uint8_t nbfm_config_index = 0;
     uint8_t wfm_config_index = 0;
-    uint8_t wfmam_config_index = 0;    
+    uint8_t wfmam_config_index = 0;
     uint8_t squelch = 80;
     uint8_t volume;
     // NOTE: update COMMON_APP_SETTINGS_COUNT when adding to this

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -139,6 +139,7 @@ struct AppSettings {
     uint8_t am_config_index = 0;
     uint8_t nbfm_config_index = 0;
     uint8_t wfm_config_index = 0;
+    uint8_t wfmam_config_index = 0;    
     uint8_t squelch = 80;
     uint8_t volume;
     // NOTE: update COMMON_APP_SETTINGS_COUNT when adding to this

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -274,12 +274,14 @@ void ReceiverModel::set_configuration_without_update(
     size_t new_am_config_index,
     size_t new_nbfm_config_index,
     size_t new_wfm_config_index,
+    size_t new_wfmam_config_index,
     uint8_t new_squelch_level) {
     settings_.mode = new_mode;
     settings_.frequency_step = new_frequency_step;
     settings_.am_config_index = new_am_config_index;
     settings_.nbfm_config_index = new_nbfm_config_index;
     settings_.wfm_config_index = new_wfm_config_index;
+    settings_.wfmam_config_index = new_wfmam_config_index;
     settings_.squelch_level = new_squelch_level;
 }
 

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -129,6 +129,7 @@ class ReceiverModel {
         size_t new_am_config_index,
         size_t new_nbfm_config_index,
         size_t new_wfm_config_index,
+        size_t new_wfmam_config_index,
         uint8_t new_squelch_level);
 
     void configure_from_app_settings(const app_settings::AppSettings& settings);


### PR DESCRIPTION
## Brief description what you did
Adding permanent mem, about the  selected NOAA filter (80khz / 38khz )  in the Audio App ,  exactly same as other WFM modes.

Now, in the Audio  App , the user can recover the last settings used in  Modulation mode (WFM , AM , NFM , FMAM , AMFM , ...) including  FMAM (NOAA mode) filter . All those Audio App user settings are stored  in SD /SETTINGS/rx_audio.ini.
(we are adding the last used NOAA bandwith filter index (80khz / 38khz)  ,  in that rx_audio.ini  file ) 

## Checklist
- [YES ]  Kept changes minimal and limited to necessary files
- [ YES]  Verified functionality remains intact and code compiles