### PR TITLE
Fix bmp16bit with nocomp header

### DIFF
--- a/firmware/common/bmpfile.cpp
+++ b/firmware/common/bmpfile.cpp
@@ -167,8 +167,18 @@ bool BMPFile::read_next_px(ui::Color& px, bool seek = true) {
     if (res.is_error()) return false;
     switch (type) {
         case 5: {
-            uint16_t color16 = (uint16_t)buffer[0] | ((uint16_t)buffer[1] << 8);
-            px = ui::Color(color16);  // has glitches!
+            // ARGB1555
+            uint16_t val = buffer[0] | (buffer[1] << 8);
+            // Extract components
+            //*a = (val >> 15) & 0x01;            // 1-bit alpha
+            uint8_t r = (val >> 10) & 0x1F;  // 5-bit red
+            uint8_t g = (val >> 5) & 0x1F;   // 5-bit green
+            uint8_t b = (val) & 0x1F;        // 5-bit blue
+            // expand
+            r = (r << 3) | (r >> 2);
+            g = (g << 3) | (g >> 2);
+            b = (b << 3) | (b >> 2);
+            px = ui::Color(r, g, b);
             break;
         }
         case 2:  // 32

--- a/firmware/common/bmpfile.cpp
+++ b/firmware/common/bmpfile.cpp
@@ -173,7 +173,7 @@ bool BMPFile::read_next_px(ui::Color& px, bool seek = true) {
             //*a = (val >> 15) & 0x01;            // 1-bit alpha
             uint8_t r = (val >> 10) & 0x1F;  // 5-bit red
             uint8_t g = (val >> 5) & 0x1F;   // 5-bit green
-            uint8_t b = (val) & 0x1F;        // 5-bit blue
+            uint8_t b = (val)&0x1F;          // 5-bit blue
             // expand
             r = (r << 3) | (r >> 2);
             g = (g << 3) | (g >> 2);


### PR DESCRIPTION
Fixed the 16bit bmp drawer with default (ancient) format for nocomp header layout.