### PR TITLE
Adding_BPF_selection_to_the_NOAA_APT_signal

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -143,7 +143,7 @@ class WFMAMAptOptionsView : public View {
     };
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        16,  // Max option char length "80khz (NOAA Apt)" example.
+        19,  // Max option char length "80k-NOAA Apt LPF-2K" , example.
         {
             // Using common messages from freqman_ui.cpp
         }};

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -105,10 +105,10 @@ void WFMConfig::apply() const {
 
 void WFMAMConfig::apply() const {
     const WFMAMConfigureMessage message{
-        decim_0,               // 	Fixed 24 taps array : taps_16k0_decim_0
-        decim_1,               // 	Fixed 32 taps array : taps_84k_wfm_decim_1
-        taps_64_lp_1875_2166,  // Fixed channel audio filter , 64 taps array , to filter DSB AM 2k4 carrier before demod. AM .
-        17000,                 // NOAA satellite tx , FM deviation = +-17Khz.
+        decim_0,         // 	Fixed 24 taps array : taps_16k0_decim_0
+        decim_1,         // Dynamic  32 taps array : taps_80k_wfmam_decim_1, 38k_wfmam
+        taps_64_lp_bpf,  // Dynamic 64 taps array , to filter modulated DSB AM 2k4 carrier before demod. AM .(LPF / BPF)
+        17000,           // NOAA satellite tx , FM deviation = +-17Khz.
         apt_audio_12k_notch_2k4_config,
         apt_audio_12k_lpf_2000hz_config};
     send_message(&message);

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -65,6 +65,7 @@ struct WFMConfig {
 struct WFMAMConfig {
     const fir_taps_real<24> decim_0;  // To handle WFM filter   BW=40K for NOAA APT
     const fir_taps_real<32> decim_1;
+    const fir_taps_real<64> taps_64_lp_bpf;  // to handle dynamically  LPF / BPF .
 
     void apply() const;
 };

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -108,8 +108,9 @@ options_t freqman_bandwidths[6] = {
     },
     {
         // WFMAM for NOAA satellites,  137 Mhz band
-        {"80kHz (NOAA Apt)", 0},  // Fixed RX demod- WFM config Index 1 : FM+AM  for Audio NOAA APT ones.
-        {"38kHz (NOAA Apt)", 1},
+        {"80k-NOAA Apt LPF-2K", 0},
+        {"38k-NOAA Apt LPF-2K", 1},
+        {"38k-NOAA Apt BPF-2K", 2},  // Symetrical BPF centred to the 2k4 AM subcarrier,  BW = 2KHz
     },
 };
 

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -69,9 +69,10 @@ static constexpr std::array<baseband::WFMConfig, 3> wfm_configs{{
     {taps_80k_wfm_decim_0, taps_80k_wfm_decim_1},
 }};
 
-static constexpr std::array<baseband::WFMAMConfig, 2> wfmam_configs{{
-    {taps_16k0_decim_0, taps_80k_wfmam_decim_1},
-    {taps_16k0_decim_0, taps_38k_wfmam_decim_1},
+static constexpr std::array<baseband::WFMAMConfig, 3> wfmam_configs{{
+    {taps_16k0_decim_0, taps_80k_wfmam_decim_1, taps_64_lp_1875_2166},
+    {taps_16k0_decim_0, taps_38k_wfmam_decim_1, taps_64_lp_1875_2166},
+    {taps_16k0_decim_0, taps_38k_wfmam_decim_1, taps_64_bpf_2k4_bw_2k},
 }};
 
 } /* namespace */

--- a/firmware/common/dsp_fir_taps.hpp
+++ b/firmware/common/dsp_fir_taps.hpp
@@ -1491,6 +1491,26 @@ constexpr fir_taps_real<64> taps_64_lp_1875_2166{
     }},
 };
 
+/* 1st Wideband FM demod baseband filter of audio AM tones ,
+   to pass all DSB band of  AM  fsubcarrier 2.4Khz mod. with APT */
+/* 24kHz int16_t input
+ * -> FIR filter, HPF center 2k4 carrier ,APT  BW 2kHz
+ * -> 12kHz int16_t output, gain of 1.0 (I think).
+ */
+constexpr fir_taps_real<64> taps_64_bpf_2k4_bw_2k{
+    .low_frequency_normalized = -0.1875f,  // not updated, this is just for LPF , waterfall GUI,  we are not using in HPF NOAA app.
+    .high_frequency_normalized = 0.1875f,  // not used GUI in NOAA App.
+    .transition_normalized = 0.03f,        // not used GUI in NOAA app.
+    .taps = {{-45, -29, 32, 63, 0, -125, -181, -81, 61,
+              0, -329, -635, -551, -147, 0, -547, -1404, -1625,
+              -849, 0, -414, -2118, -3358, -2422, 0, 911, -1792,
+              -6126, -6773, 0, 11839, 21131, 21131, 11839, 0, -6773,
+              -6126, -1792, 911, 0, -2422, -3358, -2118, -414, 0,
+              -849, -1625, -1404, -547, 0, -147, -551, -635, -329,
+              0, 61, -81, -181, -125, 0, 63, 32, -29,
+              -45}},
+};
+
 // TPMS decimation filters ////////////////////////////////////////////////
 
 // IFIR image-reject filter: fs=2457600, pass=100000, stop=407200, decim=4, fout=614400


### PR DESCRIPTION
## Brief description what you did
Adding new BASEBAND APT filter iinside Audo App , WFMAM NOAA APT mode   , mainly for investigation.

In previous past PR's we optimized the front RF filters according to NOAA APT sat signal. (this is done) . 
But now I wanted to invetigate if we could improve the AM demod. sensitivity some dB's more , applying better symetrical BPF filter to the subcarrier  before APT AM demodulation, compared to the current a little unbalance  LPF .  

After doing many local test,  
there is no change in the RF sensitivity . (just slightly different audio sound in the demodulated APT signal) 
just reducing slightly some visual "overshoot ringings". (but just visible  appying ZOOM.) 
very imilar  video resolution.  

In general , it is very minor difference , and I just leave that new user  option ,
 for check with real live signals. 

The BW "38kHZ -NOAA Apt LPF -2k", filter ,  is the  hardcoded filter that it is applied  in the other stand alone NOAA Apt . (no need to be changed, both "38k - with LPF 2K" and  "38k with BPF 2k" are very similar.

FYI : Below picture comparison , is magnified a lot with zoom,  otherwise , almost no difference. 
![image](https://github.com/user-attachments/assets/a24397a0-5de1-49a8-b792-cf6519db42c7)
 

## Checklist
- [YES ]  Kept changes minimal and limited to necessary files
- [ YES]  Verified functionality remains intact and code compiles
