### PR TITLE
blerx: optimize some processing. cpu usage 98%->75% now

### DIFF
--- a/firmware/baseband/proc_btlerx.cpp
+++ b/firmware/baseband/proc_btlerx.cpp
@@ -316,8 +316,8 @@ void BTLERxProcessor::execute(const buffer_c8_t& buffer) {
     auto* end = &buffer.p[buffer.count];
 
     uint32_t maxMag = 0;
-    uint8_t maxMaxReal = 0;
-    uint8_t maxMaxImag = 0;
+    int8_t maxMaxReal = 0;
+    int8_t maxMaxImag = 0;
     while (ptr < end) {
         uint32_t mag = (uint32_t)(ptr->real() * ptr->real() + ptr->imag() * ptr->imag());
         if (mag > maxMag) {

--- a/firmware/baseband/proc_btlerx.cpp
+++ b/firmware/baseband/proc_btlerx.cpp
@@ -27,7 +27,7 @@
 
 #include "event_m4.hpp"
 
-float BTLERxProcessor::get_phase_diff(const complex16_t& sample0, const complex16_t& sample1) {
+inline float BTLERxProcessor::get_phase_diff(const complex16_t& sample0, const complex16_t& sample1) {
     // Calculate the phase difference between two samples.
     float dI = sample1.real() * sample0.real() + sample1.imag() * sample0.imag();
     float dQ = sample1.imag() * sample0.real() - sample1.real() * sample0.imag();
@@ -36,7 +36,7 @@ float BTLERxProcessor::get_phase_diff(const complex16_t& sample0, const complex1
     return phase_diff;
 }
 
-uint32_t BTLERxProcessor::crc_init_reorder(uint32_t crc_init) {
+inline uint32_t BTLERxProcessor::crc_init_reorder(uint32_t crc_init) {
     int i;
     uint32_t crc_init_tmp, crc_init_input, crc_init_input_tmp;
 
@@ -62,7 +62,7 @@ uint32_t BTLERxProcessor::crc_init_reorder(uint32_t crc_init) {
     return (crc_init_tmp);
 }
 
-uint_fast32_t BTLERxProcessor::crc_update(uint_fast32_t crc, const void* data, size_t data_len) {
+inline uint_fast32_t BTLERxProcessor::crc_update(uint_fast32_t crc, const void* data, size_t data_len) {
     const unsigned char* d = (const unsigned char*)data;
     unsigned int tbl_idx;
 
@@ -76,18 +76,14 @@ uint_fast32_t BTLERxProcessor::crc_update(uint_fast32_t crc, const void* data, s
     return crc & 0xffffff;
 }
 
-uint_fast32_t BTLERxProcessor::crc24_byte(uint8_t* byte_in, int num_byte, uint32_t init_hex) {
+inline uint_fast32_t BTLERxProcessor::crc24_byte(uint8_t* byte_in, int num_byte, uint32_t init_hex) {
     uint_fast32_t crc = init_hex;
-
     crc = crc_update(crc, byte_in, num_byte);
-
     return (crc);
 }
 
-bool BTLERxProcessor::crc_check(uint8_t* tmp_byte, int body_len, uint32_t crc_init) {
-    int crc24_checksum;
-
-    crc24_checksum = crc24_byte(tmp_byte, body_len, crc_init);  // 0x555555 --> 0xaaaaaa. maybe because byte order
+inline bool BTLERxProcessor::crc_check(uint8_t* tmp_byte, int body_len, uint32_t crc_init) {
+    int crc24_checksum = crc24_byte(tmp_byte, body_len, crc_init);  // 0x555555 --> 0xaaaaaa. maybe because byte order
     checksumReceived = 0;
     checksumReceived = ((checksumReceived << 8) | tmp_byte[body_len + 2]);
     checksumReceived = ((checksumReceived << 8) | tmp_byte[body_len + 1]);
@@ -96,15 +92,13 @@ bool BTLERxProcessor::crc_check(uint8_t* tmp_byte, int body_len, uint32_t crc_in
     return (crc24_checksum != checksumReceived);
 }
 
-void BTLERxProcessor::scramble_byte(uint8_t* byte_in, int num_byte, const uint8_t* scramble_table_byte, uint8_t* byte_out) {
-    int i;
-
-    for (i = 0; i < num_byte; i++) {
+inline void BTLERxProcessor::scramble_byte(uint8_t* byte_in, int num_byte, const uint8_t* scramble_table_byte, uint8_t* byte_out) {
+    for (int i = 0; i < num_byte; i++) {
         byte_out[i] = byte_in[i] ^ scramble_table_byte[i];
     }
 }
 
-int BTLERxProcessor::verify_payload_byte(int num_payload_byte, ADV_PDU_TYPE pdu_type) {
+inline int BTLERxProcessor::verify_payload_byte(int num_payload_byte, ADV_PDU_TYPE pdu_type) {
     // Should at least have 6 bytes for the MAC Address.
     // Also ensuring that there is at least 1 byte of data.
     if (num_payload_byte <= 6) {
@@ -131,26 +125,26 @@ int BTLERxProcessor::verify_payload_byte(int num_payload_byte, ADV_PDU_TYPE pdu_
     return 0;
 }
 
-void BTLERxProcessor::resetOffsetTracking() {
+inline void BTLERxProcessor::resetOffsetTracking() {
     frequency_offset = 0.0f;
     frequency_offset_estimate = 0.0f;
     phase_buffer_index = 0;
     memset(phase_buffer, 0, sizeof(phase_buffer));
 }
 
-void BTLERxProcessor::resetBitPacketIndex() {
+inline void BTLERxProcessor::resetBitPacketIndex() {
     memset(rb_buf, 0, sizeof(rb_buf));
     packet_index = 0;
     bit_index = 0;
 }
 
-void BTLERxProcessor::resetToDefaultState() {
+inline void BTLERxProcessor::resetToDefaultState() {
     parseState = Parse_State_Begin;
     resetOffsetTracking();
     resetBitPacketIndex();
 }
 
-void BTLERxProcessor::demodulateFSKBits(int num_demod_byte) {
+inline void BTLERxProcessor::demodulateFSKBits(int num_demod_byte) {
     for (; packet_index < num_demod_byte; packet_index++) {
         for (; bit_index < 8; bit_index++) {
             if (samples_eaten >= (int)dst_buffer.count) {
@@ -178,7 +172,7 @@ void BTLERxProcessor::demodulateFSKBits(int num_demod_byte) {
     }
 }
 
-void BTLERxProcessor::handleBeginState() {
+inline void BTLERxProcessor::handleBeginState() {
     uint32_t validAccessAddress = DEFAULT_ACCESS_ADDR;
     uint32_t accesssAddress = 0;
 
@@ -224,7 +218,7 @@ void BTLERxProcessor::handleBeginState() {
     parseState = Parse_State_PDU_Header;
 }
 
-void BTLERxProcessor::handlePDUHeaderState() {
+inline void BTLERxProcessor::handlePDUHeaderState() {
     if (samples_eaten > (int)dst_buffer.count) {
         return;
     }
@@ -251,7 +245,7 @@ void BTLERxProcessor::handlePDUHeaderState() {
     }
 }
 
-void BTLERxProcessor::handlePDUPayloadState() {
+inline void BTLERxProcessor::handlePDUPayloadState() {
     const int num_demod_byte = (payload_len + 3);
 
     if (samples_eaten > (int)dst_buffer.count) {
@@ -318,23 +312,22 @@ void BTLERxProcessor::execute(const buffer_c8_t& buffer) {
 
     max_dB = -128;
 
-    real = -128;
-    imag = -128;
-
     auto* ptr = buffer.p;
     auto* end = &buffer.p[buffer.count];
 
+    uint32_t maxMag = 0;
+    uint8_t maxMaxReal = 0;
+    uint8_t maxMaxImag = 0;
     while (ptr < end) {
-        float dbm = mag2_to_dbm_8bit_normalized(ptr->real(), ptr->imag(), 1.0f, 50.0f);
-
-        if (dbm > max_dB) {
-            max_dB = dbm;
-            real = ptr->real();
-            imag = ptr->imag();
+        uint32_t mag = (uint32_t)(ptr->real() * ptr->real() + ptr->imag() * ptr->imag());
+        if (mag > maxMag) {
+            maxMag = mag;
+            maxMaxReal = ptr->real();
+            maxMaxImag = ptr->imag();
         }
-
         ptr++;
     }
+    max_dB = mag2_to_dbm_8bit_normalized(maxMaxReal, maxMaxImag, 1.0f, 50.0f);
 
     // 4Mhz 2048 samples
     // Decimated by 4 to achieve 2048/4 = 512 samples at 1 sample per symbol.

--- a/firmware/baseband/proc_btlerx.hpp
+++ b/firmware/baseband/proc_btlerx.hpp
@@ -133,8 +133,6 @@ class BTLERxProcessor : public BasebandProcessor {
     uint8_t payload_len{0};
     uint8_t pdu_type{0};
     int32_t max_dB{0};
-    int8_t real{0};
-    int8_t imag{0};
     uint16_t packet_index{0};
     uint8_t bit_index{0};
 


### PR DESCRIPTION
see title. 
more ble devices shown again.

conclusion: avoid floating point calculations at all cost. hopefully there is no "cost" in this solution.