### PR TITLE
Clean_LCD_beat_in_NOAA_Rx_App

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -143,7 +143,7 @@ class WFMAMAptOptionsView : public View {
     };
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        19,  // Max option char length "80k-NOAA Apt LPF-2K" , example.
+        16,  // Max option char length "80k-NOAA Apt LPF" , example.
         {
             // Using common messages from freqman_ui.cpp
         }};

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -108,9 +108,9 @@ options_t freqman_bandwidths[6] = {
     },
     {
         // WFMAM for NOAA satellites,  137 Mhz band
-        {"80k-NOAA Apt LPF-2K", 0},
-        {"38k-NOAA Apt LPF-2K", 1},
-        {"38k-NOAA Apt BPF-2K", 2},  // Symetrical BPF centred to the 2k4 AM subcarrier,  BW = 2KHz
+        {"80k-NOAA Apt LPF", 0},  // Captured RF IQ filtered BW 80K, APT baseband filtered with Low Pass Filter 4k5 fc -3dB
+        {"38k-NOAA Apt LPF", 1},  // Captured RF IQ filtered BW 38K, APT baseband filtered with Low Pass Filter 4k5 fc -3dB
+        {"38k-NOAA Apt BPF", 2},  // Captured RF IQ filtered BW 38K, APT baseband filtered BPF centred to the 2k4 AM subcarrier,  BW = 2KHz
     },
 };
 

--- a/firmware/baseband/proc_noaaapt_rx.cpp
+++ b/firmware/baseband/proc_noaaapt_rx.cpp
@@ -157,7 +157,7 @@ void NoaaAptRx::configure(const NoaaAptRxConfigureMessage& message) {
     channel_filter_high_f = taps_38k_wfmam_decim_1.high_frequency_normalized * decim_1_input_fs;
     channel_filter_transition = taps_38k_wfmam_decim_1.transition_normalized * decim_1_input_fs;
     demod.configure(demod_input_fs, 17000);
-    audio_filter.configure(taps_64_lp_1875_2166.taps);
+    audio_filter.configure(taps_64_bpf_2k4_bw_2k.taps);
     audio_output.configure(apt_audio_12k_notch_2k4_config, apt_audio_12k_lpf_2000hz_config);
     // channel_spectrum.set_decimation_factor(1);
     update_params();

--- a/firmware/common/dsp_fir_taps.hpp
+++ b/firmware/common/dsp_fir_taps.hpp
@@ -1498,7 +1498,7 @@ constexpr fir_taps_real<64> taps_64_lp_1875_2166{
  * -> 12kHz int16_t output, gain of 1.0 (I think).
  */
 constexpr fir_taps_real<64> taps_64_bpf_2k4_bw_2k{
-    .low_frequency_normalized = -0.1875f,  // not updated, this is just for LPF , waterfall GUI,  we are not using in HPF NOAA app.
+    .low_frequency_normalized = -0.1875f,  // not updated, this is just for LPF , waterfall GUI,  we are not using in BPF NOAA app.
     .high_frequency_normalized = 0.1875f,  // not used GUI in NOAA App.
     .transition_normalized = 0.03f,        // not used GUI in NOAA app.
     .taps = {{-45, -29, 32, 63, 0, -125, -181, -81, 61,


### PR DESCRIPTION
## Brief description what you did

Previous  Apt  subcarrier BP filter addition done in  PR #2675 , showed negligible benefit in the Audio Rx App (WFMAM NOAA Apt mode), respect sensitivity and satellite picture quality. 

But in the current binary (before that PR) the same replayed signal , showed a constant interference picture beat reproduction in the stand alone NOAA Rx App. (most probably done by LCD refresh activity , when showing each new pixel ) .

Applying the same added BPF  filter to that Application, showed a big picture quality improvement . (now that beat is not visible in the LCD , nor  in the  captured .bmp picture, (not visible with  visual zoom x 1 , x2 .  just slightly visible with big picture zoom x 5.) 
  So big  picture  improvement in that stand alone NOAA Rx App. changing that baseband filter LPF --> BPF 
 Therefore in that PR , we are hardcoding that APT  baseband filter to that BPF .
 
FYI , just a visual comparison of both binaries, using same replay signal conditions, (very easy to see if you are displaying it in a PC , but in mobile  you may need to zoom your browser to recognise that interf  beat. But once you see it , it was very annoying .)
 
Current decoded .bmp , using  binary (ORIGINAL CONDITION  without zooming -x1 ZOOM,  current LPF binary  (visible interf. beat)  
![image](https://github.com/user-attachments/assets/4fde53bd-8012-4293-87c6-47f56cf2b887)

x5 visual ZOOM 
![image](https://github.com/user-attachments/assets/5410d440-04eb-4be9-af74-859ffda725e0)


Same decoded .bmp , after that PR , without zooming  - x1 ZOOM  , with BPF filter  (very clean picture !!!!) 
![image](https://github.com/user-attachments/assets/2d51c227-0c56-4bfd-ab99-774c2641f94c)

x5 visual ZOOM  (slightly visible, but big reduction !!!)
![image](https://github.com/user-attachments/assets/f625cfb6-457b-43d3-aedc-84d017eb0c5f)


## Checklist
- [YES]  Kept changes minimal and limited to necessary files
- [YES]  Verified functionality remains intact and code compiles

Now it will remain to add in next future the Hsync capture trigger .
Cheers, and good captures !