### PR TITLE
language support

### DIFF
--- a/firmware/common/firmware/application/menu_settings.cpp
+++ b/firmware/common/firmware/application/menu_settings.cpp
@@ -1,0 +1,20 @@
+#include "ui_language.hpp"
+// ... diğer gerekli include’lar ve kodlar ...
+
+// Eğer bir ayarlar menü sistemi varsa, aşağıdaki gibi bir dil seçimi ekleyin:
+
+const char* languageOptions[] = { "English", "Türkçe" };
+
+MenuEntry languageMenuEntry;
+languageMenuEntry.title = "Language";
+languageMenuEntry.type = MENU_ENTRY_TYPE_CHOICE;
+languageMenuEntry.choices = languageOptions;
+languageMenuEntry.numChoices = 2;
+languageMenuEntry.selected = (LanguageHelper::currentMessages == LanguageHelper::englishMessages) ? 0 : 1;
+languageMenuEntry.onChange = [](int choice) {
+    if (choice == 0) LanguageHelper::setLanguage(ENGLISH);
+    else if (choice == 1) LanguageHelper::setLanguage(TURKISH);
+    // Menülerin yeniden çizilmesi gerekiyorsa burada çağırın (ör: refreshMenu();)
+};
+// Menüye ekleyin:
+settingsMenu.addEntry(languageMenuEntry);

--- a/firmware/common/firmware/common/lang_tr.hpp
+++ b/firmware/common/firmware/common/lang_tr.hpp
@@ -1,0 +1,35 @@
+#ifndef __LANG_TR_H__
+#define __LANG_TR_H__
+
+static const char* turkishMessages[] = {
+    "Tamam",         // LANG_OK
+    "İptal",         // LANG_CANCEL
+    "Hata",          // LANG_ERROR
+    "Modem Ayarı",   // LANG_MODEM_SETUP
+    "Hata Ayıklama", // LANG_DEBUG
+    "Kayıt",         // LANG_LOG
+    "Bitti",         // LANG_DONE
+    "Başlat",        // LANG_START
+    "Durdur",        // LANG_STOP
+    "Tara",          // LANG_SCAN
+    "Temizle",       // LANG_CLEAR
+    "Hazır",         // LANG_READY
+    "Veri:",         // LANG_DATADP
+    "Döngü",         // LANG_LOOP
+    "Sıfırla",       // LANG_RESET
+    "Duraklat",      // LANG_PAUSE
+    "Devam Et",      // LANG_RESUME
+    "Flood",         // LANG_FLOOD
+    "QR Göster",     // LANG_SHOWQR
+    "Kaydet",        // LANG_SAVE
+    "Kilitle",       // LANG_LOCK
+    "Kilidi Aç",     // LANG_UNLOCK
+    "Gözat",         // LANG_BROWSE
+    "Ayarla",        // LANG_SET
+    "Dosya Aç",      // LANG_OPEN_FILE
+    "Dosya Kaydet",  // LANG_SAVE_FILE
+    "Gönder",        // LANG_SEND
+    "Al"             // LANG_RECV
+};
+
+#endif

--- a/firmware/common/firmware/common/ui_language.cpp
+++ b/firmware/common/firmware/common/ui_language.cpp
@@ -1,0 +1,25 @@
+#include "ui_language.hpp"
+#include "lang_tr.hpp"
+
+const char* LanguageHelper::englishMessages[] = {
+    "OK", "Cancel", "Error", "Modem setup", "Debug", "Log", "Done", "Start", "Stop", "Scan", "Clear", "Ready", "Data:", "Loop", "Reset", "Pause", "Resume", "Flood", "Show QR", "Save", "Lock", "Unlock", "Browse", "Set", "Open File", "Save File", "Send", "Receive"
+};
+const char* LanguageHelper::turkishMessages[] = turkishMessages;
+
+const char** LanguageHelper::currentMessages = englishMessages;
+
+void LanguageHelper::setLanguage(LanguageList lang) {
+    switch (lang) {
+        case TURKISH:
+            currentMessages = turkishMessages;
+            break;
+        default:
+        case ENGLISH:
+            currentMessages = englishMessages;
+            break;
+    }
+}
+
+const char* LanguageHelper::getMessage(LangConsts msg) {
+    return currentMessages[msg];
+}

--- a/firmware/common/firmware/common/ui_language.hpp
+++ b/firmware/common/firmware/common/ui_language.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 HTotoo
+ * ... (mevcut telif ve açıklamalar) ...
+ */
+
+#ifndef __UI_LANGUAGE_H__
+#define __UI_LANGUAGE_H__
+
+// Çoklu dil desteği için güncellendi
+enum LanguageList {
+    ENGLISH,
+    TURKISH,
+};
+
+// enum'a eleman ekledikçe, ilgili string'i LanguageHelper'da aynı sıraya ekleyin
+enum LangConsts {
+    LANG_OK,
+    LANG_CANCEL,
+    LANG_ERROR,
+    LANG_MODEM_SETUP,
+    LANG_DEBUG,
+    LANG_LOG,
+    LANG_DONE,
+    LANG_START,
+    LANG_STOP,
+    LANG_SCAN,
+    LANG_CLEAR,
+    LANG_READY,
+    LANG_DATADP,
+    LANG_LOOP,
+    LANG_RESET,
+    LANG_PAUSE,
+    LANG_RESUME,
+    LANG_FLOOD,
+    LANG_SHOWQR,
+    LANG_SAVE,
+    LANG_LOCK,
+    LANG_UNLOCK,
+    LANG_BROWSE,
+    LANG_SET,
+    LANG_OPEN_FILE,
+    LANG_SAVE_FILE,
+    LANG_SEND,
+    LANG_RECV
+};
+
+class LanguageHelper {
+   public:
+    static void setLanguage(LanguageList lang);
+    static const char* getMessage(LangConsts msg);
+    static const char** currentMessages;
+
+   private:
+    static const char* englishMessages[];
+    static const char* turkishMessages[];
+};
+
+#endif

--- a/firmware/common/lang_tr.h
+++ b/firmware/common/lang_tr.h
@@ -1,0 +1,11 @@
+#ifndef LANG_TR_H
+#define LANG_TR_H
+
+#define LANG_NAME "Türkçe"
+
+#define MENU_FILE "Dosya"
+#define MENU_SAVE "Kaydet"
+#define MENU_EXIT "Çıkış"
+// Diğer metin sabitlerini de çevirin...
+
+#endif // LANG_TR_H

--- a/firmware/common/languages.h
+++ b/firmware/common/languages.h
@@ -1,0 +1,10 @@
+#include "lang_en.h"
+#include "lang_es.h"
+#include "lang_tr.h" // <-- Türkçe'yi ekleyin
+
+static const language_t* languages[] = {
+    &lang_en,
+    &lang_es,
+    &lang_tr, // <-- Türkçe'yi ekleyin
+    // Diğer diller...
+};


### PR DESCRIPTION
## Brief description what you did

## Checklist

This file contains Turkish user interface messages for PortaPack Mayhem firmware.
// Use this together with ui_language.hpp and ui_language.cpp to add Turkish language support.
// The messages defined here provide Turkish translations for UI string literals used in the firmware.