### PR TITLE
Added ability to enter custom tone values in Morse app

### DIFF
--- a/firmware/application/external/morse_tx/ui_morse.cpp
+++ b/firmware/application/external/morse_tx/ui_morse.cpp
@@ -99,7 +99,7 @@ static msg_t loopthread_fn(void* arg) {
 }
 
 void MorseView::on_set_tone(NavigationView& nav) {
-    tone_input_buffer = std::to_string(tone);
+    tone_input_buffer = to_string_dec_uint(tone);
 
     text_prompt(nav, tone_input_buffer, 4, ENTER_KEYBOARD_MODE_DIGITS, [this](std::string& buffer) {
         if (!buffer.empty() && std::all_of(buffer.begin(), buffer.end(), ::isdigit)) {

--- a/firmware/application/external/morse_tx/ui_morse.cpp
+++ b/firmware/application/external/morse_tx/ui_morse.cpp
@@ -212,7 +212,7 @@ void MorseView::set_foxhunt(size_t i) {
 
 MorseView::MorseView(
     NavigationView& nav)
-    : nav_(nav), tone_input_buffer{} {
+    : nav_(nav) {
     // baseband::run_image(portapack::spi_flash::image_tag_tones);
     baseband::run_prepared_image(portapack::memory::map::m4_code.base());
 

--- a/firmware/application/external/morse_tx/ui_morse.hpp
+++ b/firmware/application/external/morse_tx/ui_morse.hpp
@@ -72,6 +72,7 @@ class MorseView : public View {
     NavigationView& nav_;
     std::string message{};
     uint32_t time_units{0};
+    std::string tone_input_buffer;  // Holds the tone value while the text prompt is open
 
     TxRadioState radio_state_{
         0 /* frequency */,
@@ -100,6 +101,7 @@ class MorseView : public View {
 
     bool start_tx();
     void update_tx_duration();
+    void on_set_tone(NavigationView& nav);
     void on_set_text(NavigationView& nav);
     void set_foxhunt(size_t i);
 

--- a/firmware/application/external/morse_tx/ui_morse.hpp
+++ b/firmware/application/external/morse_tx/ui_morse.hpp
@@ -72,7 +72,7 @@ class MorseView : public View {
     NavigationView& nav_;
     std::string message{};
     uint32_t time_units{0};
-    std::string tone_input_buffer;  // Holds the tone value while the text prompt is open
+    std::string tone_input_buffer{};  // Holds the tone value while the text prompt is open
 
     TxRadioState radio_state_{
         0 /* frequency */,


### PR DESCRIPTION
Added the ability to type in a custom tone value in the Morse TX app (#2582)

- Click on the tone field to open a keyboard for entering in a custom value between 100hz - 9999hz.
- Maintains original step value of 20 when scrolling the rotary wheel.

## Checklist
- [✔]  Kept changes minimal and limited to necessary files
- [✔]  Verified functionality remains intact and code compiles
